### PR TITLE
FDB/SQL Refactor

### DIFF
--- a/modules/formats/FDB.py
+++ b/modules/formats/FDB.py
@@ -106,6 +106,7 @@ class FdbLoader(BaseFile):
 						if s.find(find.encode()) == -1:
 							run = False
 							logging.error(f'SQL error: "{find}" not found in {self.file_entry.name}. Aborting SQL commands.')
+							break
 
 				if run:
 					con = sqlite3.connect(fdb_path)

--- a/modules/formats/FDB.py
+++ b/modules/formats/FDB.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
 import logging
 import os
 import shutil
 import sqlite3
 import struct
 import traceback
+import mmap
+from collections import namedtuple
 
 from generated.formats.ovl_base.versions import is_pz, is_pz16
 from modules.formats.BaseFormat import BaseFile
@@ -42,32 +45,98 @@ class FdbLoader(BaseFile):
 		with open(command_path, "r") as file:
 			return file.read()
 
+	@staticmethod
+	def hash_djb2(s):
+		hash = 5381
+		for x in s:
+			hash = (( hash << 5) + hash) + ord(x)
+		return hash & 0xFFFFFFFF
+
+	ScriptContext = namedtuple('ScriptContext', ['name', 'command', 'num_strings', 'find_strings'])
+	def context_is_valid(self, context: ScriptContext, name_tuples):
+		if not context or not name_tuples:
+			return False
+		# Require at least N tuples from the GUI, strings over context.num_strings are ignored
+		if len(name_tuples) < context.num_strings:
+			logging.warning(f"Required replacement strings missing for {self.file_entry.name}")
+			logging.info(f"Skipping {self.file_entry.name}. Script strings in need of replacement: {context.find_strings}")
+			logging.info(f"Rename Contents on this FDB needs {context.num_strings} strings in both Find/Replace separated by new lines.")
+			return False
+		return context.name and context.command and context.find_strings
+
 	def rename_content(self, name_tuples):
-		command = None
-		s = None
+		# The current script context e.g. "animals" or "research"
+		context = None
+		# The SQL strings per script
+		script_strings = {
+			"animals" : [("ORIGINAL_SPECIES", "NEW_SPECIES"), ("ORIGINAL_PREFAB", "NEW_PREFAB")],
+			"education" : [("ORIGINAL_SPECIES", "NEW_SPECIES")],
+			"research" : [("ORIGINAL_SPECIES", "NEW_SPECIES")],
+			"zoopedia": [("ORIGINAL_SPECIES", "NEW_SPECIES")]
+		}
+
 		if is_pz(self.ovl) or is_pz16(self.ovl):
 			for s in ("zoopedia", "research", "education", "animals"):
 				if s in self.file_entry.name:
-					command = self.open_command(f"pz_{s}")
+					# The SQL strings for the current context
+					find_strings = list(script_strings.get(s, [()]))
+					context = self.ScriptContext(s, self.open_command(f"pz_{s}"), len(find_strings), find_strings)
 					break
-		if command:
+
+		if self.context_is_valid(context, name_tuples):
 			logging.info(f"Executing command '{s}' on {self.file_entry.name}")
 			try:
 				temp_dir, out_dir_func = self.get_tmp_dir()
 				fdb_path = self.extract(out_dir_func)[0]
-				con = sqlite3.connect(fdb_path)
-				cur = con.cursor()
 
-				for old, new in name_tuples:
-					command_replaced = command.replace("ORIGINAL", old).replace("NEW", new)
-					# print(command_replaced)
-					cur.executescript(command_replaced)
-				# Save (commit) the changes
-				con.commit()
-				con.close()
+				# Clean up with VACUUM first
+				try:
+					con = sqlite3.connect(fdb_path)
+					con.execute("VACUUM")
+				except sqlite3.Error as e:
+					logging.error(f"SQL error: {str(e)}")
+				finally:
+					con.close()
+
+				# Before running SQL commands, verify the strings exist or you will get empty FDBs
+				run = True
+				with open(fdb_path, 'rb', 0) as file, mmap.mmap(file.fileno(), 0, access=mmap.ACCESS_READ) as s:
+					for tup in name_tuples[:context.num_strings]:
+						find = tup[0]
+						if s.find(find.encode()) == -1:
+							run = False
+							logging.error(f'SQL error: "{find}" not found in {self.file_entry.name}. Aborting SQL commands.')
+
+				if run:
+					con = sqlite3.connect(fdb_path)
+					cur = con.cursor()
+					try:
+						command_replaced = context.command
+						for i, find in enumerate(context.find_strings):
+							command_replaced = command_replaced.replace(find[0], name_tuples[i][0]).replace(find[1], name_tuples[i][1])
+						
+						# Calculate new research hash
+						# CALCULATED_HASH gets added to the original ResearchID in the SQL script
+						# Uses both Find and Replace strings for reduced chance of collisions
+						if context.name == "research":
+							command_replaced = command_replaced.replace("CALCULATED_HASH", str(self.hash_djb2(name_tuples[0][0] + name_tuples[0][1])))
+
+						cur.executescript(command_replaced)
+						# Save (commit) the changes
+						con.commit()
+					except sqlite3.Error as e:
+						logging.error(f"SQL error: {str(e)}")
+						#logging.warning(f"Re-extracting {self.file_entry.name} due to failed SQL commands")
+						# Possibly unncessary but safest
+						#fdb_path = self.extract(out_dir_func, None)[0]
+					finally:
+						con.close()
+
 				self.remove()
 				self.ovl.create_file(fdb_path)
 				shutil.rmtree(temp_dir)
 			except BaseException as err:
 				traceback.print_exc()
