### PR TITLE
Updates for version, bitflags, bitfield and default tags.

### DIFF
--- a/codegen.py
+++ b/codegen.py
@@ -202,6 +202,17 @@ def copy_src_to_generated():
     copy_tree(src_dir, trg_dir)
 
 
+def create_inits():
+    """Create a __init__.py file in all subdirectories that don't have one, to prevent error on second import"""
+    base_dir = os.path.join(os.getcwd(), 'generated')
+    init_file = "__init__.py"
+    for root, dirs, files in os.walk(base_dir):
+        if init_file not in files:
+            # __init__.py does not exist, create it
+            with open(os.path.join(root, init_file), 'x'): pass
+        # don't go into subdirectories that start with a double underscore
+        dirs[:] = [dirname for dirname in dirs if dirname[:2] != '__']
+
 def generate_classes():
     logging.info("Starting class generation")
     cwd = os.getcwd()
@@ -215,6 +226,7 @@ def generate_classes():
                 logging.info(f"Reading {format_name} format")
                 xmlp = XmlParser(format_name)
                 xmlp.load_xml(xml_path)
+    create_inits()
 
 
 generate_classes()

--- a/codegen.py
+++ b/codegen.py
@@ -34,6 +34,8 @@ class XmlParser:
         """Set up the xml parser."""
 
         self.format_name = format_name
+        # which encoding to use for the output files
+        self.encoding='utf-8'
 
         # elements for versions
         self.version_string = None

--- a/codegen.py
+++ b/codegen.py
@@ -81,7 +81,8 @@ class XmlParser:
 
         for child in root:
             self.replace_tokens(child)
-            self.apply_conventions(child)
+            if child.tag != 'version':
+                self.apply_conventions(child)
             try:
                 if child.tag in self.struct_types:
                     Compound(self, child)

--- a/codegen.py
+++ b/codegen.py
@@ -138,6 +138,8 @@ class XmlParser:
             if field.tag in FIELD_TYPES:
                 self.apply_convention(field, convention.name_attribute, ("name",))
                 self.apply_convention(field, convention.name_class, ("type",))
+                self.apply_convention(field, convention.name_class, ("onlyT",))
+                self.apply_convention(field, convention.name_class, ("excludeT",))
 
         # filter comment str
         struct.text = clean_comment_str(struct.text, indent="\t", class_comment='"""')
@@ -208,11 +210,6 @@ class XmlParser:
             for op_token, op_str in fixed_tokens:
                 expr_str = expr_str.replace(op_token, op_str)
             xml_struct.attrib[attrib] = expr_str
-        # onlyT & excludeT act as aliases for deprecated cond
-        for t, pref in (("onlyT", ""), ("excludeT", "!")):
-            if t in xml_struct.attrib:
-                xml_struct.attrib["cond"] = pref+xml_struct.attrib[t]
-                break
         for xml_child in xml_struct:
             self.replace_tokens(xml_child)
 

--- a/codegen.py
+++ b/codegen.py
@@ -15,7 +15,7 @@ from codegen.naming_conventions import clean_comment_str
 logging.basicConfig(level=logging.DEBUG)
 
 FIELD_TYPES = ("add", "field")
-VER = "stream.version"
+VER = "self.context.version"
 
 
 def write_file(filename: str, contents: str):
@@ -66,6 +66,7 @@ class XmlParser:
         self.path_dict["Array"] = "array"
         self.path_dict["BasicBitfield"] = "bitfield"
         self.path_dict["BitfieldMember"] = "bitfield"
+        self.path_dict["ContextReference"] = "context"
         self.path_dict["UbyteEnum"] = "base_enum"
         self.path_dict["UshortEnum"] = "base_enum"
         self.path_dict["UintEnum"] = "base_enum"

--- a/codegen.py
+++ b/codegen.py
@@ -18,14 +18,6 @@ FIELD_TYPES = ("add", "field")
 VER = "self.context.version"
 
 
-def write_file(filename: str, contents: str):
-    file_dir = os.path.dirname(filename)
-    if not os.path.exists(file_dir):
-        os.makedirs(file_dir)
-    with open(filename, 'w', encoding='utf-8') as file:
-        file.write(contents)
-
-
 class XmlParser:
     struct_types = ("compound", "niobject", "struct")
     bitstruct_types = ("bitfield", "bitflags", "bitstruct")
@@ -115,19 +107,6 @@ class XmlParser:
                             token.attrib["attrs"].split(" ")))
 
     @staticmethod
-    def get_names(struct):
-        # struct types can be organized in a hierarchy
-        # if inherit attribute is defined, look for corresponding base block
-        class_name = convention.name_class(struct.attrib.get("name"))
-        class_basename = struct.attrib.get("inherit")
-        class_debug_str = clean_comment_str(struct.text, indent="\t")
-        if class_basename:
-            # avoid turning None into 'None' if class doesn't inherit
-            class_basename = convention.name_class(class_basename)
-            # logging.debug(f"Struct {class_name} is based on {class_basename}")
-        return class_name, class_basename, class_debug_str
-
-    @staticmethod
     def apply_convention(struct, func, params):
         for k in params:
             if struct.attrib.get(k):
@@ -146,18 +125,6 @@ class XmlParser:
 
         # filter comment str
         struct.text = clean_comment_str(struct.text, indent="\t", class_comment='"""')
-
-    def collect_types(self, imports, struct):
-        """Iterate over all fields in struct and collect type references"""
-        # import classes used in the fields
-        for field in struct:
-            if field.tag in ("add", "field", "member"):
-                field_type = convention.name_class(field.attrib["type"])
-                if field_type not in imports:
-                    if field_type == "self.template":
-                        imports.append("typing")
-                    else:
-                        imports.append(field_type)
 
     def method_for_type(self, dtype: str, mode="read", attr="self.dummy", arg=None, template=None):
         if self.tag_dict[dtype.lower()] == "enum":

--- a/codegen.py
+++ b/codegen.py
@@ -49,10 +49,10 @@ class XmlParser:
             # only check stuff that has a name - ignore version tags
             if child.tag not in ("version", "module", "token"):
                 class_name = convention.name_class(child.attrib["name"])
-                out_segments = ["formats", self.format_name, child.tag, ]
-                if child.tag == "niobject":
+                out_segments = ["formats", self.format_name,]
+                if child.attrib.get("module"):
                     out_segments.append(child.attrib["module"])
-                out_segments.append(class_name)
+                out_segments.extend([child.tag, class_name, ])
                 # store the final relative module path for this class
                 self.path_dict[class_name] = os.path.join(*out_segments)
                 self.tag_dict[class_name.lower()] = child.tag

--- a/codegen/BaseClass.py
+++ b/codegen/BaseClass.py
@@ -40,7 +40,7 @@ class BaseClass:
                 if self.parser.format_name in root and py_name == name.lower():
                     src_path = os.path.join(root, name)
                     print("found source", src_path)
-                    with open(src_path, "r") as f:
+                    with open(src_path, "r", encoding=self.parser.encoding) as f:
                         return f.read()
         return ""
 

--- a/codegen/Bitfield.py
+++ b/codegen/Bitfield.py
@@ -49,7 +49,7 @@ class Bitfield(BaseClass):
 		self.class_basename = "BasicBitfield"
 
 		# write to python file
-		with open(self.out_file, "w") as f:
+		with open(self.out_file, "w", encoding=self.parser.encoding) as f:
 			# write the header stuff
 			super().write(f)
 			self.map_pos()

--- a/codegen/Bitfield.py
+++ b/codegen/Bitfield.py
@@ -22,8 +22,12 @@ class Bitfield(BaseClass):
 					num_bits = int(field.attrib["numbits"])
 				elif "width" in field.attrib:
 					num_bits = int(field.attrib["width"])
+				elif "bit" in field.attrib:
+					num_bits = 1
+					field.attrib["pos"] = field.attrib["bit"]
+					field.attrib["type"] = "bool"
 				else:
-					raise AttributeError(f"Neither width or mask or numbits are defined for {field.attrib['name']}")
+					raise AttributeError(f"Neither width, mask, bit or numbits are defined for {field.attrib['name']}")
 				pos = int(field.attrib["pos"])
 
 				mask = ~((~0) << (pos + num_bits)) & ((~0) << pos)

--- a/codegen/Bitfield.py
+++ b/codegen/Bitfield.py
@@ -23,7 +23,7 @@ class Bitfield(BaseClass):
 				elif "width" in field.attrib:
 					num_bits = int(field.attrib["width"])
 				else:
-					raise AttributeError(f"Neither width or mask or numbits are defined for {field.name}")
+					raise AttributeError(f"Neither width or mask or numbits are defined for {field.attrib['name']}")
 				pos = int(field.attrib["pos"])
 
 				mask = ~((~0) << (pos + num_bits)) & ((~0) << pos)

--- a/codegen/Compound.py
+++ b/codegen/Compound.py
@@ -3,7 +3,7 @@ from .BaseClass import BaseClass
 from .Union import Union, get_params
 
 FIELD_TYPES = ("add", "field")
-VER = "stream.version"
+VER = "self.context.version"
 
 
 class Compound(BaseClass):
@@ -31,16 +31,21 @@ class Compound(BaseClass):
 			# write the header stuff
 			super().write(f)
 
+			if not self.class_basename:
+				f.write(f"\n\n\tcontext = ContextReference()")
+
 			# check all fields/members in this class and write them as fields
 			# for union in self.field_unions.values():
 			# 	union.write_declaration(f)
 
 			if "def __init__" not in self.src_code:
-				f.write(f"\n\n\tdef __init__(self, arg=None, template=None):")
+				f.write(f"\n\n\tdef __init__(self, context, arg=None, template=None):")
 				f.write(f"\n\t\tself.name = ''")
 				# classes that this class inherits from have to be read first
 				if self.class_basename:
-					f.write(f"\n\t\tsuper().__init__(arg, template)")
+					f.write(f"\n\t\tsuper().__init__(context, arg, template)")
+				else:
+					f.write(f"\n\t\tself._context = context")
 				f.write(f"\n\t\tself.arg = arg")
 				f.write(f"\n\t\tself.template = template")
 				f.write(f"\n\t\tself.io_size = 0")
@@ -60,7 +65,6 @@ class Compound(BaseClass):
 				# classes that this class inherits from have to be read first
 				if self.class_basename:
 					f.write(f"\n\t\tsuper().{method_type}(stream)")
-
 				for union in self.field_unions:
 					last_condition = union.write_io(f, method_type, last_condition)
 

--- a/codegen/Compound.py
+++ b/codegen/Compound.py
@@ -27,7 +27,7 @@ class Compound(BaseClass):
 				self.imports.add("numpy")
 
 		# write to python file
-		with open(self.out_file, "w") as f:
+		with open(self.out_file, "w", encoding=self.parser.encoding) as f:
 			# write the header stuff
 			super().write(f)
 

--- a/codegen/Enum.py
+++ b/codegen/Enum.py
@@ -18,7 +18,7 @@ class Enum(BaseClass):
 		self.class_basename = enum_base
 		self.imports.add(enum_base)
 		# write to python file
-		with open(self.out_file, "w") as f:
+		with open(self.out_file, "w", encoding=self.parser.encoding) as f:
 			# write the header stuff
 			super().write(f)
 			for option in self.struct:

--- a/codegen/Enum.py
+++ b/codegen/Enum.py
@@ -1,7 +1,7 @@
 from .BaseClass import BaseClass
 
 FIELD_TYPES = ("add", "field")
-VER = "stream.version"
+VER = "self.context.version"
 
 
 class Enum(BaseClass):

--- a/codegen/Imports.py
+++ b/codegen/Imports.py
@@ -1,3 +1,6 @@
+from os.path import sep
+
+
 NO_CLASSES = ("Padding",)
 
 
@@ -43,7 +46,7 @@ class Imports:
             if class_import in NO_CLASSES:
                 continue
             if class_import in self.path_dict:
-                import_path = "generated." + self.path_dict[class_import].replace("\\", ".")
+                import_path = "generated." + self.path_dict[class_import].replace(sep, ".")
                 local_imports.append(f"from {import_path} import {class_import}\n")
             else:
                 module_imports.append(f"import {class_import}\n")

--- a/codegen/Imports.py
+++ b/codegen/Imports.py
@@ -31,6 +31,8 @@ class Imports:
                 self.add(field_type)
                 # arr1 needs typing.List
                 arr1 = field.attrib.get("arr1")
+                if arr1 is None:
+                    arr1 = field.attrib.get("length")
                 if arr1:
                     self.add("typing")
                     self.add("Array")

--- a/codegen/Imports.py
+++ b/codegen/Imports.py
@@ -31,6 +31,11 @@ class Imports:
                 if arr1:
                     self.add("typing")
                     self.add("Array")
+                type_attribs = ("onlyT", "excludeT")
+                for attrib in type_attribs:
+                    attrib_type = field.attrib.get(attrib)
+                    if attrib_type:
+                        self.add(attrib_type)
 
     def add(self, cls_to_import, import_from=None):
         if cls_to_import:

--- a/codegen/Imports.py
+++ b/codegen/Imports.py
@@ -14,6 +14,9 @@ class Imports:
         self.imports = []
         # import parent class
         self.add(xml_struct.attrib.get("inherit"))
+        # import ContextReference class
+        if xml_struct.tag in parser.struct_types and not xml_struct.attrib.get("inherit"):
+            self.add("ContextReference")
 
         # import classes used in the fields
         for field in xml_struct:

--- a/codegen/Imports.py
+++ b/codegen/Imports.py
@@ -40,6 +40,13 @@ class Imports:
                     if attrib_type:
                         self.add(attrib_type)
 
+                for default in field:
+                    if default.tag in ("default",):
+                        for attrib in type_attribs:
+                            attrib_type = default.attrib.get(attrib)
+                            if attrib_type:
+                                self.add(attrib_type)
+
     def add(self, cls_to_import, import_from=None):
         if cls_to_import:
             must_import, import_type = self.parent.map_type(cls_to_import)

--- a/codegen/Module.py
+++ b/codegen/Module.py
@@ -16,9 +16,9 @@ class Module:
         self.custom = bool(eval(element.attrib.get("custom","true").replace("true","True").replace("false","False"),{}))
 
     def write(self, rel_path):
-        file = open(os.path.join(os.getcwd(), "generated", rel_path, "__init__.py"), "w", encoding=self.parser.encoding)
-        file.write(self.comment_str)
-        file.write(f'\n\n__priority__ = {repr(self.priority)}')
-        file.write(f'\n__depends__ = {repr(self.depends)}')
-        file.write(f'\n__custom__ = {repr(self.custom)}')
-        file.write(f'\n')
+        with open(os.path.join(os.getcwd(), "generated", rel_path, "__init__.py"), "w", encoding=self.parser.encoding) as file:
+            file.write(self.comment_str)
+            file.write(f'\n\n__priority__ = {repr(self.priority)}')
+            file.write(f'\n__depends__ = {repr(self.depends)}')
+            file.write(f'\n__custom__ = {repr(self.custom)}')
+            file.write(f'\n')

--- a/codegen/Module.py
+++ b/codegen/Module.py
@@ -1,0 +1,24 @@
+import os
+from codegen.naming_conventions import clean_comment_str, name_module
+
+class Module:
+
+    def __init__(self, parser, element):
+        self.parser = parser
+        self.element = element
+        self.read(element)
+        self.write(parser.path_dict[name_module(element.attrib["name"])])
+
+    def read(self, element):
+        self.comment_str = clean_comment_str(element.text, indent="", class_comment='"""')[2:]
+        self.priority = int(element.attrib.get("priority",""))
+        self.depends = [name_module(module) for module in element.attrib.get("depends","").split(" ")]
+        self.custom = bool(eval(element.attrib.get("custom","true").replace("true","True").replace("false","False"),{}))
+
+    def write(self, rel_path):
+        file = open(os.path.join(os.getcwd(), "generated", rel_path, "__init__.py"), "w", encoding=self.parser.encoding)
+        file.write(self.comment_str)
+        file.write(f'\n\n__priority__ = {repr(self.priority)}')
+        file.write(f'\n__depends__ = {repr(self.depends)}')
+        file.write(f'\n__custom__ = {repr(self.custom)}')
+        file.write(f'\n')

--- a/codegen/Union.py
+++ b/codegen/Union.py
@@ -38,7 +38,7 @@ def get_conditions(field):
 	elif ver2:
 		conditionals.append(f"{VER} <= {ver2}")
 	if vercond:
-		vercond = Expression(vercond)
+		vercond = Expression(vercond, g_vars=True)
 		conditionals.append(f"{vercond}")
 	if versions:
 		conditionals.append(f"({' or '.join([f'is_{version}(self.context)' for version in versions])})")

--- a/codegen/Union.py
+++ b/codegen/Union.py
@@ -158,6 +158,8 @@ class Union:
 				# we have to check if the default is an enum default value, in which case it has to be a member of that enum
 				if type_of_field_type == "enum":
 					default_string = f'{field_type}.{default_string}'
