### PR TITLE
OVL Tool Fixes

### DIFF
--- a/generated/formats/animalresearch/versions.py
+++ b/generated/formats/animalresearch/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/assetpkg/versions.py
+++ b/generated/formats/assetpkg/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/bani/versions.py
+++ b/generated/formats/bani/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/bnk/versions.py
+++ b/generated/formats/bnk/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/cinematic/versions.py
+++ b/generated/formats/cinematic/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/curve/versions.py
+++ b/generated/formats/curve/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/dinosaurmaterialvariants/versions.py
+++ b/generated/formats/dinosaurmaterialvariants/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/enumnamer/versions.py
+++ b/generated/formats/enumnamer/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/fct/versions.py
+++ b/generated/formats/fct/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/fgm/versions.py
+++ b/generated/formats/fgm/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/guesteconomy/versions.py
+++ b/generated/formats/guesteconomy/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/habitatboundaryprop/versions.py
+++ b/generated/formats/habitatboundaryprop/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/island/versions.py
+++ b/generated/formats/island/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/janitorsettings/versions.py
+++ b/generated/formats/janitorsettings/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/logicalcontrols/versions.py
+++ b/generated/formats/logicalcontrols/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/lua/versions.py
+++ b/generated/formats/lua/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/manis/versions.py
+++ b/generated/formats/manis/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/matcol/versions.py
+++ b/generated/formats/matcol/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/mechanicresearch/versions.py
+++ b/generated/formats/mechanicresearch/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/mergedetails/versions.py
+++ b/generated/formats/mergedetails/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/motiongraph/versions.py
+++ b/generated/formats/motiongraph/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/ms2/versions.py
+++ b/generated/formats/ms2/versions.py
@@ -142,7 +142,7 @@ def set_jwe2(context):
 	context.version = 51
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('DLA', 'DLA'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('JWE_1', 'JWE1'), ('JWE_2', 'JWE2'), ('OLD', 'Old'), ('PC', 'PC'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('PZ', 'PZ'), ('PZ_16', 'PZ16'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('ZTUAC', 'ZTUAC'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('DLA', 'DLA'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('JWE_1', 'JWE1'), ('JWE_2', 'JWE2'), ('OLD', 'Old'), ('PC', 'PC'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('PZ', 'PZ'), ('PZ_16', 'PZ16'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('ZTUAC', 'ZTUAC'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):

--- a/generated/formats/ovl/__init__.py
+++ b/generated/formats/ovl/__init__.py
@@ -613,13 +613,13 @@ class OvlFile(Header, IoFile):
 			if loader.file_entry.name in filenames:
 				loader.remove()
 
-	def rename(self, name_tups, animal_mode=False):
-		logging.info(f"Renaming for {name_tups}, animal mode = {animal_mode}")
+	def rename(self, name_tups, mesh_mode=False):
+		logging.info(f"Renaming for {name_tups}, mesh mode = {mesh_mode}")
 		# todo - support renaming included_ovls?
 		# make a temporary copy
 		temp_loaders = list(self.loaders.values())
 		for loader in temp_loaders:
-			if animal_mode and loader.file_entry.ext not in (".ms2", ".mdl2", ".motiongraph", ".motiongraphvars"):
+			if mesh_mode and loader.file_entry.ext not in (".ms2", ".mdl2", ".motiongraph", ".motiongraphvars"):
 				continue
 			loader.rename(name_tups)
 		# recreate the loaders dict

--- a/generated/formats/ovl/versions.py
+++ b/generated/formats/ovl/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/ovl_base/ovl_base.xml
+++ b/generated/formats/ovl_base/ovl_base.xml
@@ -32,7 +32,7 @@
     <version id="ZTUAC" version="17">Zoo Tycoon Ultimate Animal Collection</version>
     <version id="PC" version="18" user_version="8340 8724 8212" version_flag="8">Planet Coaster</version>
     <version id="PZ" version="19" user_version="8340 8724 8212">Planet Zoo pre-1.6</version>
-    <version id="PZ16" version="20" user_version="8340 8724 8212">Planet Zoo 1.6+</version>
+    <version id="PZ16" version="20" user_version="8340 8724 8212">Planet Zoo</version>
     <version id="JWE" version="19" user_version="24724 25108 24596">Jurassic World Evolution</version>
     <version id="JWE2" version="20" user_version="24724 25108 24596">Jurassic World Evolution 2</version>
 

--- a/generated/formats/ovl_base/versions.py
+++ b/generated/formats/ovl_base/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/posedriverdef/versions.py
+++ b/generated/formats/posedriverdef/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/pscollection/versions.py
+++ b/generated/formats/pscollection/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/renderparameters/versions.py
+++ b/generated/formats/renderparameters/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/restaurantsettings/versions.py
+++ b/generated/formats/restaurantsettings/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/ridesettings/versions.py
+++ b/generated/formats/ridesettings/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/scaleformlanguagedata/versions.py
+++ b/generated/formats/scaleformlanguagedata/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/specdef/versions.py
+++ b/generated/formats/specdef/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/spl/versions.py
+++ b/generated/formats/spl/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/tex/versions.py
+++ b/generated/formats/tex/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/trackedridecar/versions.py
+++ b/generated/formats/trackedridecar/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/uimoviedefinition/versions.py
+++ b/generated/formats/uimoviedefinition/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/userinterfaceicondata/versions.py
+++ b/generated/formats/userinterfaceicondata/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/voxelskirt/versions.py
+++ b/generated/formats/voxelskirt/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/wmeta/versions.py
+++ b/generated/formats/wmeta/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/world/versions.py
+++ b/generated/formats/world/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/wsm/versions.py
+++ b/generated/formats/wsm/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/generated/formats/xmlconfig/versions.py
+++ b/generated/formats/xmlconfig/versions.py
@@ -70,7 +70,7 @@ def set_jwe2(context):
 	context.user_version._value = 24724
 
 
-games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO_1_6', 'Planet Zoo 1.6+'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
 
 
 def get_game(context):
@@ -83,7 +83,7 @@ def get_game(context):
 	if is_pz(context):
 		return [games.PLANET_ZOO_PRE_1_6]
 	if is_pz16(context):
-		return [games.PLANET_ZOO_1_6]
+		return [games.PLANET_ZOO]
 	if is_jwe(context):
 		return [games.JURASSIC_WORLD_EVOLUTION]
 	if is_jwe2(context):
@@ -102,7 +102,7 @@ def set_game(context, game):
 		return set_pc(context)
 	if game in {games.PLANET_ZOO_PRE_1_6}:
 		return set_pz(context)
-	if game in {games.PLANET_ZOO_1_6}:
+	if game in {games.PLANET_ZOO}:
 		return set_pz16(context)
 	if game in {games.JURASSIC_WORLD_EVOLUTION}:
 		return set_jwe(context)

--- a/ovl_tool_gui.py
+++ b/ovl_tool_gui.py
@@ -195,6 +195,7 @@ class MainWindow(widgets.MainWindow):
 		# self.statusBar.showMessage(get_commit_str())
 		label = QtWidgets.QLabel(f"Cobra Tools Version {get_commit_str()}")
 		self.statusBar.addWidget(label)
+		self.statusBar.setContentsMargins(5, 0, 0, 0)
 		self.setStatusBar(self.statusBar)
 
 	def compare_ovls(self):

--- a/ovl_tool_gui.py
+++ b/ovl_tool_gui.py
@@ -294,6 +294,7 @@ class MainWindow(widgets.MainWindow):
 		# force new name to be lowercase
 		names = [(old_name, new_name.lower()), ]
 		self.ovl_data.rename(names)
+		self.file_widget.dirty = True
 		self.update_gui_table()
 
 	def biosyn_changed(self):
@@ -533,6 +534,7 @@ class MainWindow(widgets.MainWindow):
 				for ovl in self.handle_path():
 					if self.is_open_ovl():
 						self.ovl_data.rename(names, animal_mode=self.t_animal_ovl.isChecked())
+						self.file_widget.dirty = True
 						self.update_gui_table()
 		except BaseException as err:
 			print(err)
@@ -551,6 +553,7 @@ class MainWindow(widgets.MainWindow):
 			for ovl in self.handle_path():
 				if self.is_open_ovl():
 					self.ovl_data.rename_contents(names, only_files)
+					self.file_widget.dirty = True
 					self.update_gui_table()
 
 	# Save the OVL file list to disk
@@ -591,6 +594,7 @@ class MainWindow(widgets.MainWindow):
 			if selected_file_names:
 				try:
 					self.ovl_data.remove(selected_file_names)
+					self.file_widget.dirty = True
 				except:
 					traceback.print_exc()
 				self.update_gui_table()

--- a/ovl_tool_gui.py
+++ b/ovl_tool_gui.py
@@ -130,11 +130,12 @@ class MainWindow(widgets.MainWindow):
 		biosyn_frame.setContentsMargins(0, 0, 0, 0)
 
 		self.e_name_old = QtWidgets.QTextEdit("")
+		self.e_name_old.setPlaceholderText("Find")
 		self.e_name_old.setToolTip("Old strings - one item per line")
 		self.e_name_new = QtWidgets.QTextEdit("")
+		self.e_name_new.setPlaceholderText("Replace")
 		self.e_name_new.setToolTip("New strings - one item per line")
-		self.e_name_old.setFixedHeight(100)
-		self.e_name_new.setFixedHeight(100)
+		self.e_name_old.setSizePolicy(QtWidgets.QSizePolicy.Maximum, QtWidgets.QSizePolicy.Preferred)
 		self.e_name_old.setTabChangesFocus(True)
 		self.e_name_new.setTabChangesFocus(True)
 
@@ -145,8 +146,8 @@ class MainWindow(widgets.MainWindow):
 		self.splitter.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
 
 		self.qgrid = QtWidgets.QGridLayout()
-		self.qgrid.addWidget(self.e_name_old, 0, 0, 5, 1)
-		self.qgrid.addWidget(self.e_name_new, 0, 1, 5, 1)
+		self.qgrid.addWidget(self.e_name_old, 0, 0, 3, 1)
+		self.qgrid.addWidget(self.e_name_new, 0, 1, 3, 1)
 
 		self.qgrid.addWidget(self.t_show_temp_files, 0, 3)
 		self.qgrid.addWidget(self.in_folder, 1, 3)

--- a/ovl_tool_gui.py
+++ b/ovl_tool_gui.py
@@ -120,6 +120,14 @@ class MainWindow(widgets.MainWindow):
 		self.t_biosyn.setToolTip("Check for opening OVLs with MS2 files after JWE2 Biosyn upgrade.")
 		self.t_biosyn.setChecked(False)
 		self.t_biosyn.stateChanged.connect(self.biosyn_changed)
+		biosyn_frame = QtWidgets.QWidget()
+		biosyn_box = QtWidgets.QHBoxLayout()
+		biosyn_box.setSpacing(0)
+		biosyn_box.setContentsMargins(0, 0, 0, 0)
+		biosyn_box.addStretch(1)
+		biosyn_box.addWidget(self.t_biosyn)
+		biosyn_frame.setLayout(biosyn_box)
+		biosyn_frame.setContentsMargins(0, 0, 0, 0)
 
 		self.e_name_old = QtWidgets.QTextEdit("")
 		self.e_name_old.setToolTip("Old strings - one item per line")
@@ -143,7 +151,7 @@ class MainWindow(widgets.MainWindow):
 		self.qgrid.addWidget(self.t_show_temp_files, 0, 3)
 		self.qgrid.addWidget(self.in_folder, 1, 3)
 		self.qgrid.addWidget(self.t_mesh_ovl, 2, 3)
-		self.qgrid.addWidget(self.t_biosyn, 3, 3)
+		self.qgrid.addWidget(biosyn_frame, 2, 4)
 		self.qgrid.addWidget(self.game_choice, 0, 4,)
 		self.qgrid.addWidget(self.compression_choice, 1, 4,)
 

--- a/ovl_tool_gui.py
+++ b/ovl_tool_gui.py
@@ -112,9 +112,9 @@ class MainWindow(widgets.MainWindow):
 		self.in_folder.setToolTip("Runs commands on all OVLs of current folder")
 		self.in_folder.setChecked(False)
 
-		self.t_animal_ovl = QtWidgets.QCheckBox("Animal OVL Mode")
-		self.t_animal_ovl.setToolTip("Renames only MS2, MDL2 and MOTIONGRAPH files.")
-		self.t_animal_ovl.setChecked(False)
+		self.t_mesh_ovl = QtWidgets.QCheckBox("Mesh OVL Mode")
+		self.t_mesh_ovl.setToolTip("Renames only MS2, MDL2 and MOTIONGRAPH files.")
+		self.t_mesh_ovl.setChecked(False)
 
 		self.t_biosyn = QtWidgets.QCheckBox("Biosyn Format")
 		self.t_biosyn.setToolTip("Check for opening OVLs with MS2 files after JWE2 Biosyn upgrade.")
@@ -142,7 +142,7 @@ class MainWindow(widgets.MainWindow):
 
 		self.qgrid.addWidget(self.t_show_temp_files, 0, 3)
 		self.qgrid.addWidget(self.in_folder, 1, 3)
-		self.qgrid.addWidget(self.t_animal_ovl, 2, 3)
+		self.qgrid.addWidget(self.t_mesh_ovl, 2, 3)
 		self.qgrid.addWidget(self.t_biosyn, 3, 3)
 		self.qgrid.addWidget(self.game_choice, 0, 4,)
 		self.qgrid.addWidget(self.compression_choice, 1, 4,)
@@ -533,7 +533,7 @@ class MainWindow(widgets.MainWindow):
 			if names:
 				for ovl in self.handle_path():
 					if self.is_open_ovl():
-						self.ovl_data.rename(names, animal_mode=self.t_animal_ovl.isChecked())
+						self.ovl_data.rename(names, mesh_mode=self.t_mesh_ovl.isChecked())
 						self.file_widget.dirty = True
 						self.update_gui_table()
 		except BaseException as err:

--- a/ovl_tool_gui.py
+++ b/ovl_tool_gui.py
@@ -216,17 +216,28 @@ class MainWindow(widgets.MainWindow):
 			self.populate_game_widget(dir_game)
 			return dir_game
 
-	def set_game_dir(self):
-		dir_game = self.cfg.get("dir_game", "")
+	def get_game_dir(self):
+		return self.cfg.get("dir_game", "")
 
+	def set_game_dir(self):
+		dir_game = self.get_game_dir()
 		if dir_game:
 			self.populate_game_widget(dir_game)
 		else:
 			self.ask_game_dir()
 
+	def set_game_choice(self, game):
+		for g in games:
+			if g.value in self.get_game_dir():
+				self.game_choice.entry.setText(game)
+
 	def populate_game_widget(self, dir_game):
 		rt_index = self.model.setRootPath(dir_game)
 		self.dirs_container.setRootIndex(rt_index)
+		# Set Game Choice default based on current game dir
+		for g in games:
+			if g.value in self.get_game_dir():
+				self.set_game_choice(g.value)
 
 	def get_selected_dir(self):
 		model = self.dirs_container.model()

--- a/source/formats/ovl/__init__.py
+++ b/source/formats/ovl/__init__.py
@@ -613,13 +613,13 @@ class OvlFile(Header, IoFile):
 			if loader.file_entry.name in filenames:
 				loader.remove()
 
-	def rename(self, name_tups, animal_mode=False):
-		logging.info(f"Renaming for {name_tups}, animal mode = {animal_mode}")
+	def rename(self, name_tups, mesh_mode=False):
+		logging.info(f"Renaming for {name_tups}, mesh mode = {mesh_mode}")
 		# todo - support renaming included_ovls?
 		# make a temporary copy
 		temp_loaders = list(self.loaders.values())
 		for loader in temp_loaders:
-			if animal_mode and loader.file_entry.ext not in (".ms2", ".mdl2", ".motiongraph", ".motiongraphvars"):
+			if mesh_mode and loader.file_entry.ext not in (".ms2", ".mdl2", ".motiongraph", ".motiongraphvars"):
 				continue
 			loader.rename(name_tups)
 		# recreate the loaders dict

--- a/source/formats/ovl_base/ovl_base.xml
+++ b/source/formats/ovl_base/ovl_base.xml
@@ -32,7 +32,7 @@
     <version id="ZTUAC" version="17">Zoo Tycoon Ultimate Animal Collection</version>
     <version id="PC" version="18" user_version="8340 8724 8212" version_flag="8">Planet Coaster</version>
     <version id="PZ" version="19" user_version="8340 8724 8212">Planet Zoo pre-1.6</version>
-    <version id="PZ16" version="20" user_version="8340 8724 8212">Planet Zoo 1.6+</version>
+    <version id="PZ16" version="20" user_version="8340 8724 8212">Planet Zoo</version>
     <version id="JWE" version="19" user_version="24724 25108 24596">Jurassic World Evolution</version>
     <version id="JWE2" version="20" user_version="24724 25108 24596">Jurassic World Evolution 2</version>
 

--- a/tests/unit/TestOVLCreate.py
+++ b/tests/unit/TestOVLCreate.py
@@ -20,7 +20,7 @@ class TestOVLCreate(unittest.TestCase):
 		self.assertEqual(game, get_game(self.ovlfile)[0].value, "Should have the same game")
 
 	def test_ovl_save_pz(self):
-		game = "Planet Zoo 1.6+"
+		game = "Planet Zoo"
 		file = 'tests/tmp/pz.ovl'
 		set_game(self.ovlfile.context, game)
 		set_game(self.ovlfile, game)

--- a/tests/unit/TestOVLSave.py
+++ b/tests/unit/TestOVLSave.py
@@ -19,7 +19,7 @@ class TestOVLSave(unittest.TestCase):
 		self.assertEqual(game, get_game(self.ovlfile)[0].value, "Should have the same game")
 
 	def test_ovl_save_pz(self):
-		game = "Planet Zoo 1.6+"
+		game = "Planet Zoo"
 		file = 'tests/tmp/pz.ovl'
 		set_game(self.ovlfile.context, game)
 		set_game(self.ovlfile, game)


### PR DESCRIPTION
- Rename Animal OVL mode because it is used for props etc. 
- Added automatic game selection based on game dir
- Sets file widget to dirty for more operations (Rename, Rename Contents, Remove)
- Renames Planet Zoo string in Game Choice (for automatic game selection based on game dir)
- Minor GUI layout changes