+		elif context:
+			logging.error(f'SQL Script context "{context.name}" invalid on {self.file_entry.name}')
 

--- a/modules/formats/FDB.py
+++ b/modules/formats/FDB.py
@@ -116,7 +116,6 @@ class FdbLoader(BaseFile):
 						# Uses both Find and Replace strings for reduced chance of collisions
 						if context.name == "research":
 							command_replaced = command_replaced.replace("CALCULATED_HASH", str(djb(name_tuples[0][0] + name_tuples[0][1])))
-							print(djb(name_tuples[0][0] + name_tuples[0][1]))
 
 						cur.executescript(command_replaced)
 						# Save (commit) the changes

--- a/sql_commands/pz_animals.sql
+++ b/sql_commands/pz_animals.sql
@@ -1,152 +1,194 @@
-/*Copy the whole script below into SQLite’s SQL Editor; change ORIGINAL, NEW, and ORIGINAL into your original animal, its replacement, and the length of the animal’s name. USE THE FULL NAME OF THE ANIMAL even if you’re only replacing part of it. IE CuviersDwarfCaiman into NilecrcDwarfCaiman - I’d enter both full names, not only the part that changes*/
+-- FDB Animals
+--***********************
 
-CREATE TEMP TABLE Replacement(Original TEXT PRIMARY KEY, New TEXT, Length INTEGER);
+-- IF USING IN SQLITESTUDIO:
+-- Open with Ctrl+O or the Folder icon in SQL Editor
+-- Make sure Configuration > SQL Queries > "Execute only the query under the cursor" is UNCHECKED
+-- Replace the 4 strings below Original/New/OriginalPrefab/NewPrefab with your base and modded species
+-- NOTES:
+--    Incomplete names ARE supported e.g. 'Grey' -> 'Harbor' will rename GreySeal to HarborSeal
+--    Do NOT use incomplete strings that are too short or generic e.g. Giant, Red, Nile, which all have multiple species matched.
 
-Insert Into Replacement(Original,New,Length) Values ('ORIGINAL','NEW',length('ORIGINAL'));
+CREATE TEMP TABLE IF NOT EXISTS Replacement(Original TEXT PRIMARY KEY, New TEXT, OriginalPrefab TEXT, NewPrefab TEXT);
+INSERT OR IGNORE INTO Replacement(Original,				New,				OriginalPrefab,				NewPrefab)
+-- Replace the 4 strings below here, 2 for species name, 2 for prefabs which contain an underscore in base game e.g. GreySeal -> Grey_Seal.
+VALUES                 ('ORIGINAL_SPECIES',				'NEW_SPECIES',			'ORIGINAL_PREFAB',				'NEW_PREFAB');
 