+				elif type_of_field_type in ("bitfield", "bitflags"):
+					default_string = f'{field_type}({default_string})'
 			# no default, so guess one
 			else:
 				if type_of_field_type in ("compound", "struct", "niobject", "enum", "bitfield", "bitflags", "bitstruct"):

--- a/codegen/Union.py
+++ b/codegen/Union.py
@@ -29,11 +29,11 @@ def get_params(field):
 	vercond = field.attrib.get("vercond")
 	cond = field.attrib.get("cond")
 	if ver1 and ver2:
-		conditionals.append(f"{ver1} <= {VER} < {ver2}")
+		conditionals.append(f"{ver1} <= {VER} <= {ver2}")
 	elif ver1:
 		conditionals.append(f"{VER} >= {ver1}")
 	elif ver2:
-		conditionals.append(f"{VER} < {ver2}")
+		conditionals.append(f"{VER} <= {ver2}")
 	if vercond:
 		vercond = Expression(vercond)
 		conditionals.append(f"{vercond}")

--- a/codegen/Union.py
+++ b/codegen/Union.py
@@ -31,6 +31,8 @@ def get_params(field):
 		ver2 = Version(ver2)
 	vercond = field.attrib.get("vercond")
 	cond = field.attrib.get("cond")
+	onlyT = field.attrib.get("onlyT")
+	excludeT = field.attrib.get("excludeT")
 	if ver1 and ver2:
 		conditionals.append(f"{ver1} <= {VER} <= {ver2}")
 	elif ver1:
@@ -43,6 +45,11 @@ def get_params(field):
 	if cond:
 		cond = Expression(cond)
 		conditionals.append(f"{cond}")
+	if onlyT:
+		conditionals.append(f"isinstance(self, {onlyT})")
+	if excludeT:
+		conditionals.append(f"not isinstance(self, {excludeT})")
+
 	arg = field.attrib.get("arg")
 	arr1 = get_attr_with_backups(field, ["arr1", "length"])
 	arr2 = get_attr_with_backups(field, ["arr2", "width"])

--- a/codegen/Union.py
+++ b/codegen/Union.py
@@ -4,6 +4,17 @@ from .naming_conventions import clean_comment_str
 VER = "stream.version"
 
 
+def get_attr_with_backups(field, attribute_keys):
+	# return the value of the first attribute in the list that is not empty or
+	# missing
+	for key in attribute_keys:
+		attr_value = field.attrib.get(key)
+		if attr_value:
+			return attr_value
+	else:
+		return None
+
+
 def get_params(field):
 	# parse all conditions
 	conditionals = []
@@ -11,21 +22,13 @@ def get_params(field):
 	field_type = field.attrib["type"]
 	pad_mode = field.attrib.get("padding")
 	template = field.attrib.get("template")
-	ver1 = field.attrib.get("ver1")
+	ver1 = get_attr_with_backups(field, ["ver1", "since"])
 	if ver1:
 		ver1 = Version(ver1)
-	else:
-		ver1 = field.attrib.get("since")
-		if ver1:
-			ver1 = Version(ver1)
 
-	ver2 = field.attrib.get("ver2")
+	ver2 = get_attr_with_backups(field, ["ver2", "until"])
 	if ver2:
 		ver2 = Version(ver2)
-	else:
-		ver2 = field.attrib.get("until")
-		if ver2:
-			ver2 = Version(ver2)
 	vercond = field.attrib.get("vercond")
 	cond = field.attrib.get("cond")
 	if ver1 and ver2:
@@ -40,9 +43,9 @@ def get_params(field):
 	if cond:
 		cond = Expression(cond)
 		conditionals.append(f"{cond}")
-	arr1 = field.attrib.get("arr1")
-	arr2 = field.attrib.get("arr2")
 	arg = field.attrib.get("arg")
+	arr1 = get_attr_with_backups(field, ["arr1", "length"])
+	arr2 = get_attr_with_backups(field, ["arr2", "width"])
 	if arg:
 		arg = Expression(arg)
 	if arr1:

--- a/codegen/Versions.py
+++ b/codegen/Versions.py
@@ -19,7 +19,7 @@ class Versions:
 	def write(self, out_file):
 		full_game_names = []
 		if self.versions:
-			with open(out_file, "w") as stream:
+			with open(out_file, "w", encoding=self.parent.encoding) as stream:
 				stream.write(f"from enum import Enum\n\n\n")
 
 				for version in self.versions:

--- a/codegen/Versions.py
+++ b/codegen/Versions.py
@@ -91,12 +91,12 @@ class Versions:
 				for version in self.versions:
 					if len(version_default_map[version.attrib['id']]) > 0:
 						stream.write(f"\n\tif game in {{{', '.join([f'games.{key}' for key in version_default_map[version.attrib['id']]])}}}:")
-						stream.write(f"\n\t\tset_{version.attrib['id'].lower()}(inst)")
+						stream.write(f"\n\t\treturn set_{version.attrib['id'].lower()}(inst)")
 				# then the rest
 				for version in self.versions:
 					non_default_games = set(version_game_map[version.attrib['id']]) - version_default_map[version.attrib['id']]
 					if len(non_default_games) > 0:
 						stream.write(f"\n\tif game in {{{', '.join([f'games.{key}' for key in non_default_games])}}}:")
-						stream.write(f"\n\t\tset_{version.attrib['id'].lower()}(inst)")
+						stream.write(f"\n\t\treturn set_{version.attrib['id'].lower()}(inst)")
 				stream.write("\n\n\n")
 

--- a/codegen/Versions.py
+++ b/codegen/Versions.py
@@ -5,6 +5,10 @@ from codegen.expression import Version
 class Versions:
 	"""Creates and writes a version block"""
 
+	@staticmethod
+	def format_id(version_id):
+		return version_id.lower()
+
 	def __init__(self, parser):
 		self.parent = parser
 		self.versions = []
@@ -19,7 +23,7 @@ class Versions:
 				stream.write(f"from enum import Enum\n\n\n")
 
 				for version in self.versions:
-					stream.write(f"def is_{version.attrib['id'].lower()}(inst):")
+					stream.write(f"def is_{self.format_id(version.attrib['id'])}(inst):")
 					conds_list = []
 					for k, v in version.attrib.items():
 						if k != "id":
@@ -35,7 +39,7 @@ class Versions:
 					stream.write("\n\t\treturn True")
 					stream.write("\n\n\n")
 
-					stream.write(f"def set_{version.attrib['id'].lower()}(inst):")
+					stream.write(f"def set_{self.format_id(version.attrib['id'])}(inst):")
 					for k, v in version.attrib.items():
 						if k != "id":
 							name = k.lower()
@@ -80,7 +84,7 @@ class Versions:
 				# write game lookup function
 				stream.write(f"def get_game(inst):")
 				for version in self.versions:
-					stream.write(f"\n\tif is_{version.attrib['id'].lower()}(inst):")
+					stream.write(f"\n\tif is_{self.format_id(version.attrib['id'])}(inst):")
 					stream.write(f"\n\t\treturn [{', '.join([f'games.{key}' for key in version_game_map[version.attrib['id']]])}]")
 				stream.write("\n\treturn [games.UNKOWN_GAME]")
 				stream.write("\n\n\n")
@@ -91,12 +95,12 @@ class Versions:
 				for version in self.versions:
 					if len(version_default_map[version.attrib['id']]) > 0:
 						stream.write(f"\n\tif game in {{{', '.join([f'games.{key}' for key in version_default_map[version.attrib['id']]])}}}:")
-						stream.write(f"\n\t\treturn set_{version.attrib['id'].lower()}(inst)")
+						stream.write(f"\n\t\treturn set_{self.format_id(version.attrib['id'])}(inst)")
 				# then the rest
 				for version in self.versions:
 					non_default_games = set(version_game_map[version.attrib['id']]) - version_default_map[version.attrib['id']]
 					if len(non_default_games) > 0:
 						stream.write(f"\n\tif game in {{{', '.join([f'games.{key}' for key in non_default_games])}}}:")
-						stream.write(f"\n\t\treturn set_{version.attrib['id'].lower()}(inst)")
+						stream.write(f"\n\t\treturn set_{self.format_id(version.attrib['id'])}(inst)")
 				stream.write("\n\n\n")
 

--- a/codegen/Versions.py
+++ b/codegen/Versions.py
@@ -1,4 +1,5 @@
 from codegen.naming_conventions import name_enum_key