-/*This clears out everything except our base creature.*/
+-- Support older FDB versions by creating missing tables
+-- 1.7-1.9 Tables
+CREATE TABLE IF NOT EXISTS AnimalBurrowsData (AnimalType TEXT PRIMARY KEY REFERENCES AnimalDefinitions (AnimalType) ON UPDATE CASCADE NOT NULL COLLATE NOCASE UNIQUE, BurrowType TEXT NOT NULL, BabiesWaitForMother BOOLEAN NOT NULL DEFAULT (0), AfterbirthDuration REAL NOT NULL, MaleEnterOverOffset REAL NOT NULL, MaleEnterUnderOffset REAL NOT NULL, MaleExitUnderOffset REAL NOT NULL, MaleExitOverOffset REAL NOT NULL, FemaleEnterOverOffset REAL NOT NULL, FemaleEnterUnderOffset REAL NOT NULL, FemaleExitUnderOffset REAL NOT NULL, FemaleExitOverOffset REAL NOT NULL, JuvenileEnterOverOffset REAL NOT NULL, JuvenileEnterUnderOffset REAL NOT NULL, JuvenileExitUnderOffset REAL NOT NULL, JuvenileExitOverOffset REAL NOT NULL);
+CREATE TABLE IF NOT EXISTS EscapeSpecificBarrierData (AnimalType TEXT REFERENCES AnimalDefinitions (AnimalType) ON UPDATE CASCADE NOT NULL, BarrierType TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS WaterStations (WaterStationPrefabName TEXT NOT NULL UNIQUE CHECK (WaterStationPrefabName NOT LIKE '% ') PRIMARY KEY);
+CREATE TABLE IF NOT EXISTS WaterStationSuitabilityBlacklist (AnimalType TEXT REFERENCES AnimalDefinitions (AnimalType) ON UPDATE CASCADE NOT NULL, WaterStationPrefabName TEXT NOT NULL REFERENCES WaterStations (WaterStationPrefabName) ON UPDATE CASCADE, CONSTRAINT "Animal and Feeding Station Combination are not Unique" UNIQUE (AnimalType COLLATE NOCASE, WaterStationPrefabName COLLATE NOCASE));
+-- 1.10 Tables
+CREATE TABLE IF NOT EXISTS AnimalSingingData (AnimalType TEXT COLLATE NOCASE REFERENCES AnimalDefinitions (AnimalType) ON UPDATE CASCADE, MinCallsPerChorus INTEGER NOT NULL, MaxCallsPerChorus INTEGER NOT NULL, ProbabilityOfPartialCall DOUBLE NOT NULL DEFAULT (0.0), MinTimeBetweenCalls DOUBLE NOT NULL DEFAULT (0.0), MaxTimeBetweenCalls DOUBLE NOT NULL DEFAULT (0.0), PartialCallVariants INTEGER NOT NULL DEFAULT (0), PartialCallAndReplyStart DOUBLE DEFAULT (0.5) NOT NULL, PartialCallAndReplyDuration INTEGER NOT NULL DEFAULT (1), ForceInstantTransitionIdle INTEGER NOT NULL DEFAULT (0));
+CREATE TABLE IF NOT EXISTS AnimalSingingPartialWeights (AnimalType TEXT REFERENCES AnimalDefinitions (AnimalType) ON UPDATE CASCADE NOT NULL COLLATE NOCASE, PartialName TEXT NOT NULL, PartialWeighting DOUBLE NOT NULL);
+CREATE TABLE IF NOT EXISTS SpeciesSniffWeighting (AnimalType TEXT REFERENCES AnimalDefinitions (AnimalType) ON UPDATE CASCADE, SniffWeighting DOUBLE NOT NULL CHECK (SniffWeighting >= 0 AND SniffWeighting <= 1.0) DEFAULT (0.5));
 
-delete from ActionCalculationParameters where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalBiomePreferences where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalCameraData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalContinentPreferences where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalEnrichmentItemSuitability where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalExchangeData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalFoodPreferences where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalHabitatRequirements where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalInterestRating where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from ActionCalculationParameters where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalNameLanguages where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalPurchaseCosts where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalsReadyToBePlacedInGame where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalTaxonomicFamilies where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalTalkParticipantData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalTerrainRequirements where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalTestData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalTheatreParameters where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from BeddingStationSuitability where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from BodyMass where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from BoxData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from CheatVariables where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from ColourMorphData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from DeepSwimmingBehaviourWeights where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from DeepSwimmingParameters where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from DefecationData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from DesiredGenderRatios where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from DesiredPopulationSizes where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from EnrichmentOffsets where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from EnrichmentRequirements where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from EscapeData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from FeedingStationSuitability where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from FertilityData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from FightAgeThresholds where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from GuestAnimalDesire where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from GuestStance where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from IdleBehaviourWeights where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from InterspeciesInteractionData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from LongevityData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from LocomotionSpeeds where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from MatingPairingRules where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from NavigationWorlds where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from NutritionData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from Offsets where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from PerformableAnimations where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from SizeData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from SleepVariables where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from SocialBehaviourSettings where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from SocialInteractionsParameters where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from SpaceRequirements where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from SpeciesDiseaseValues where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from SpeciesEnum where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from SpeciesIdleExploreTypeWeights where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from SpeciesSpecificNeedModifiers where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from SpeciesThatFight where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from SpeciesWithAlpha where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from StressParameters where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from TheatreClearRadii where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from ViewingDistanceModifier where AnimalType not like('%'||(select Original from Replacement)||'%');
-delete from VisualVariation where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from EnrichmentPartialTypesToUse where AnimalType not like ('%'||(select Original from Replacement)||'%');
-Delete from AudioPerActionCallData where ifnull(AnimalType,(select original from replacement)) not like ('%'||(select Original from Replacement)||'%');
-delete from FixRagdollMethodData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-delete from PounceVariablesData where AnimalType not like ('%'||(select Original from Replacement)||'%');
-/*unfinished*/
-/*Delete * from SocialEnrichmentData;*/
+/* This clears out everything except our base creature */
+DELETE FROM ActionCalculationParameters WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalBiomePreferences WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalBurrowsData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalCameraData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalDiggingData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalContinentPreferences WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalEnrichmentItemSuitability WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalExchangeData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalFoodPreferences WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalHabitatRequirements WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalInterestRating WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM ActionCalculationParameters WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalNameLanguages WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalPurchaseCosts WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalsReadyToBePlacedInGame WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalSingingData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%'); -- 1.10
+DELETE FROM AnimalSingingPartialWeights WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%'); -- 1.10
+DELETE FROM AnimalTaxonomicFamilies WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalTalkParticipantData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalTerrainRequirements WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalTestData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalTheatreParameters WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM BeddingStationSuitability WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM BodyMass WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM BoxData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM CheatVariables WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM ColourMorphData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM DeepSwimmingBehaviourWeights WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM DeepSwimmingParameters WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM DefecationData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM DesiredGenderRatios WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM DesiredPopulationSizes WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM EnrichmentOffsets WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM EnrichmentRequirements WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM EscapeData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM EscapeSpecificBarrierData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM FeedingStationSuitability WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM FertilityData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM FightAgeThresholds WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM GuestAnimalDesire WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM GuestStance WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM IdleBehaviourWeights WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM InterspeciesInteractionData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM LongevityData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM LocomotionSpeeds WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM MatingPairingRules WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM NavigationWorlds WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM FixRagdollMethodData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM NutritionData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM Offsets WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM PerformableAnimations WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM PersonalityWeights WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SizeData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SleepVariables WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SocialBehaviourSettings WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM PounceVariablesData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SocialInteractionsParameters WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpaceRequirements WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpeciesDiseaseValues WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpeciesEnum WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpeciesIdleExploreTypeWeights WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpeciesSniffWeighting WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%'); -- 1.10
+DELETE FROM SpeciesSpecificNeedModifiers WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpeciesThatFight WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpeciesWithAlpha WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM StressParameters WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM TheatreClearRadii WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM ViewingDistanceModifier WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM VisualVariation WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM EnrichmentPartialTypesToUse WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AudioPerActionCallData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%'); 
+DELETE FROM PounceVariablesData WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%'); 
+DELETE FROM TemporaryFoodVisualOffsetModifier WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM WaterStationSuitabilityBlacklist WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SocialEnrichmentData;
+DELETE FROM AnimalDefinitions WHERE AnimalType NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalType NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
 
-delete from AnimalDefinitions where AnimalType not like ('%'||(select Original from Replacement)||'%');
+/* This creates our new creature modeled off the base creature in the master table for this FDB */
+INSERT OR IGNORE INTO AnimalDefinitions (AnimalType,AdultMaleGamePrefab,AdultMaleVisualPrefab,AdultFemaleGamePrefab,AdultFemaleVisualPrefab,JuvenileGamePrefab,JuvenileVisualPrefab,ContentPack)
+SELECT
+    replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement)),
+    replace(AdultMaleGamePrefab, (SELECT OriginalPrefab FROM Replacement), (SELECT NewPrefab FROM Replacement)),
+    replace(AdultMaleVisualPrefab, (SELECT OriginalPrefab FROM Replacement), (SELECT NewPrefab FROM Replacement)),
+    replace(AdultFemaleGamePrefab, (SELECT OriginalPrefab FROM Replacement), (SELECT NewPrefab FROM Replacement)),
+    replace(AdultFemaleVisualPrefab, (SELECT OriginalPrefab FROM Replacement), (SELECT NewPrefab FROM Replacement)),
+    replace(JuvenileGamePrefab, (SELECT OriginalPrefab FROM Replacement), (SELECT NewPrefab FROM Replacement)),
+    replace(JuvenileVisualPrefab, (SELECT OriginalPrefab FROM Replacement), (SELECT NewPrefab FROM Replacement)),
+    ContentPack
+FROM AnimalDefinitions;
 
+/* This updates all other tables to use your new species instead of the base creature */
+UPDATE ActionCalculationParameters SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalBiomePreferences SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalCameraData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalContinentPreferences SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalEnrichmentItemSuitability SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalExchangeData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalFoodPreferences SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalHabitatRequirements SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalInterestRating SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE ActionCalculationParameters SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalNameLanguages SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalPurchaseCosts SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalsReadyToBePlacedInGame SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalSingingData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement)); -- 1.10
+UPDATE AnimalSingingPartialWeights SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement)); -- 1.10
+UPDATE AnimalTaxonomicFamilies SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalTalkParticipantData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalTerrainRequirements SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalTestData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalTheatreParameters SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE BeddingStationSuitability SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE BodyMass SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE BoxData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE CheatVariables SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE ColourMorphData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE DeepSwimmingBehaviourWeights SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE DeepSwimmingParameters SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE DefecationData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE DesiredGenderRatios SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE DesiredPopulationSizes SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE EnrichmentOffsets SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE EnrichmentRequirements SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE EscapeData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE FeedingStationSuitability SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE FertilityData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE FightAgeThresholds SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE GuestAnimalDesire SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE GuestStance SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE IdleBehaviourWeights SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE InterspeciesInteractionData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE LongevityData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE LocomotionSpeeds SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE MatingPairingRules SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE NavigationWorlds SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE NutritionData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE Offsets SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE PerformableAnimations SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE SizeData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE SleepVariables SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE SocialBehaviourSettings SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE PounceVariablesData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE SocialInteractionsParameters SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE SpaceRequirements SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE SpeciesDiseaseValues SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE SpeciesEnum SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AnimalsReadyToBePlacedInGame SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE SpeciesIdleExploreTypeWeights SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE SpeciesSniffWeighting SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement)); -- 1.10
+UPDATE SpeciesSpecificNeedModifiers SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE SpeciesThatFight SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE SpeciesWithAlpha SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE StressParameters SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE TheatreClearRadii SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE ViewingDistanceModifier SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE VisualVariation SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE EnrichmentPartialTypesToUse SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE FixRagdollMethodData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE AudioPerActionCallData SET AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement)) WHERE AnimalType is not null;
 