+from codegen.expression import Version
 
 
 class Versions:
@@ -24,6 +25,8 @@ class Versions:
 						if k != "id":
 							name = k.lower()
 							val = v.strip()
+							if name == 'num':
+								val = str(Version(val))
 							if " " in val:
 								conds_list.append(f"inst.{name} in ({val.replace(' ', ', ')})")
 							else:
@@ -43,6 +46,8 @@ class Versions:
 								suffix = "._value"
 							else:
 								suffix = ""
+								if name == "num":
+									val = str(Version(val))
 							stream.write(f"\n\tinst.{name}{suffix} = {val}")
 					stream.write("\n\n\n")
 

--- a/codegen/Versions.py
+++ b/codegen/Versions.py
@@ -1,3 +1,5 @@
+from codegen.naming_conventions import name_enum_key
+
 
 class Versions:
 	"""Creates and writes a version block"""
@@ -13,6 +15,8 @@ class Versions:
 		full_game_names = []
 		if self.versions:
 			with open(out_file, "w") as stream:
+				stream.write(f"from enum import Enum\n\n\n")
+
 				for version in self.versions:
 					stream.write(f"def is_{version.attrib['id'].lower()}(inst):")
 					conds_list = []
@@ -42,26 +46,52 @@ class Versions:
 							stream.write(f"\n\tinst.{name}{suffix} = {val}")
 					stream.write("\n\n\n")
 
+				# go through all the games, record them and map defaults to versions
+				full_name_key_map = {}
+				version_default_map = {}
+				version_game_map = {}
+				for version in self.versions:
+					version_default_map[version.attrib['id']] = set()
+					game_names = version.text.split(', ')
+					for i, game_name in enumerate(game_names):
+						game_name = game_name.strip()
+						# detect defaults and add them to the map
+						if len(game_name) > 4:
+							if game_name[:2] == '{{' and game_name[-2:] == '}}':
+								game_name = game_name[2:-2]
+
+								version_default_map[version.attrib['id']].add(name_enum_key(game_name))
+								game_names[i] = game_name
+						if game_name not in full_name_key_map:
+							full_name_key_map[game_name] = name_enum_key(game_name)
+					version_game_map[version.attrib['id']] = [full_name_key_map[game_name] for game_name in game_names]
+
+				# define game enum
+				full_name_key_map = {full_name: key for full_name, key in sorted(full_name_key_map.items(), key=lambda item: item[1])}
+				full_name_key_map["Unknown Game"] = "UNKNOWN_GAME"
+				stream.write(f"games = Enum('Games',{repr([(key, full_name) for full_name, key in full_name_key_map.items()])})")
+				stream.write("\n\n\n")
+
 				# write game lookup function
 				stream.write(f"def get_game(inst):")
 				for version in self.versions:
 					stream.write(f"\n\tif is_{version.attrib['id'].lower()}(inst):")
-					full_game_name = version.text.replace('"', '').strip()
-					full_game_names.append(full_game_name)
-					stream.write(f"\n\t\treturn '{full_game_name}'")
-				stream.write("\n\treturn 'Unknown Game'")
+					stream.write(f"\n\t\treturn [{', '.join([f'games.{key}' for key in version_game_map[version.attrib['id']]])}]")
+				stream.write("\n\treturn [games.UNKOWN_GAME]")
 				stream.write("\n\n\n")
 
 				# write game version setting function
 				stream.write(f"def set_game(inst, game):")
+				# first check all the defaults
 				for version in self.versions:
-					full_game_name = version.text.replace('"', '').strip()
-					stream.write(f"\n\tif game == '{full_game_name}':")
-					stream.write(f"\n\t\tset_{version.attrib['id'].lower()}(inst)")
+					if len(version_default_map[version.attrib['id']]) > 0:
+						stream.write(f"\n\tif game in {{{', '.join([f'games.{key}' for key in version_default_map[version.attrib['id']]])}}}:")
+						stream.write(f"\n\t\tset_{version.attrib['id'].lower()}(inst)")
+				# then the rest
+				for version in self.versions:
+					non_default_games = set(version_game_map[version.attrib['id']]) - version_default_map[version.attrib['id']]
+					if len(non_default_games) > 0:
+						stream.write(f"\n\tif game in {{{', '.join([f'games.{key}' for key in non_default_games])}}}:")
+						stream.write(f"\n\t\tset_{version.attrib['id'].lower()}(inst)")
 				stream.write("\n\n\n")
 
-				full_game_names.sort()
-				full_game_names.append("Unknown Game")
-				# write game list
-				stream.write(f"games = {str(full_game_names)}")
-				stream.write("\n\n\n")

--- a/codegen/expression.py
+++ b/codegen/expression.py
@@ -1,7 +1,7 @@
 """Expression parser (for arr1, arr2, cond, and vercond xml attributes of
 <add> tag)."""
 
-from codegen import naming_conventions as convention
+from codegen.naming_conventions import name_attribute
 
 
 class Version(object):
@@ -60,87 +60,14 @@ class Expression(object):
 
     operators = {'==', '!=', '>=', '<=', '&&', '||', '&', '|', '-', '!', '<', '>', '/', '*', '+', '%'}
 
-    def __init__(self, expr_str, name_filter=None, g_vars=False):
+    def __init__(self, expr_str, g_vars=False):
         try:
             left, self._op, right = self._partition(expr_str)
-            self._left = self._parse(left, name_filter, g_vars)
-            self._right = self._parse(right, name_filter, g_vars)
+            self._left = self._parse(left, g_vars)
+            self._right = self._parse(right, g_vars)
         except:
             print("error while parsing expression '%s'" % expr_str)
             raise
-
-    def eval(self, data=None):
-        """Evaluate the expression to an integer."""
-
-        if isinstance(self._left, Expression):
-            left = self._left.eval(data)
-        elif isinstance(self._left, str):
-            if self._left == '""':
-                left = ""
-            else:
-                left = data
-                for part in self._left.split("."):
-                    left = getattr(left, part)
-        elif isinstance(self._left, type):
-            left = isinstance(data, self._left)
-        elif self._left is None:
-            pass
-        else:
-            assert (isinstance(self._left, int))  # debug
-            left = self._left
-
-        if not self._op:
-            return left
-
-        if isinstance(self._right, Expression):
-            right = self._right.eval(data)
-        elif isinstance(self._right, str):
-            if (not self._right) or self._right == '""':
-                right = ""
-            else:
-                right = getattr(data, self._right)
-        elif isinstance(self._right, type):
-            right = isinstance(data, self._right)
-        elif self._right is None:
-            pass
-        else:
-            assert (isinstance(self._right, int))  # debug
-            right = self._right
-
-        if self._op == '==':
-            return left == right
-        elif self._op == '!=':
-            return left != right
-        elif self._op == '>=':
-            return left >= right
-        elif self._op == '<=':
-            return left <= right
-        elif self._op == '&&':
-            return left and right
-        elif self._op == '||':
-            return left or right
-        elif self._op == '&':
-            return left & right
-        elif self._op == '|':
-            return left | right
-        elif self._op == '-':
-            return left - right
-        elif self._op == '!':
-            return not (right)
-        elif self._op == '>':
-            return left > right
-        elif self._op == '<':
-            return left < right
-        elif self._op == '/':
-            return left / right
-        elif self._op == '*':
-            return left * right
-        elif self._op == '+':
-            return left + right
-        elif self._op == '%':
-            return left % right
-        else:
-            raise NotImplementedError("expression syntax error: operator '" + self._op + "' not implemented")
 
     def __str__(self):
         """Reconstruct the expression to a string."""
@@ -163,7 +90,7 @@ class Expression(object):
         return f"{left} {op} {right}".strip()
 
     @classmethod
-    def _parse(cls, expr_str, name_filter=None, g_vars=False):
+    def _parse(cls, expr_str, g_vars=False):
         """Returns an Expression, string, or int, depending on the
         contents of <expr_str>."""
         if not expr_str:
@@ -171,10 +98,10 @@ class Expression(object):
             return None
         # brackets or operators => expression
         if ("(" in expr_str) or (")" in expr_str):
-            return Expression(expr_str, name_filter, g_vars)
+            return Expression(expr_str, g_vars)
         for op in cls.operators:
             if expr_str.find(op) != -1:
-                return Expression(expr_str, name_filter, g_vars)
+                return Expression(expr_str, g_vars)
         # try to convert it to one of the following classes
         for create_cls in (int, Version):
             try:
@@ -185,15 +112,12 @@ class Expression(object):
         # at this point, expr_str is a single attribute
         # apply name filter on each component separately
         # (where a dot separates components)