+/* This clears out the base creature. */
+DELETE FROM AnimalDefinitions WHERE AnimalType NOT LIKE replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
 
-/*This creates our new creature modeled off the base creature in the master table for this FDB*/
-Insert into AnimalDefinitions (AnimalType,AdultMaleGamePrefab,AdultMaleVisualPrefab,AdultFemaleGamePrefab,AdultFemaleVisualPrefab,JuvenileGamePrefab,JuvenileVisualPrefab,ContentPack) select (((select New from Replacement))||(substr(AnimalType,(select length+1 from Replacement)))),(((select New from Replacement))||(substr(AdultMaleGamePrefab,(select length+1 from Replacement)))),(((select New from Replacement))||(substr(AdultMaleVisualPrefab,(select length+1 from Replacement)))),(((select New from Replacement))||(substr(AdultFemaleGamePrefab,(select length+1 from Replacement)))),(((select New from Replacement))||(substr(AdultFemaleVisualPrefab,(select length+1 from Replacement)))),(((select New from Replacement))||(substr(JuvenileGamePrefab,(select length+1 from Replacement)))),(((select New from Replacement))||(substr(JuvenileVisualPrefab,(select length+1 from Replacement)))),ContentPack from AnimalDefinitions;
+DROP TABLE Replacement;
 
-
-/*This updates all other tables to use your new species instead of the base creature*/
-Update ActionCalculationParameters set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalBiomePreferences set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalCameraData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalContinentPreferences set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalEnrichmentItemSuitability set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalExchangeData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalFoodPreferences set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalHabitatRequirements set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalInterestRating set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update ActionCalculationParameters set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalNameLanguages set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalPurchaseCosts set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalsReadyToBePlacedInGame set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalTaxonomicFamilies set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalTalkParticipantData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalTerrainRequirements set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalTestData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalTheatreParameters set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update BeddingStationSuitability set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update BodyMass set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update BoxData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update CheatVariables set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update ColourMorphData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update DeepSwimmingBehaviourWeights set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update DeepSwimmingParameters set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update DefecationData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update DesiredGenderRatios set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update DesiredPopulationSizes set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update EnrichmentOffsets set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update EnrichmentRequirements set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update EscapeData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update FeedingStationSuitability set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update FertilityData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update FightAgeThresholds set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update GuestAnimalDesire set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update GuestStance set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update IdleBehaviourWeights set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update InterspeciesInteractionData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update LongevityData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update LocomotionSpeeds set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update MatingPairingRules set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update NavigationWorlds set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update NutritionData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update Offsets set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update PerformableAnimations set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update SizeData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update SleepVariables set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update SocialBehaviourSettings set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update SocialInteractionsParameters set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update SpaceRequirements set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update SpeciesDiseaseValues set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update SpeciesEnum set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AnimalsReadyToBePlacedInGame set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update SpeciesIdleExploreTypeWeights set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update SpeciesSpecificNeedModifiers set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update SpeciesThatFight set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update SpeciesWithAlpha set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update StressParameters set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update TheatreClearRadii set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update ViewingDistanceModifier set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update VisualVariation set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update EnrichmentPartialTypesToUse set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update FixRagdollMethodData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement))));
-Update AudioPerActionCallData set AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from replacement)))) where AnimalType is not null;
-
-
-/*This clears out everything except our base creature.*/
-delete from AnimalDefinitions where AnimalType not like (select New from Replacement);
+VACUUM;