-        if name_filter is None:
-            def name_filter(x):
-                return convention.name_attribute(x)
         if g_vars:
             # globals are stored on the context
             prefix = "self.context."
         else:
             prefix = "self."
-        return prefix + ('.'.join(name_filter(comp) for comp in expr_str.split(".")))
+        return prefix + ('.'.join(name_attribute(comp) for comp in expr_str.split(".")))
 
     @classmethod
     def _partition(cls, expr_str):
@@ -330,16 +254,6 @@ class Expression(object):
             if start_pos != -1 or end_pos != -1:
                 raise ValueError("expression syntax error (non-matching brackets?)")
         return start_pos, end_pos
-
-    def map_(self, func):
-        if isinstance(self._left, Expression):
-            self._left.map_(func)
-        else:
-            self._left = func(self._left)
-        if isinstance(self._right, Expression):
-            self._right.map_(func)
-        else:
-            self._right = func(self._right)
 
 
 if __name__ == "__main__":

--- a/codegen/expression.py
+++ b/codegen/expression.py
@@ -193,7 +193,7 @@ class Expression(object):
         # it is only a global if the leftmost member has version in it
         # ie. general_info.ms2_version is not a global
         if "version" in expr_str.split(".")[0].lower():
-            prefix = "stream."
+            prefix = "self.context."
         return prefix + ('.'.join(name_filter(comp) for comp in expr_str.split(".")))
 
     @classmethod

--- a/codegen/naming_conventions.py
+++ b/codegen/naming_conventions.py
@@ -124,3 +124,14 @@ def clean_comment_str(comment_str="", indent="", class_comment=""):
     else:
         lines = [f"\n{indent}# {line.strip()}" for line in comment_str.strip().split("\n")]
     return "\n" + "".join(lines)
+
+
+def name_module(name):
+    """Converts a module name into a name suitable for a python module
+    :param name: the module name
+    :type name: str
+    :return: Reformatted module name
+    >>> name_module('BSHavok')
+    'bshavok'
+    """
+    return name.lower()

--- a/codegen/naming_conventions.py
+++ b/codegen/naming_conventions.py
@@ -102,6 +102,17 @@ def name_class(name):
     return ''.join(part.capitalize() for part in name_parts(name))
 
 
+def name_enum_key(name):
+    """Converts a key name into a name suitable for an enum key.
+    :param name: the key name
+    :type name: str
+    :return: Reformatted key name.
+    >>> name_enum_key('Some key name')
+    'SOME_KEY_NAME'
+    """
+    return '_'.join(part.upper() for part in name_parts(name))
+
+
 def clean_comment_str(comment_str="", indent="", class_comment=""):
     """Reformats an XML comment string into multi-line a python style comment block"""
     if comment_str is None:

--- a/source/bitfield.py
+++ b/source/bitfield.py
@@ -21,7 +21,7 @@ class BitfieldMember(object):
         instance._value |= (value << self.pos) & self.mask
 
 
-class BasicBitfield(int):
+class BasicBitfield(object):
     _value: int = 0
 
     def set_defaults(self):
@@ -40,29 +40,6 @@ class BasicBitfield(int):
         elif isinstance(other, int):
             return self._value == other
         return False
-
-    def __new__(cls, *args, **kwargs):
-        return super(BasicBitfield, cls).__new__(cls)
-
-    def __add__(self, other):
-        self._value += other
-        return self
-
-    def __sub__(self, other):
-        self._value -= other
-        return self
-
-    def __mul__(self, other):
-        self._value *= other
-        return self
-
-    def __floordiv__(self, other):
-        self._value //= other
-        return self
-
-    def __truediv__(self, other):
-        self._value /= other
-        return self
 
     def __init__(self, value=None):
         super().__init__()
@@ -83,6 +60,167 @@ class BasicBitfield(int):
             val = getattr(self, field)
             info += f"\n\t{field} = {str(val)}"
         return info