--- a/sql_commands/pz_research.sql
+++ b/sql_commands/pz_research.sql
@@ -1,25 +1,70 @@
-/*Copy the whole script below into SQLite’s SQL Editor; change ORIGINAL, NEW, and ORIGINAL into your original animal, its replacement, and the length of the animal’s name. USE THE FULL NAME OF THE ANIMAL even if you’re only replacing part of it. IE CuviersDwarfCaiman into NilecrcDwarfCaiman - I’d enter both full names, not only the part that changes*/
+-- FDB RESEARCH
+--***********************
 
-CREATE TEMP TABLE Replacement(Original TEXT PRIMARY KEY, New TEXT, Length INTEGER);
+-- IF USING IN SQLITESTUDIO:
+-- Install this function, named djb2 in the SQL Functions Editor (Fx icon) as Type: Scalar, Implementation Language: QtScript, leaving Inputs undefined:
+-- Do not copy paste the /* */ lines
+/*
+    var str = arguments[0];
+    var len = str.length;
+    var h = 5381;
+    for (var i = 0; i < len; i++) {
+    h = h * 33 ^ str.charCodeAt(i);
+    }
+    return h >>> 0;
+*/
+-- Replace CALCULATED_HASH with:
+--     djb2(replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement)))
+-- You can also replace CALCULATED_HASH with your own number instead.
+-- Open with Ctrl+O or the Folder icon in SQL Editor
+-- Make sure Configuration > SQL Queries > "Execute only the query under the cursor" is UNCHECKED
+-- Replace the 2 strings below Original/New with your base and modded species
+-- NOTES:
+--    Incomplete names ARE supported e.g. 'Grey' -> 'Harbor' will rename GreySeal to HarborSeal
+--    Do NOT use incomplete strings that are too short or generic e.g. Giant, Red, Nile, which all have multiple species matched.
 
-Insert Into Replacement(Original,New,Length) Values ('ORIGINAL','NEW',length('ORIGINAL'));
+CREATE TEMP TABLE IF NOT EXISTS Replacement(Original TEXT PRIMARY KEY, New TEXT);
+INSERT OR IGNORE INTO Replacement	(Original,		New)
+-- Replace the 2 strings below here
+VALUES			('ORIGINAL_SPECIES',	'NEW_SPECIES');
 
-/*This clears out everything except our base creature.*/
-delete from BreedingPackStatChanges where ResearchPack not like ('%'||(select Original from Replacement)||'%');
-delete from EducationPackStatChanges where ResearchPack not like ('%'||(select Original from Replacement)||'%');
-delete from ResearchItemData where ResearchItem not like ('%'||(select Original from Replacement)||'%');
-delete from ResearchPackData where ResearchPack not like ('%'||(select Original from Replacement)||'%');
-delete from AnimalData where AnimalSpecies not like ('%'||(select Original from Replacement)||'%');
+/* This clears out everything except our base creature. */
+DELETE FROM DiseasePackStatChanges;
+DELETE FROM ResearchItemData WHERE ResearchCategory NOT LIKE '%VetLevel%';
+DELETE FROM ResearchPackData WHERE AnimalType IS NULL;
+DELETE FROM ResearchCategoryData WHERE ResearchCategory NOT LIKE '%VetLevel%';
+DELETE FROM DiseaseData;
+DELETE FROM BreedingPackStatChanges WHERE ResearchPack NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND ResearchPack NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM EducationPackStatChanges WHERE ResearchPack NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND ResearchPack NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM ResearchItemData WHERE ResearchItem NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND ResearchItem NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM ResearchPackData WHERE ResearchPack NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND ResearchPack NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM AnimalData WHERE AnimalSpecies NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND AnimalSpecies NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
 
-/*This creates our new creature modeled off the base creature in the master table for this FDB*/
-Insert into AnimalData (AnimalSpecies,AnimalType,NumberOfResearchLevels) select ((select New from Replacement)||(substr(AnimalSpecies,(Select Length+1 from Replacement)))),AnimalType,NumberOfResearchLevels from AnimalData;
+/* This creates our new creature modeled off the base creature in the master table for this FDB */
+INSERT OR IGNORE INTO AnimalData (AnimalSpecies, AnimalType, NumberOfResearchLevels)
+SELECT 
+    replace(AnimalSpecies, (SELECT Original FROM Replacement), (SELECT New FROM Replacement)),
+    AnimalType,
+    NumberOfResearchLevels
+FROM AnimalData;
 
-/*This updates all other tables to use your new species instead of the base creature*/
-Update ResearchItemData set ResearchItem = ((select New from Replacement)||(substr(ResearchItem,(select length+1 from Replacement)))), Icon = 'speciesImage_'||(select New from Replacement);
-Update ResearchPackData set ResearchPack = ((select New from Replacement)||(substr(ResearchPack,(select length+1 from Replacement)))), AnimalType = ((select New from Replacement)||(substr(AnimalType,(select length+1 from Replacement))));
-Update BreedingPackStatChanges set ResearchPack = ((select New from Replacement)||(substr(ResearchPack,(select length+1 from Replacement))));
-Update EducationPackStatChanges set ResearchPack = ((select New from Replacement)||(substr(ResearchPack,(select length+1 from Replacement))));
+/* This updates all other tables to use your new species instead of the base creature */
+UPDATE ResearchItemData SET
+    ResearchItem = replace(ResearchItem, (SELECT Original FROM Replacement), (SELECT New FROM Replacement)),
+    ResearchItemID = ResearchItemID + CALCULATED_HASH,
+    Icon = replace(Icon, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE ResearchPackData SET
+    ResearchPack = replace(ResearchPack, (SELECT Original FROM Replacement), (SELECT New FROM Replacement)),
+    ResearchPackID = ResearchPackID + CALCULATED_HASH
+WHERE AnimalType LIKE '%'||(SELECT Original FROM Replacement)||'%';
+UPDATE ResearchPackData SET
+    AnimalType = replace(AnimalType, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE BreedingPackStatChanges SET ResearchPack = replace(ResearchPack, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
+UPDATE EducationPackStatChanges SET ResearchPack = replace(ResearchPack, (SELECT Original FROM Replacement), (SELECT New FROM Replacement));
 
-/*This deletes the base animal from the master table*/
-delete from AnimalData where AnimalSpecies not like (select New from Replacement);
+/* This deletes the base animal from the master table */
+DELETE FROM AnimalData WHERE AnimalSpecies LIKE ('%'||(SELECT Original FROM Replacement)||'%');
 
+DROP TABLE Replacement;
+
+VACUUM;

--- a/sql_commands/pz_zoopedia.sql
+++ b/sql_commands/pz_zoopedia.sql
@@ -1,43 +1,61 @@
-/*Copy the whole script below into SQLite’s SQL Editor; change ORIGINAL, NEW, and ORIGINAL into your original animal, its replacement, and the length of the animal’s name. USE THE FULL NAME OF THE ANIMAL even if you’re only replacing part of it. IE CuviersDwarfCaiman into NilecrcDwarfCaiman - I’d enter both full names, not only the part that changes*/
+-- FDB Zoopedia
+--***********************
 
-CREATE TEMP TABLE Replacement(Original TEXT PRIMARY KEY, New TEXT, Length INTEGER);
+-- IF USING IN SQLITESTUDIO:
+-- Open with Ctrl+O or the Folder icon in SQL Editor
+-- Make sure Configuration > SQL Queries > "Execute only the query under the cursor" is UNCHECKED
+-- Replace the 2 strings below Original/New with your base and modded species
+-- NOTES:
+--    Incomplete names ARE supported e.g. 'Grey' -> 'Harbor' will rename GreySeal to HarborSeal
+--    Do NOT use incomplete strings that are too short or generic e.g. Giant, Red, Nile, which all have multiple species matched.
 
-Insert Into Replacement(Original,New,Length) Values ('ORIGINAL','NEW',length('ORIGINAL'));
+CREATE TEMP TABLE IF NOT EXISTS Replacement(Original TEXT PRIMARY KEY, New TEXT);
+INSERT OR IGNORE INTO Replacement	(Original,		New)
+-- Replace the 2 strings below here
+VALUES			('ORIGINAL_SPECIES',	'NEW_SPECIES');
 
+/* This clears out everything except our base creature. */
+DELETE FROM BarrierRequirements WHERE Species NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND Species NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpeciesFunFactsUnitData WHERE Species NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND Species NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpeciesAverageStats WHERE Species NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND Species NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpeciesZoopediaData WHERE Species NOT LIKE('%'||(SELECT Original FROM Replacement)||'%') AND Species NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpeciesFunFacts WHERE Species NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND Species NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM SpeciesZoopediaUnitData WHERE Species NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND Species NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
+DELETE FROM Species WHERE InternalName NOT LIKE ('%'||(SELECT Original FROM Replacement)||'%') AND InternalName NOT LIKE ('%'||(SELECT New FROM Replacement)||'%');
 
-/*This clears out everything except our base creature.*/
-delete from BarrierRequirements where Species not like ('%'||(select Original from Replacement)||'%');
-delete from SpeciesFunFactsUnitData where Species not like ('%'||(select Original from Replacement)||'%');
-delete from SpeciesAverageStats where Species not like ('%'||(select Original from Replacement)||'%');
-delete from SpeciesZoopediaData where Species not like('%'||(select Original from Replacement)||'%');
-delete from SpeciesFunFacts where Species not like ('%'||(select Original from Replacement)||'%');
-delete from SpeciesZoopediaUnitData where Species not like ('%'||(select Original from Replacement)||'%');
-delete from Species where InternalName not like ('%'||(select Original from Replacement)||'%');
+/* This creates our new creature modeled off the base creature in the master table for this FDB */
+INSERT OR IGNORE INTO Species(InternalName,EnclosureType,ContentPack)
+SELECT replace(s.InternalName, r.Original, r.New), s.EnclosureType, s.ContentPack
+FROM Replacement r, Species s WHERE r.Original = s.InternalName;
 
+/* This updates all other tables to use your new species instead of the base creature */
+UPDATE BarrierRequirements SET Species = (SELECT New FROM Replacement);
+UPDATE SpeciesAverageStats SET Species = (SELECT New FROM Replacement);
+UPDATE SpeciesZoopediaData SET Species = (SELECT New FROM Replacement);
 
-/*This creates our new creature modeled off the base creature in the master table for this FDB*/
-Insert Into Species(InternalName,EnclosureType,ContentPack)
-select r.new, s.enclosuretype, s.contentpack from replacement r, species s where r.original = s.internalname;
+INSERT OR IGNORE INTO SpeciesFunFacts (Species,FunFact,ResearchPackName)
+SELECT (SELECT Original FROM Replacement),'dummy','dummy'
+WHERE EXISTS (SELECT * FROM Species WHERE InternalName LIKE '%'||(SELECT Original FROM Replacement)||'%');
 
+UPDATE SpeciesFunFactsUnitData SET FunFact = 'dummy'
+WHERE EXISTS (SELECT * FROM Species WHERE InternalName LIKE '%'||(SELECT Original FROM Replacement)||'%');
 
-/*This updates all other tables to use your new species instead of the base creature*/
+UPDATE SpeciesFunFacts SET
+    Species = (SELECT new FROM Replacement),
+    FunFact = replace(FunFact, (SELECT Original FROM Replacement), (SELECT New FROM Replacement)),
+    ResearchPackName = replace(ResearchPackName, (SELECT Original FROM Replacement), (SELECT New FROM Replacement))
+WHERE FunFact != 'dummy';
 
-Update BarrierRequirements set Species = (select New from Replacement);
+UPDATE SpeciesFunFactsUnitData SET 
+    Species = (SELECT New FROM Replacement),
+    FunFact = (SELECT FunFact FROM SpeciesFunFacts);
+DELETE FROM SpeciesFunFacts WHERE FunFact = 'dummy';
 
-Update SpeciesAverageStats set Species = (select New from Replacement);
+UPDATE SpeciesZoopediaUnitData SET Species = (SELECT New FROM Replacement);
 
-Update SpeciesZoopediaData set Species = (select New from Replacement);
+/* This deletes the base animal from the master table */
+DELETE FROM Species WHERE InternalName NOT LIKE '%'||(SELECT New FROM Replacement)||'%';
 
-Insert into SpeciesFunFacts (Species,FunFact,ResearchPackName) values ((select original from replacement),'dummy','dummy');
-Update SpeciesFunFactsUnitData set FunFact = 'dummy';
+DROP TABLE Replacement;
 
-Update SpeciesFunFacts set species = (select new from replacement), FunFact = 'Zoopedia_FunFacts_'||(select New from Replacement)||(substr(FunFact,(select length+19 from replacement))), ResearchPackName = ((select New from Replacement)||(substr(ResearchPackName,(select length+1 from replacement)))) where FunFact != 'dummy';
-
-Update SpeciesFunFactsUnitData set Species = (select New from Replacement), FunFact = (select FunFact from SpeciesFunFacts);
-Delete from SpeciesFunFacts where FunFact = 'dummy';
-
-Update SpeciesZoopediaUnitData set Species = (select New from Replacement);
-
-/*This deletes the base animal from the master table*/
-Delete from Species where InternalName not like (select New from Replacement);
-
+VACUUM;


### PR DESCRIPTION
- Peek in FDBs to only run SQL commands when a string exists. Otherwise empty FDBs will occur.
- Automatically generate new ResearchIDs for research FDB.
- SQL scripts updated for 1.10
    - More rigorous, more resilient to data loss/corruption.
    - All SQL can be run multiple times without breaking FDBs
    - Can run on 1.7-1.9 FDBs, by adding missing tables first.