+
+
+    # basic arithmetic functions
+    def __add__(self, other):
+        return self._value + other
+
+    def __sub__(self, other):
+        return self._value - other
+
+    def __mul__(self, other):
+        return self._value * other
+
+    def __truediv__(self, other):
+        return self._value / other
+
+    def __floordiv__(self, other):
+        return self._value // other
+
+    def __mod__(self, other):
+        return self._value % other
+
+    def __divmod__(self, other):
+        return divmod(self._value, other)
+
+    def __pow__(self, other, modulo=None):
+        if modulo is None:
+            return pow(self._value, other)
+        else:
+            return pow(self._value, other, modulo)
+
+    def __lshift__(self, other):
+        return self._value << other
+
+    def __rshift__(self, other):
+        return self._value >> other
+
+    def __and__(self, other):
+        return self._value & other
+
+    def __xor__(self, other):
+        return self._value ^ other
+
+    def __or__(self, other):
+        return self._value | other
+
+    # reflected basic arithmetic functions
+    def __radd__(self, other):
+        return other + self._value
+
+    def __rsub__(self, other):
+        return other - self._value
+
+    def __rmul__(self, other):
+        return other * self._value
+
+    def __rtruediv__(self, other):
+        return other / self._value
+
+    def __rfloordiv__(self, other):
+        return other // self._value
+
+    def __rmod__(self, other):
+        return other % self._value
+
+    def __rdivmod__(self, other):
+        return divmod(other, self._value)
+
+    def __rpow__(self, other, modulo=None):
+        if modulo is None:
+            return pow(other, self._value)
+        else:
+            return pow(other, self._value, modulo)
+
+    def __rlshift__(self, other):
+        return other << self._value
+
+    def __rrshift__(self, other):
+        return other >> self._value
+
+    def __rand__(self, other):
+        return other & self._value
+
+    def __rxor__(self, other):
+        return other ^ self._value
+
+    def __ror__(self, other):
+        return other | self._value
+
+    # arithmetic assignments
+    def __iadd__(self, other):
+        self._value = int(self._value + other)
+        return self
+
+    def __isub__(self, other):
+        self._value = int(self._value - other)
+        return self
+
+    def __imul__(self, other):
+        self._value = int(self._value * other)
+        return self
+
+    def __itruediv__(self, other):
+        self._value = int(self._value / other)
+        return self
+
+    def __ifloordiv__(self, other):
+        self._value = int(self._value // other)
+        return self
+
+    def __imod__(self, other):
+        self._value = int(self._value % other)
+        return self
+
+    def __ipow__(self, other, modulo=None):
+        if modulo is None:
+            self._value = int(pow(self._value, other))
+        else:
+            self._value = int(pow(self._value, other, modulo))
+        return self
+
+    def __ilshift__(self, other):
+        self._value = int(self._value << other)
+        return self
+
+    def __irshift__(self, other):
+        self._value = int(self._value >> other)
+        return self
+
+    def __iand__(self, other):
+        self._value = int(self._value & other)
+        return self
+
+    def __ixor__(self, other):
+        self._value = int(self._value ^ other)
+        return self
+
+    def __ior__(self, other):
+        self._value = int(self._value | other)
+        return self
+
+    # unary operators
+    def __neg__(self):
+        return -self._value
+
+    def __pos__(self):
+        return +self._value
+
+    def __abs__(self):
+        return abs(self._value)
+
+    def __invert__(self):
+        return ~self._value
+
+    def __complex__(self):
+        return complex(self._value)
+
+    def __float__(self):
+        return float(self._value)
+
+    def __index__(self):
+        return self.__int__()
 
 
 class AlphaFunction(IntEnum):

--- a/source/bitfield.py
+++ b/source/bitfield.py
@@ -34,13 +34,6 @@ class BasicBitfield(object):
     def __int__(self):
         return self._value
 
-    def __eq__(self, other):
-        if isinstance(other, BasicBitfield):
-            return self._value == other._value
-        elif isinstance(other, int):
-            return self._value == other
-        return False
-
     def __init__(self, value=None):
         super().__init__()
         if value is not None:
@@ -61,6 +54,24 @@ class BasicBitfield(object):
             info += f"\n\t{field} = {str(val)}"
         return info
 
+    # rich comparison methods
+    def __lt__(self, other):
+        return self._value < other
+
+    def __le__(self, other):
+        return self._value <= other
+
+    def __eq__(self, other):
+        return self._value == other
+
+    def __ne__(self, other):
+        return self._value != other
+
+    def __gt__(self, other):
+        return self._value > other
+
+    def __ge__(self, other):
+        return self._value >= other
 
     # basic arithmetic functions
     def __add__(self, other):

--- a/source/context.py
+++ b/source/context.py
@@ -1,0 +1,7 @@
+class ContextReference(object):
+
+    def __get__(self, instance, owner):
+        return instance._context
+
+    def __set__(self, instance, value):
+        raise AttributeError(f"Can't modify context attribute!")

--- a/source/formats/fgm/fgm.xml
+++ b/source/formats/fgm/fgm.xml
@@ -9,7 +9,7 @@
     <version id="PZ16" version="20" user_version="8340 8724">Planet Zoo 1.6</version>
     <version id="JWE" version="19" user_version="24724 25108">Jurassic World Evolution</version>
 
-    <token name="verexpr" attrs="vercond cond">
+    <token name="verexpr" attrs="vercond">
         Commonly used version expressions.
         <verexpr token="#DLA#" string="(#VER# #EQ# 15)">Disneyland Adventure</verexpr>
         <verexpr token="#ZTUAC#" string="(#VER# #EQ# 17)">ZTUAC</verexpr>
@@ -19,7 +19,7 @@
         <verexpr token="#JWE#" string="(((#USER# #EQ# 24724) #OR# (#USER# #EQ# 25108)) #AND# (#VER# #EQ# 19))">JWE, 25108 is JWE on switch</verexpr>
     </token>
 
-    <token name="global" attrs="vercond cond">
+    <token name="global" attrs="vercond">
         Global Tokens.
         NOTE: These must be listed after the above tokens so that they replace last. For example, `verexpr` uses these tokens.
         <global token="#USER#" string="user_version" />

--- a/source/formats/manis/manis.xml
+++ b/source/formats/manis/manis.xml
@@ -4,7 +4,7 @@
 
 
 
-    <token name="verexpr" attrs="vercond cond">
+    <token name="verexpr" attrs="vercond">
         Commonly used version expressions.
         <verexpr token="#PZ#" string="(#USER# #EQ# 8340)">PZ</verexpr>
         <verexpr token="#PZ16#" string="(#VER# #EQ# 20)">PZ</verexpr>
@@ -12,7 +12,7 @@
 		<verexpr token="#PC#" string="(#VER# #EQ# 18)">PC</verexpr>
     </token>
 
-    <token name="global" attrs="vercond cond">
+    <token name="global" attrs="vercond">
         Global Tokens.
         NOTE: These must be listed after the above tokens so that they replace last. For example, `verexpr` uses these tokens.
         <global token="#USER#" string="user_version" />
@@ -224,10 +224,10 @@
 		<add name="ff1" type="ubyte" >always FF FF</add>
 		<add name="ff2" type="ubyte" >always FF FF</add>
 		<add name="e" type="ushort" > </add>
-		<add name="extra pc" type="ushort" arr1="5" cond="#PC#"> </add>
+		<add name="extra pc" type="ushort" arr1="5" vercond="#PC#"> </add>
 		<add name="g" type="ushort" > </add>
 		<add name="zeros 2" type="uint" arr1="57"  > rest 228 bytes </add>
-		<add name="extra zeros pc" type="ushort" arr1="7" cond="#PC#" > rest 14 bytes </add>
+		<add name="extra zeros pc" type="ushort" arr1="7" vercond="#PC#" > rest 14 bytes </add>
 		<add name="i" type="ushort" > </add>
 		<add name="j" type="ushort" > </add>
 		<add name="ff" type="ushort" > always FF </add>
@@ -241,17 +241,17 @@
 <!--    JWE uses uint-->
 
 		<add name="ref" type="Empty" > </add>
-		<add name="indices c 2" type="ushort" arr1="#ARG#\c2" cond="#PC#" > </add>
-		<add name="indices c 2" type="uint" arr1="#ARG#\c2" cond="!#PC#" > </add>
+		<add name="indices c 2" type="ushort" arr1="#ARG#\c2" vercond="#PC#" > </add>
+		<add name="indices c 2" type="uint" arr1="#ARG#\c2" vercond="!#PC#" > </add>
 
-		<add name="indices 0" type="ushort" arr1="#ARG#\c" cond="#PC#" > </add>
-		<add name="indices 0" type="uint" arr1="#ARG#\c" cond="!#PC#" > </add>
+		<add name="indices 0" type="ushort" arr1="#ARG#\c" vercond="#PC#" > </add>
+		<add name="indices 0" type="uint" arr1="#ARG#\c" vercond="!#PC#" > </add>
 
-		<add name="indices 1" type="ushort" arr1="#ARG#\name count" cond="#PC#" > </add>
-		<add name="indices 1" type="uint" arr1="#ARG#\name count" cond="!#PC#" > </add>
+		<add name="indices 1" type="ushort" arr1="#ARG#\name count" vercond="#PC#" > </add>
+		<add name="indices 1" type="uint" arr1="#ARG#\name count" vercond="!#PC#" > </add>
 
-		<add name="indices e2" type="ushort" arr1="#ARG#\e2" cond="#PC#" > </add>
-		<add name="indices e2" type="uint" arr1="#ARG#\e2" cond="!#PC#" > </add>
+		<add name="indices e2" type="ushort" arr1="#ARG#\e2" vercond="#PC#" > </add>
+		<add name="indices e2" type="uint" arr1="#ARG#\e2" vercond="!#PC#" > </add>
 
 <!--		<add name="indices 2" type="ubyte" arr1="#ARG#\e" cond="#PC#" > </add>-->
 <!--		<add name="indices 2" type="ubyte" arr1="#ARG#\e" cond="!#PC#" > </add>-->
@@ -259,10 +259,10 @@
 <!--		<add name="indices 2" type="uint" arr1="#ARG#\e" cond="!#PC#" > </add>-->
 
 		<add name="p indices 00" type="ubyte" arr1="#ARG#\c2" > </add>
-		<add name="p indices 00" type="ubyte" arr1="#ARG#\c2" cond="#PC#"> </add>
+		<add name="p indices 00" type="ubyte" arr1="#ARG#\c2" vercond="#PC#"> </add>
 
 		<add name="p indices 0" type="ubyte" arr1="#ARG#\c" > </add>
-		<add name="p indices 0" type="ubyte" arr1="#ARG#\c" cond="#PC#"> </add>
+		<add name="p indices 0" type="ubyte" arr1="#ARG#\c" vercond="#PC#"> </add>
 
 		<add name="p indices 0b" type="ubyte" arr1="#ARG#\e" > </add>
 

--- a/source/formats/matcol/matcol.xml
+++ b/source/formats/matcol/matcol.xml
@@ -2,13 +2,13 @@
 <!DOCTYPE niftoolsxml>
 <niftoolsxml version="0.7.1.0">
 
-    <token name="verexpr" attrs="vercond cond">
+    <token name="verexpr" attrs="vercond">
         Commonly used version expressions.
         <verexpr token="#PZ#" string="(#USER# #EQ# 8340)">PZ</verexpr>
         <verexpr token="#JWE#" string="(#USER# #EQ# 24724)">JWE</verexpr>
     </token>
 	
-    <token name="global" attrs="vercond cond">
+    <token name="global" attrs="vercond">
         Global Tokens.
         NOTE: These must be listed after the above tokens so that they replace last. For example, `verexpr` uses these tokens.
         <global token="#USER#" string="user_version" />

--- a/source/formats/ms2/ms2.xml
+++ b/source/formats/ms2/ms2.xml
@@ -4,7 +4,7 @@
 
     <version id="old" version="17 18" >Old</version>
 
-    <token name="verexpr" attrs="vercond cond">
+    <token name="verexpr" attrs="vercond">
         Commonly used version expressions.
         <verexpr token="#DLA#" string="(#VER# #EQ# 15)">Disneyland Adventure</verexpr>
         <verexpr token="#ZTUAC#" string="(#VER# #EQ# 17)">ZTUAC</verexpr>
@@ -15,7 +15,7 @@
         <verexpr token="#JWE#" string="(((#USER# #EQ# 24724) #OR# (#USER# #EQ# 25108)) #AND# (#VER# #EQ# 19))">JWE, 25108 is JWE on switch</verexpr>
     </token>
 	
-	<token name="global" attrs="vercond cond">
+	<token name="global" attrs="vercond">
 		Global Tokens.
 		NOTE: These must be listed after the above tokens so that they replace last. For example, `verexpr` uses these tokens.
 		<global token="#USER#" string="user_version" />
@@ -323,18 +323,18 @@
 		<add name="bone info index" type="uint" >used to find bone info</add>
 		<add name="ms2 name" type="string" >name of ms2</add>
 
-		<add name="model info" type="CoreModelInfo" cond="!#OLD#" >gives relevant info on the mdl, including counts and pack base</add>
-		<add name="materials" type="MaterialName" arr1="model info\num_materials" cond="!#OLD#" >name pointers for each material</add>
-		<add name="lods" type="LodInfo" arr1="model info\num_lods" cond="!#OLD# #AND# model info\num_models" >lod info for each level, only present if models are present (despite the count sometimes saying otherwise!)</add>
-		<add name="objects" type="MeshLink" arr1="model info\num_objects" cond="!#OLD#" >instantiate the meshes with materials</add>
-		<add name="models" type="ModelData" arr1="model info\num_models" cond="!#OLD#" >model data blocks for this mdl2</add>
+		<add name="model info" type="CoreModelInfo" vercond="!#OLD#" >gives relevant info on the mdl, including counts and pack base</add>
+		<add name="materials" type="MaterialName" arr1="model info\num_materials" vercond="!#OLD#" >name pointers for each material</add>
+		<add name="lods" type="LodInfo" arr1="model info\num_lods" vercond="!#OLD#" con="model info\num_models" >lod info for each level, only present if models are present (despite the count sometimes saying otherwise!)</add>
+		<add name="objects" type="MeshLink" arr1="model info\num_objects" vercond="!#OLD#" >instantiate the meshes with materials</add>
+		<add name="models" type="ModelData" arr1="model info\num_models" vercond="!#OLD#" >model data blocks for this mdl2</add>
 	</compound>
 
 	<compound name="MaterialName">
-		<add name="name index" type="uint" cond="!#OLD#">index into ms2 names array</add>
-		<add name="name index" type="ushort" cond="#OLD#">index into ms2 names array</add>
-		<add name="some index" type="uint" cond="!#OLD#">unknown, nonzero in PZ flamingo juvenile, might be junk (padding)</add>
-		<add name="some index" type="ushort" cond="#OLD#">unknown, nonzero in PZ flamingo juvenile, might be junk (padding)</add>
+		<add name="name index" type="uint" vercond="!#OLD#">index into ms2 names array</add>
+		<add name="name index" type="ushort" vercond="#OLD#">index into ms2 names array</add>
+		<add name="some index" type="uint" vercond="!#OLD#">unknown, nonzero in PZ flamingo juvenile, might be junk (padding)</add>
+		<add name="some index" type="ushort" vercond="#OLD#">unknown, nonzero in PZ flamingo juvenile, might be junk (padding)</add>
 	</compound>
 
 	<compound name="MeshLink">
@@ -522,7 +522,7 @@
 		<add name="count7" type="uint64" >index count 7</add>
 		<add name="unknownextra" type="uint64" vercond="#OLD#" >zero</add>
 		<add name="joint count" type="uint64" >joint count</add>
-		<add name="unk78count" type="uint64" vercond="! #OLD#" >unnk 78 count</add>
+		<add name="unk78count" type="uint64" vercond="!#OLD#" >unnk 78 count</add>
 		<add name="unknown88" type="uint64" vercond="#JWE# #OR# #OLD#" >jwe only, everything is shifted a bit due to extra uint 0</add>
 
 		<add name="name indices" type="uint" arr1="name count" vercond="!#OLD#">index into ms2 string table for bones used here</add>
@@ -597,28 +597,28 @@
 		<add name="count_0" type="uint" >small number</add>
 		<add name="count_1" type="uint" >small number</add>
 		<add name="count_2" type="uint" >small number</add>
-		<add name="zeros extra" type="uint" arr1="2" cond="#PC#">0s, might be related to count 7 in PC</add>
+		<add name="zeros extra" type="uint" arr1="2" vercond="#PC#">0s, might be related to count 7 in PC</add>
 		<add name="namespace length" type="uint" >size of the name buffer below, including trailing zeros</add>
 		<add name="zeros 0" type="uint" arr1="5" >0s</add>
 		<add name="pc count" type="uint" >0 or 1</add>
 		<add name="zeros 1" type="uint" arr1="7">0s</add>
-		<add name="extra zeros pc" type="uint" arr1="4" cond="#PC#">0s</add>
+		<add name="extra zeros pc" type="uint" arr1="4" vercond="#PC#">0s</add>
 		<add name="ones" type="uint64" arr1="2" >1, 1</add>
 		<add name="bone count" type="uint" >matches bone count from bone info</add>
 		<add name="joint entry count" type="uint" >0</add>
 		<add name="zeros 2" type="uint" arr1="4">usually 0s</add>
 		<add name="joint_transforms" type="JointEntry" arr1="joint_count" >corresponds to bone transforms</add>
 
-		<add name="zeros 3" type="uint64" arr1="joint_count" cond="! #PC#">might be pointers</add>
-		<add name="UnknownListc" type="ListCEntry" arr1="joint_count" cond="! #PC#" ></add>
-		<add name="first list" type="ListFirst" arr1="count_0" cond="! #PC#" >used by ptero, 16 bytes per entry</add>
-		<add name="short list" type="ListShort" arr1="count_1" cond="! #PC#" ></add>
-		<add name="long list" type="ListLong" arr1="count_2" cond="! #PC#" ></add>
+		<add name="zeros 3" type="uint64" arr1="joint_count" vercond="!#PC#">might be pointers</add>
+		<add name="UnknownListc" type="ListCEntry" arr1="joint_count" vercond="!#PC#" ></add>
+		<add name="first list" type="ListFirst" arr1="count_0" vercond="!#PC#" >used by ptero, 16 bytes per entry</add>
+		<add name="short list" type="ListShort" arr1="count_1" vercond="!#PC#" ></add>
+		<add name="long list" type="ListLong" arr1="count_2" vercond="!#PC#" ></add>
 
-		<add name="pc ffs" type="PcFFCounter" cond="#PC#" >?</add>
-		<add name="pc bytes" type="byte" arr1="9" cond="#PC#" >1FAA FFAAFF00 000000</add>
-		<add name="pc hitcheck count" type="uint64" cond="#PC#">counts hitchecks for pz</add>
-		<add name="pc zero 0" type="uint64" cond="#PC#">0</add>
+		<add name="pc ffs" type="PcFFCounter" vercond="#PC#" >?</add>
+		<add name="pc bytes" type="byte" arr1="9" vercond="#PC#" >1FAA FFAAFF00 000000</add>
+		<add name="pc hitcheck count" type="uint64" vercond="#PC#">counts hitchecks for pz</add>
+		<add name="pc zero 0" type="uint64" vercond="#PC#">0</add>
 		<add name="pc floats" type="float" arr1="pc count" arr2="10" vercond="#PC#">sometimes an array of floats</add>
 
 		<add name="joint indices" type="int" arr1="joint_count" >index into bone info bones for each joint; bone that the joint is attached to</add>

--- a/source/formats/ovl/ovl.xml
+++ b/source/formats/ovl/ovl.xml
@@ -9,7 +9,7 @@
     <version id="PZ16" version="20" user_version="8340 8724">Planet Zoo 1.6+</version>
     <version id="JWE" version="19" user_version="24724 25108">Jurassic World Evolution</version>
 
-    <token name="verexpr" attrs="vercond cond">
+    <token name="verexpr" attrs="vercond">
         Commonly used version expressions.
         <verexpr token="#DLA#" string="(#VER# #EQ# 15)">Disneyland Adventure</verexpr>
         <verexpr token="#ZTUAC#" string="(#VER# #EQ# 17)">ZTUAC</verexpr>
@@ -19,7 +19,7 @@
         <verexpr token="#JWE#" string="(((#USER# #EQ# 24724) #OR# (#USER# #EQ# 25108)) #AND# (#VER# #EQ# 19))">JWE, 25108 is JWE on switch</verexpr>
     </token>
 
-    <token name="global" attrs="vercond cond">
+    <token name="global" attrs="vercond">
         Global Tokens.
         NOTE: These must be listed after the above tokens so that they replace last. For example, `verexpr` uses these tokens.
         <global token="#USER#" string="user_version" />

--- a/source/formats/tex/tex.xml
+++ b/source/formats/tex/tex.xml
@@ -9,7 +9,7 @@
     <version id="PZ16" version="20" user_version="8340 8724">Planet Zoo 1.6</version>
     <version id="JWE" version="19" user_version="24724 25108">Jurassic World Evolution</version>
 
-    <token name="verexpr" attrs="vercond cond">
+    <token name="verexpr" attrs="vercond">
         Commonly used version expressions.
         <verexpr token="#DLA#" string="(#VER# #EQ# 15)">Disneyland Adventure</verexpr>
         <verexpr token="#ZTUAC#" string="(#VER# #EQ# 17)">ZTUAC</verexpr>
@@ -19,7 +19,7 @@
         <verexpr token="#JWE#" string="(((#USER# #EQ# 24724) #OR# (#USER# #EQ# 25108)) #AND# (#VER# #EQ# 19))">JWE, 25108 is JWE on switch</verexpr>
     </token>
 
-    <token name="global" attrs="vercond cond">
+    <token name="global" attrs="vercond">
         Global Tokens.
         NOTE: These must be listed after the above tokens so that they replace last. For example, `verexpr` uses these tokens.
         <global token="#USER#" string="user_version" />

--- a/source/formats/voxelskirt/voxelskirt.xml
+++ b/source/formats/voxelskirt/voxelskirt.xml
@@ -7,7 +7,7 @@
     <version id="PZ" version="19" user_version="8340 8724">Planet Zoo</version>
     <version id="JWE" version_flag="1" version="19" user_version="24724 25108">Jurassic World Evolution</version>
 
-    <token name="verexpr" attrs="vercond cond">
+    <token name="verexpr" attrs="vercond">
         Commonly used version expressions.
         <verexpr token="#ZTUAC#" string="(#VER# #EQ# 17)">ZTUAC</verexpr>
 		<verexpr token="#PC#" string="(#VER# #EQ# 18)">PC</verexpr>
@@ -15,7 +15,7 @@
         <verexpr token="#JWE#" string="(((#USER# #EQ# 24724) #OR# (#USER# #EQ# 25108)) #AND# (#VER# #EQ# 19) #AND# (#FLAG# #EQ# 1))">JWE, 25108 is JWE on switch</verexpr>
     </token>
 
-    <token name="global" attrs="vercond cond">
+    <token name="global" attrs="vercond">
         Global Tokens.
         NOTE: These must be listed after the above tokens so that they replace last. For example, `verexpr` uses these tokens.
         <global token="#USER#" string="user_version" />


### PR DESCRIPTION
## Changes
1. Bitflags are now processed, treated like bitfields where every field is width 1 and a bool.
2. Arr1 and Arr2 now can also use the alternative attribute names `length` and `width`, respectively, to match with the newer nifxml format.
3. The text in version tags can now handle more than 1 game.
4. The `{{...}}` double curly brackets for default versions for a game are now used: set_game checks for them first, and returns after setting it to that version.
5. All possible games (+ UNKNOWN_GAME) are now put into an Enum, and the get_game and set_game functions use this enum.
6. Check from the `ver2` attribute is now `<=` instead of `<`, in line with the intended nifxml function of that attribute.
7. OnlyT and ExcludeT now work like they're supposed to.
8. The non-optional 'context' argument was added to generated compounds/structs and NiObjects.
9. The formatting of the version id (for use in set/check function) is separated out into its own function.
10. The `default` tag is now parsed and handled.
11. The default encoding for the generated files is now utf-8 instead of being environment-dependent.
12. Bitfields/bitflags are now initialized as such, instead of ints.
13. Imports did not yet import anything in a field's `length` attribute (alias for arr1 used by newer nif.xml). Now does it correctly.
14. Removed unused functions from codegen.py.
15. Bitfield no longer inherits int(), and implements all numeric-type emulation functions.
16. Modules now take precedence over class tag in generated directory structure and apply to all classes.
17. \_\_init\_\_.py added to all generated subfolders
18. Changed expression evaluation on `cond` and `vercond` attributes to be in line with [nifxmlspec issue 73](https://github.com/niftools/nifxml/issues/73).
19. The `name_filter` argument was dropped from the Expression class, as well as the eval and map_ methods.

## Detailed changes
1. Bitflags were already processed by the bitfield code, but it errored because there was no code to handle the absence of width, pos and type. These are now added/processed when the bit attribute is present (i.e. bitflags). The error message itself also contained an error (field.name) that is now fixed (field.attrib['name']).
2. The function get_attr_with_backups was added since this pattern was used a lot (multiple possible attribute names for the same function).
3. The version tag text is split by `, ` as in nifxml. get_game() now always returns a list, while set_game() checks whether the game is in the set for that specific version. The version tag is excluded from the apply_conventions() function so that this is easier processed (and the apply_conventions function had no other effect on version tags anyway). This also means that get_game returns a list, rather than a string.
4. set_game first checks for the game in versions which had a default (and only in their defaults), and only then goes to check for non-default game inputs. It also returns as soon as it has found a version with matching game, rather than continuing after that.
5. The games are put into an Enum per format, whereas it was previously a list. The get_game and set_game functions also use this enum. This means that for set_game(), you must access the enum to pass that option.
6. Relatively self-explanatory.
7. The classes referenced by OnlyT and ExcludeT are added to the imports, and the check for excludeT and onlyT now uses isinstance() instead of just checking that the referenced class is not None.
8. The newly added `context` variable allows for field existence/values on initialization to depend on the version of the file they're created in (which happens in a number of cases in the xml, even fields that change type depending on version).
9. Separating the version ID formatting is used for access by other classes that might want to use it (like the `versions` attribute checking, which was necessary for the default tag).
10. The default tag is now handled. Everything is done except the import of the version checking functions. In order to do this, I've separated out the code for getting the conditions and the default value for a field and re-applied them on the default tags, if present. In the xml later default tags override previous ones. To achieve the same effect, the codegen checks them in reverse order and applies the first one it finds (should be more efficient than setting the default value and letting it override). There is also some extra checking to make sure there are no default tags which have the same conditions.
11. The encoding type is now hardcoded on the XmlParser object. Every file write operation for the generated code uses that encoding (rather than the default, which is environment-dependent). It was erroring for me on the full nif.xml due to some unicode characters (like `≤`) in the xml. This was fixed by setting the encoding to `utf-8`. While a rare case, it is theoretically possible to have a non-utf8 encoding for the xml (e.g. utf-16) that will still error when trying to write. If that needs to be addressed, we could take the most permissive encoding between utf-8 and the xml encoding. However, to access the xml encoding, we would have to switch xml parsers from etree to lxml. I've tried it out, and because they are structurally similar it takes very little effort. However, it is not a standard library.
12. Relatively self-explanatory.
13. Relatively self-explanatory.
14. Best I could tell, both by print statements within the functions and checking for errors on removal when running codegen.py, the functions collect_types(), write_file() and get_names() were unused. As such, they were removed.
15. The bitfield class inherited int. However, because `int` is immutable, the value used when right-adding (or other arithmetic operations) always used the initialized value (I think). Moreover, the previous implemented numeric emulation functions (such as \_\_add\_\_) edited the value of the bitfield in-place. It has now been changed such that only the actual assignment functions change the bitfield value. The rest of the arithmetic functions simply run the same function on the _value attribute of the object and return the result. The implemented functions are taken from here: https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types
16. Module paths previously used to only apply to niobjects, and were implemented via the directory structure `formatname/niobject/modulename`. However, the newer version of nif.xml also applies modules to structs and some enums and bitflags. Therefore, the generated directory structure is now `formatname/modulename/niobject`, `formatname/modulename/struct` etc. Moreover, an \_\_init\_\_.py file is added to every module path which sets the attributes \_\_depends\_\_, \_\_priority\_\_ and \_\_custom\_\_ in the module, taken from the attributes depends, priority and custom in the xml. While this information is not necessarily used by anything at the moment, it means they can be accessed.
17. Without \_\_init\_\_.py in the subfolders, running (for example) TimeControllerFlags gives an error when trying to reload the modules. To solve this, an empty \_\_init\_\_.py is added to every (sub)folder in the generated code, except those starting with a double underscore (to prevent them from being added in \_\_pycache\_\_ folders).
18. The nifxml spec specifies that the `vercond` attribute should only refer to global variables, while the `cond` attribute should only refer to local variables. In the old codegen, there was no difference between the evaluation of cond and vercond, and whether a variable was local or global was determined whether it had 'version' in the name. This leads to problems when evaluating the nif.xml, because there is a global variable which does not have this (`BS Header\BS Version`). Moreover, it also misclassifies any local variable with 'version' in the name. Hence the update to be in line with the spec, which neatly separates the two.
19. The `name_filter` argument is only necessary when needing a customisable naming convention. However, all expressions take it from attributes, be that on self or on the context, hence there is no need for this argument. The eval method is used to evaluate an Expression object to an int value, but Expression objects are not used in the generated code, making the eval method obsolete. The map methodis similar. Though it also has potential uses in string manipulation, all necessary ones are already covered in the _parse method.