### PR TITLE
Path Decoding

### DIFF
--- a/generated/formats/path/basic.py
+++ b/generated/formats/path/basic.py
@@ -1,0 +1,20 @@
+
+
+from generated.formats.ovl_base.basic import Byte, Ubyte, Uint64, Int64, Uint, Ushort, Int, Short, Char, Float, Double, ZString, Bool, ZStringObfuscated
+
+basic_map = {
+			'Byte': Byte,
+			'Ubyte': Ubyte,
+			'Uint64': Uint64,
+			'Int64': Int64,
+			'Uint': Uint,
+			'Ushort': Ushort,
+			'Int': Int,
+			'Short': Short,
+			'Char': Char,
+			'Float': Float,
+			'Double': Double,
+			'ZString': ZString,
+			'Bool': Bool,
+			'ZStringObfuscated': ZStringObfuscated,
+}

--- a/generated/formats/path/compound/Connector.py
+++ b/generated/formats/path/compound/Connector.py
@@ -1,0 +1,84 @@
+from source.formats.base.basic import fmt_member
+import generated.formats.base.basic
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.ovl_base.compound.Pointer import Pointer
+from generated.formats.path.compound.Vector2 import Vector2
+
+
+class Connector(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.unk_vector = Vector2(self.context, 0, None)
+		self.model_name = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.joint_name = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.unk_vector = Vector2(self.context, 0, None)
+		self.model_name = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.joint_name = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.model_name = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.joint_name = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.unk_vector = Vector2.from_stream(stream, instance.context, 0, None)
+		instance.model_name.arg = 0
+		instance.joint_name.arg = 0
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		Pointer.to_stream(stream, instance.model_name)
+		Pointer.to_stream(stream, instance.joint_name)
+		Vector2.to_stream(stream, instance.unk_vector)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'Connector [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* model_name = {fmt_member(self.model_name, indent+1)}'
+		s += f'\n	* joint_name = {fmt_member(self.joint_name, indent+1)}'
+		s += f'\n	* unk_vector = {fmt_member(self.unk_vector, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/ConnectorMultiJoint.py
+++ b/generated/formats/path/compound/ConnectorMultiJoint.py
@@ -1,0 +1,105 @@
+from source.formats.base.basic import fmt_member
+import generated.formats.base.basic
+import generated.formats.path.compound.Joint
+from generated.formats.ovl_base.compound.ArrayPointer import ArrayPointer
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.ovl_base.compound.Pointer import Pointer
+
+
+class ConnectorMultiJoint(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.padding = 0
+		self.num_joints = 0
+		self.unk_float_1 = 0.0
+		self.unk_int_1 = 0
+		self.padding = 0
+		self.model_name = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.joints = ArrayPointer(self.context, self.num_joints, generated.formats.path.compound.Joint.Joint)
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.padding = 0
+		self.num_joints = 0
+		self.unk_float_1 = 0.0
+		self.unk_int_1 = 0
+		self.padding = 0
+		self.model_name = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.joints = ArrayPointer(self.context, self.num_joints, generated.formats.path.compound.Joint.Joint)
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.model_name = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.padding = stream.read_uint64()
+		instance.joints = ArrayPointer.from_stream(stream, instance.context, instance.num_joints, generated.formats.path.compound.Joint.Joint)
+		instance.num_joints = stream.read_uint64()
+		instance.unk_float_1 = stream.read_float()
+		instance.unk_int_1 = stream.read_uint()
+		instance.padding = stream.read_uint64()
+		instance.model_name.arg = 0
+		instance.joints.arg = instance.num_joints
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		Pointer.to_stream(stream, instance.model_name)
+		stream.write_uint64(instance.padding)
+		ArrayPointer.to_stream(stream, instance.joints)
+		stream.write_uint64(instance.num_joints)
+		stream.write_float(instance.unk_float_1)
+		stream.write_uint(instance.unk_int_1)
+		stream.write_uint64(instance.padding)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'ConnectorMultiJoint [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* model_name = {fmt_member(self.model_name, indent+1)}'
+		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
+		s += f'\n	* joints = {fmt_member(self.joints, indent+1)}'
+		s += f'\n	* num_joints = {fmt_member(self.num_joints, indent+1)}'
+		s += f'\n	* unk_float_1 = {fmt_member(self.unk_float_1, indent+1)}'
+		s += f'\n	* unk_int_1 = {fmt_member(self.unk_int_1, indent+1)}'
+		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/Footer.py
+++ b/generated/formats/path/compound/Footer.py
@@ -1,0 +1,67 @@
+from source.formats.base.basic import fmt_member
+from generated.formats.path.compound.SupportAttach import SupportAttach
+
+
+class Footer(SupportAttach):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		pass
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		pass
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		pass
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'Footer [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/Joint.py
+++ b/generated/formats/path/compound/Joint.py
@@ -1,0 +1,67 @@
+from source.formats.base.basic import fmt_member
+from generated.formats.path.compound.SupportAttachExtra import SupportAttachExtra
+
+
+class Joint(SupportAttachExtra):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		pass
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		pass
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		pass
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'Joint [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/PathExtrusion.py
+++ b/generated/formats/path/compound/PathExtrusion.py
@@ -16,7 +16,7 @@ class PathExtrusion(MemStruct):
 		self.unk_float_1 = 0.0
 		self.unk_float_2 = 0.0
 		self.is_kerb = False
-		self.unk_bool = False
+		self.is_not_ground = False
 		self.model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.post_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.endcap_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
@@ -27,7 +27,7 @@ class PathExtrusion(MemStruct):
 		self.unk_float_1 = 0.0
 		self.unk_float_2 = 0.0
 		self.is_kerb = False
-		self.unk_bool = False
+		self.is_not_ground = False
 		self.model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.post_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.endcap_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
@@ -51,7 +51,7 @@ class PathExtrusion(MemStruct):
 		instance.unk_float_1 = stream.read_float()
 		instance.unk_float_2 = stream.read_float()
 		instance.is_kerb = stream.read_bool()
-		instance.unk_bool = stream.read_bool()
+		instance.is_not_ground = stream.read_bool()
 		instance.model.arg = 0
 		instance.post_model.arg = 0
 		instance.endcap_model.arg = 0
@@ -65,7 +65,7 @@ class PathExtrusion(MemStruct):
 		stream.write_float(instance.unk_float_1)
 		stream.write_float(instance.unk_float_2)
 		stream.write_bool(instance.is_kerb)
-		stream.write_bool(instance.unk_bool)
+		stream.write_bool(instance.is_not_ground)
 
 	@classmethod
 	def from_stream(cls, stream, context, arg=0, template=None):
@@ -94,7 +94,7 @@ class PathExtrusion(MemStruct):
 		s += f'\n	* unk_float_1 = {fmt_member(self.unk_float_1, indent+1)}'
 		s += f'\n	* unk_float_2 = {fmt_member(self.unk_float_2, indent+1)}'
 		s += f'\n	* is_kerb = {fmt_member(self.is_kerb, indent+1)}'
-		s += f'\n	* unk_bool = {fmt_member(self.unk_bool, indent+1)}'
+		s += f'\n	* is_not_ground = {fmt_member(self.is_not_ground, indent+1)}'
 		return s
 
 	def __repr__(self, indent=0):

--- a/generated/formats/path/compound/PathExtrusion.py
+++ b/generated/formats/path/compound/PathExtrusion.py
@@ -1,6 +1,5 @@
 from source.formats.base.basic import fmt_member
 import generated.formats.base.basic
-import numpy
 from generated.formats.ovl_base.compound.MemStruct import MemStruct
 from generated.formats.ovl_base.compound.Pointer import Pointer
 
@@ -18,7 +17,6 @@ class PathExtrusion(MemStruct):
 		self.unk_float_2 = 0.0
 		self.is_kerb = False
 		self.unk_bool = False
-		self.padding = numpy.zeros((14,), dtype=numpy.dtype('int8'))
 		self.model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.post_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.endcap_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
@@ -30,7 +28,6 @@ class PathExtrusion(MemStruct):
 		self.unk_float_2 = 0.0
 		self.is_kerb = False
 		self.unk_bool = False
-		self.padding = numpy.zeros((14,), dtype=numpy.dtype('int8'))
 		self.model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.post_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.endcap_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
@@ -55,7 +52,6 @@ class PathExtrusion(MemStruct):
 		instance.unk_float_2 = stream.read_float()
 		instance.is_kerb = stream.read_bool()
 		instance.unk_bool = stream.read_bool()
-		instance.padding = stream.read_bytes((14,))
 		instance.model.arg = 0
 		instance.post_model.arg = 0
 		instance.endcap_model.arg = 0
@@ -70,7 +66,6 @@ class PathExtrusion(MemStruct):
 		stream.write_float(instance.unk_float_2)
 		stream.write_bool(instance.is_kerb)
 		stream.write_bool(instance.unk_bool)
-		stream.write_bytes(instance.padding)
 
 	@classmethod
 	def from_stream(cls, stream, context, arg=0, template=None):
@@ -100,7 +95,6 @@ class PathExtrusion(MemStruct):
 		s += f'\n	* unk_float_2 = {fmt_member(self.unk_float_2, indent+1)}'
 		s += f'\n	* is_kerb = {fmt_member(self.is_kerb, indent+1)}'
 		s += f'\n	* unk_bool = {fmt_member(self.unk_bool, indent+1)}'
-		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
 		return s
 
 	def __repr__(self, indent=0):

--- a/generated/formats/path/compound/PathExtrusion.py
+++ b/generated/formats/path/compound/PathExtrusion.py
@@ -1,0 +1,110 @@
+from source.formats.base.basic import fmt_member
+import generated.formats.base.basic
+import numpy
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.ovl_base.compound.Pointer import Pointer
+
+
+class PathExtrusion(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.unk_float_1 = 0.0
+		self.unk_float_2 = 0.0
+		self.is_kerb = False
+		self.unk_bool = False
+		self.padding = numpy.zeros((14,), dtype=numpy.dtype('int8'))
+		self.model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.post_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.endcap_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.unk_float_1 = 0.0
+		self.unk_float_2 = 0.0
+		self.is_kerb = False
+		self.unk_bool = False
+		self.padding = numpy.zeros((14,), dtype=numpy.dtype('int8'))
+		self.model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.post_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.endcap_model = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.model = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.post_model = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.endcap_model = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.unk_float_1 = stream.read_float()
+		instance.unk_float_2 = stream.read_float()
+		instance.is_kerb = stream.read_bool()
+		instance.unk_bool = stream.read_bool()
+		instance.padding = stream.read_bytes((14,))
+		instance.model.arg = 0
+		instance.post_model.arg = 0
+		instance.endcap_model.arg = 0
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		Pointer.to_stream(stream, instance.model)
+		Pointer.to_stream(stream, instance.post_model)
+		Pointer.to_stream(stream, instance.endcap_model)
+		stream.write_float(instance.unk_float_1)
+		stream.write_float(instance.unk_float_2)
+		stream.write_bool(instance.is_kerb)
+		stream.write_bool(instance.unk_bool)
+		stream.write_bytes(instance.padding)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'PathExtrusion [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* model = {fmt_member(self.model, indent+1)}'
+		s += f'\n	* post_model = {fmt_member(self.post_model, indent+1)}'
+		s += f'\n	* endcap_model = {fmt_member(self.endcap_model, indent+1)}'
+		s += f'\n	* unk_float_1 = {fmt_member(self.unk_float_1, indent+1)}'
+		s += f'\n	* unk_float_2 = {fmt_member(self.unk_float_2, indent+1)}'
+		s += f'\n	* is_kerb = {fmt_member(self.is_kerb, indent+1)}'
+		s += f'\n	* unk_bool = {fmt_member(self.unk_bool, indent+1)}'
+		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/PathJoinPartResource.py
+++ b/generated/formats/path/compound/PathJoinPartResource.py
@@ -1,0 +1,155 @@
+from source.formats.base.basic import fmt_member
+import generated.formats.base.basic
+import generated.formats.path.compound.PointsList
+import generated.formats.path.compound.Vector4
+from generated.formats.ovl_base.compound.ArrayPointer import ArrayPointer
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.ovl_base.compound.Pointer import Pointer
+
+
+class PathJoinPartResource(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.padding_1 = 0
+		self.unk_byte_1 = 0
+		self.unk_byte_2 = 0
+		self.unk_byte_3 = 0
+		self.num_points_1 = 0
+		self.num_points_1_copy = 0
+		self.num_points_2 = 0
+		self.num_points_2_copy = 0
+		self.num_points_3 = 0
+		self.padding_2 = 0
+		self.unk_points_1 = Pointer(self.context, self.num_points_1, generated.formats.path.compound.PointsList.PointsList)
+		self.unk_points_2 = Pointer(self.context, self.num_points_2, generated.formats.path.compound.PointsList.PointsList)
+		self.unk_vector = ArrayPointer(self.context, 1, generated.formats.path.compound.Vector4.Vector4)
+		self.unk_shorts = ArrayPointer(self.context, 8, generated.formats.base.basic.Ushort)
+		self.unk_points_3 = Pointer(self.context, self.num_points_3, generated.formats.path.compound.PointsList.PointsList)
+		self.pathresource = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.padding_1 = 0
+		self.unk_byte_1 = 0
+		self.unk_byte_2 = 0
+		self.unk_byte_3 = 0
+		self.num_points_1 = 0
+		self.num_points_1_copy = 0
+		self.num_points_2 = 0
+		self.num_points_2_copy = 0
+		self.num_points_3 = 0
+		self.padding_2 = 0
+		self.unk_points_1 = Pointer(self.context, self.num_points_1, generated.formats.path.compound.PointsList.PointsList)
+		self.unk_points_2 = Pointer(self.context, self.num_points_2, generated.formats.path.compound.PointsList.PointsList)
+		self.unk_vector = ArrayPointer(self.context, 1, generated.formats.path.compound.Vector4.Vector4)
+		self.unk_shorts = ArrayPointer(self.context, 8, generated.formats.base.basic.Ushort)
+		self.unk_points_3 = Pointer(self.context, self.num_points_3, generated.formats.path.compound.PointsList.PointsList)
+		self.pathresource = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.unk_points_1 = Pointer.from_stream(stream, instance.context, instance.num_points_1, generated.formats.path.compound.PointsList.PointsList)
+		instance.unk_points_2 = Pointer.from_stream(stream, instance.context, instance.num_points_2, generated.formats.path.compound.PointsList.PointsList)
+		instance.unk_vector = ArrayPointer.from_stream(stream, instance.context, 1, generated.formats.path.compound.Vector4.Vector4)
+		instance.unk_shorts = ArrayPointer.from_stream(stream, instance.context, 8, generated.formats.base.basic.Ushort)
+		instance.unk_points_3 = Pointer.from_stream(stream, instance.context, instance.num_points_3, generated.formats.path.compound.PointsList.PointsList)
+		instance.padding_1 = stream.read_uint64()
+		instance.pathresource = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.unk_byte_1 = stream.read_byte()
+		instance.unk_byte_2 = stream.read_byte()
+		instance.unk_byte_3 = stream.read_byte()
+		instance.num_points_1 = stream.read_byte()
+		instance.num_points_1_copy = stream.read_byte()
+		instance.num_points_2 = stream.read_byte()
+		instance.num_points_2_copy = stream.read_byte()
+		instance.num_points_3 = stream.read_byte()
+		instance.padding_2 = stream.read_uint64()
+		instance.unk_points_1.arg = instance.num_points_1
+		instance.unk_points_2.arg = instance.num_points_2
+		instance.unk_vector.arg = 1
+		instance.unk_shorts.arg = 8
+		instance.unk_points_3.arg = instance.num_points_3
+		instance.pathresource.arg = 0
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		Pointer.to_stream(stream, instance.unk_points_1)
+		Pointer.to_stream(stream, instance.unk_points_2)
+		ArrayPointer.to_stream(stream, instance.unk_vector)
+		ArrayPointer.to_stream(stream, instance.unk_shorts)
+		Pointer.to_stream(stream, instance.unk_points_3)
+		stream.write_uint64(instance.padding_1)
+		Pointer.to_stream(stream, instance.pathresource)
+		stream.write_byte(instance.unk_byte_1)
+		stream.write_byte(instance.unk_byte_2)
+		stream.write_byte(instance.unk_byte_3)
+		stream.write_byte(instance.num_points_1)
+		stream.write_byte(instance.num_points_1_copy)
+		stream.write_byte(instance.num_points_2)
+		stream.write_byte(instance.num_points_2_copy)
+		stream.write_byte(instance.num_points_3)
+		stream.write_uint64(instance.padding_2)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'PathJoinPartResource [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* unk_points_1 = {fmt_member(self.unk_points_1, indent+1)}'
+		s += f'\n	* unk_points_2 = {fmt_member(self.unk_points_2, indent+1)}'
+		s += f'\n	* unk_vector = {fmt_member(self.unk_vector, indent+1)}'
+		s += f'\n	* unk_shorts = {fmt_member(self.unk_shorts, indent+1)}'
+		s += f'\n	* unk_points_3 = {fmt_member(self.unk_points_3, indent+1)}'
+		s += f'\n	* padding_1 = {fmt_member(self.padding_1, indent+1)}'
+		s += f'\n	* pathresource = {fmt_member(self.pathresource, indent+1)}'
+		s += f'\n	* unk_byte_1 = {fmt_member(self.unk_byte_1, indent+1)}'
+		s += f'\n	* unk_byte_2 = {fmt_member(self.unk_byte_2, indent+1)}'
+		s += f'\n	* unk_byte_3 = {fmt_member(self.unk_byte_3, indent+1)}'
+		s += f'\n	* num_points_1 = {fmt_member(self.num_points_1, indent+1)}'
+		s += f'\n	* num_points_1_copy = {fmt_member(self.num_points_1_copy, indent+1)}'
+		s += f'\n	* num_points_2 = {fmt_member(self.num_points_2, indent+1)}'
+		s += f'\n	* num_points_2_copy = {fmt_member(self.num_points_2_copy, indent+1)}'
+		s += f'\n	* num_points_3 = {fmt_member(self.num_points_3, indent+1)}'
+		s += f'\n	* padding_2 = {fmt_member(self.padding_2, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/PathJoinPartResourceList.py
+++ b/generated/formats/path/compound/PathJoinPartResourceList.py
@@ -1,0 +1,77 @@
+from source.formats.base.basic import fmt_member
+import numpy
+from generated.array import Array
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.path.compound.PathJoinPartResource import PathJoinPartResource
+
+
+class PathJoinPartResourceList(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.resources = Array((self.arg,), PathJoinPartResource, self.context, 0, None)
+		self.padding = numpy.zeros(((self.arg % 2) * 8,), dtype=numpy.dtype('int8'))
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.resources = Array((self.arg,), PathJoinPartResource, self.context, 0, None)
+		self.padding = numpy.zeros(((self.arg % 2) * 8,), dtype=numpy.dtype('int8'))
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.resources = Array.from_stream(stream, (instance.arg,), PathJoinPartResource, instance.context, 0, None)
+		instance.padding = stream.read_bytes(((instance.arg % 2) * 8,))
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		Array.to_stream(stream, instance.resources, (instance.arg,), PathJoinPartResource, instance.context, 0, None)
+		stream.write_bytes(instance.padding)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'PathJoinPartResourceList [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* resources = {fmt_member(self.resources, indent+1)}'
+		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/PathJoinPartResourceList.py
+++ b/generated/formats/path/compound/PathJoinPartResourceList.py
@@ -1,5 +1,4 @@
 from source.formats.base.basic import fmt_member
-import numpy
 from generated.array import Array
 from generated.formats.ovl_base.compound.MemStruct import MemStruct
 from generated.formats.path.compound.PathJoinPartResource import PathJoinPartResource
@@ -15,13 +14,11 @@ class PathJoinPartResourceList(MemStruct):
 		self.io_size = 0
 		self.io_start = 0
 		self.resources = Array((self.arg,), PathJoinPartResource, self.context, 0, None)
-		self.padding = numpy.zeros(((self.arg % 2) * 8,), dtype=numpy.dtype('int8'))
 		if set_default:
 			self.set_defaults()
 
 	def set_defaults(self):
 		self.resources = Array((self.arg,), PathJoinPartResource, self.context, 0, None)
-		self.padding = numpy.zeros(((self.arg % 2) * 8,), dtype=numpy.dtype('int8'))
 
 	def read(self, stream):
 		self.io_start = stream.tell()
@@ -37,13 +34,11 @@ class PathJoinPartResourceList(MemStruct):
 	def read_fields(cls, stream, instance):
 		super().read_fields(stream, instance)
 		instance.resources = Array.from_stream(stream, (instance.arg,), PathJoinPartResource, instance.context, 0, None)
-		instance.padding = stream.read_bytes(((instance.arg % 2) * 8,))
 
 	@classmethod
 	def write_fields(cls, stream, instance):
 		super().write_fields(stream, instance)
 		Array.to_stream(stream, instance.resources, (instance.arg,), PathJoinPartResource, instance.context, 0, None)
-		stream.write_bytes(instance.padding)
 
 	@classmethod
 	def from_stream(cls, stream, context, arg=0, template=None):
@@ -67,7 +62,6 @@ class PathJoinPartResourceList(MemStruct):
 		s = ''
 		s += super().get_fields_str()
 		s += f'\n	* resources = {fmt_member(self.resources, indent+1)}'
-		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
 		return s
 
 	def __repr__(self, indent=0):

--- a/generated/formats/path/compound/PathJoinPartResourceRoot.py
+++ b/generated/formats/path/compound/PathJoinPartResourceRoot.py
@@ -1,0 +1,77 @@
+from source.formats.base.basic import fmt_member
+import generated.formats.path.compound.PathJoinPartResourceList
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.ovl_base.compound.Pointer import Pointer
+
+
+class PathJoinPartResourceRoot(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.num_res = 0
+		self.resources_list = Pointer(self.context, self.num_res, generated.formats.path.compound.PathJoinPartResourceList.PathJoinPartResourceList)
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.num_res = 0
+		self.resources_list = Pointer(self.context, self.num_res, generated.formats.path.compound.PathJoinPartResourceList.PathJoinPartResourceList)
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.resources_list = Pointer.from_stream(stream, instance.context, instance.num_res, generated.formats.path.compound.PathJoinPartResourceList.PathJoinPartResourceList)
+		instance.num_res = stream.read_uint64()
+		instance.resources_list.arg = instance.num_res
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		Pointer.to_stream(stream, instance.resources_list)
+		stream.write_uint64(instance.num_res)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'PathJoinPartResourceRoot [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* resources_list = {fmt_member(self.resources_list, indent+1)}'
+		s += f'\n	* num_res = {fmt_member(self.num_res, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/PathMaterial.py
+++ b/generated/formats/path/compound/PathMaterial.py
@@ -17,7 +17,6 @@ class PathMaterial(MemStruct):
 		self.io_start = 0
 		self.path_sub_type = 0
 		self.num_data = 0
-		self.padding = 0
 		self.elevated_mat = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.elevated_mat_valid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.elevated_mat_invalid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
@@ -35,7 +34,6 @@ class PathMaterial(MemStruct):
 	def set_defaults(self):
 		self.path_sub_type = 0
 		self.num_data = 0
-		self.padding = 0
 		self.elevated_mat = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.elevated_mat_valid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.elevated_mat_invalid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
@@ -74,7 +72,6 @@ class PathMaterial(MemStruct):
 		instance.path_sub_type = stream.read_uint64()
 		instance.mat_data = ArrayPointer.from_stream(stream, instance.context, instance.num_data, generated.formats.path.compound.PathMaterialData.PathMaterialData)
 		instance.num_data = stream.read_uint64()
-		instance.padding = stream.read_uint64()
 		instance.elevated_mat.arg = 0
 		instance.elevated_mat_valid.arg = 0
 		instance.elevated_mat_invalid.arg = 0
@@ -103,7 +100,6 @@ class PathMaterial(MemStruct):
 		stream.write_uint64(instance.path_sub_type)
 		ArrayPointer.to_stream(stream, instance.mat_data)
 		stream.write_uint64(instance.num_data)
-		stream.write_uint64(instance.padding)
 
 	@classmethod
 	def from_stream(cls, stream, context, arg=0, template=None):
@@ -139,7 +135,6 @@ class PathMaterial(MemStruct):
 		s += f'\n	* path_sub_type = {fmt_member(self.path_sub_type, indent+1)}'
 		s += f'\n	* mat_data = {fmt_member(self.mat_data, indent+1)}'
 		s += f'\n	* num_data = {fmt_member(self.num_data, indent+1)}'
-		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
 		return s
 
 	def __repr__(self, indent=0):

--- a/generated/formats/path/compound/PathMaterial.py
+++ b/generated/formats/path/compound/PathMaterial.py
@@ -1,0 +1,149 @@
+from source.formats.base.basic import fmt_member
+import generated.formats.base.basic
+import generated.formats.path.compound.PathMaterialData
+from generated.formats.ovl_base.compound.ArrayPointer import ArrayPointer
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.ovl_base.compound.Pointer import Pointer
+
+
+class PathMaterial(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.num_data = 0
+		self.num_data_copy = 0
+		self.padding = 0
+		self.elevated_mat = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.elevated_mat_valid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.elevated_mat_invalid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.terrain_mat = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.terrain_mat_valid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.terrain_mat_invalid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.underside_mat_1 = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.underside_mat_2 = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.stairs_mat_1 = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.stairs_mat_2 = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.mat_data = ArrayPointer(self.context, self.num_data, generated.formats.path.compound.PathMaterialData.PathMaterialData)
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.num_data = 0
+		self.num_data_copy = 0
+		self.padding = 0
+		self.elevated_mat = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.elevated_mat_valid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.elevated_mat_invalid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.terrain_mat = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.terrain_mat_valid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.terrain_mat_invalid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.underside_mat_1 = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.underside_mat_2 = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.stairs_mat_1 = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.stairs_mat_2 = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.mat_data = ArrayPointer(self.context, self.num_data, generated.formats.path.compound.PathMaterialData.PathMaterialData)
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.elevated_mat = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.elevated_mat_valid = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.elevated_mat_invalid = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.terrain_mat = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.terrain_mat_valid = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.terrain_mat_invalid = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.underside_mat_1 = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.underside_mat_2 = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.stairs_mat_1 = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.stairs_mat_2 = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.num_data = stream.read_uint64()
+		instance.mat_data = ArrayPointer.from_stream(stream, instance.context, instance.num_data, generated.formats.path.compound.PathMaterialData.PathMaterialData)
+		instance.num_data_copy = stream.read_uint64()
+		instance.padding = stream.read_uint64()
+		instance.elevated_mat.arg = 0
+		instance.elevated_mat_valid.arg = 0
+		instance.elevated_mat_invalid.arg = 0
+		instance.terrain_mat.arg = 0
+		instance.terrain_mat_valid.arg = 0
+		instance.terrain_mat_invalid.arg = 0
+		instance.underside_mat_1.arg = 0
+		instance.underside_mat_2.arg = 0
+		instance.stairs_mat_1.arg = 0
+		instance.stairs_mat_2.arg = 0
+		instance.mat_data.arg = instance.num_data
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		Pointer.to_stream(stream, instance.elevated_mat)
+		Pointer.to_stream(stream, instance.elevated_mat_valid)
+		Pointer.to_stream(stream, instance.elevated_mat_invalid)
+		Pointer.to_stream(stream, instance.terrain_mat)
+		Pointer.to_stream(stream, instance.terrain_mat_valid)
+		Pointer.to_stream(stream, instance.terrain_mat_invalid)
+		Pointer.to_stream(stream, instance.underside_mat_1)
+		Pointer.to_stream(stream, instance.underside_mat_2)
+		Pointer.to_stream(stream, instance.stairs_mat_1)
+		Pointer.to_stream(stream, instance.stairs_mat_2)
+		stream.write_uint64(instance.num_data)
+		ArrayPointer.to_stream(stream, instance.mat_data)
+		stream.write_uint64(instance.num_data_copy)
+		stream.write_uint64(instance.padding)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'PathMaterial [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* elevated_mat = {fmt_member(self.elevated_mat, indent+1)}'
+		s += f'\n	* elevated_mat_valid = {fmt_member(self.elevated_mat_valid, indent+1)}'
+		s += f'\n	* elevated_mat_invalid = {fmt_member(self.elevated_mat_invalid, indent+1)}'
+		s += f'\n	* terrain_mat = {fmt_member(self.terrain_mat, indent+1)}'
+		s += f'\n	* terrain_mat_valid = {fmt_member(self.terrain_mat_valid, indent+1)}'
+		s += f'\n	* terrain_mat_invalid = {fmt_member(self.terrain_mat_invalid, indent+1)}'
+		s += f'\n	* underside_mat_1 = {fmt_member(self.underside_mat_1, indent+1)}'
+		s += f'\n	* underside_mat_2 = {fmt_member(self.underside_mat_2, indent+1)}'
+		s += f'\n	* stairs_mat_1 = {fmt_member(self.stairs_mat_1, indent+1)}'
+		s += f'\n	* stairs_mat_2 = {fmt_member(self.stairs_mat_2, indent+1)}'
+		s += f'\n	* num_data = {fmt_member(self.num_data, indent+1)}'
+		s += f'\n	* mat_data = {fmt_member(self.mat_data, indent+1)}'
+		s += f'\n	* num_data_copy = {fmt_member(self.num_data_copy, indent+1)}'
+		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/PathMaterial.py
+++ b/generated/formats/path/compound/PathMaterial.py
@@ -15,8 +15,8 @@ class PathMaterial(MemStruct):
 		self.template = template
 		self.io_size = 0
 		self.io_start = 0
+		self.path_sub_type = 0
 		self.num_data = 0
-		self.num_data_copy = 0
 		self.padding = 0
 		self.elevated_mat = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.elevated_mat_valid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
@@ -33,8 +33,8 @@ class PathMaterial(MemStruct):
 			self.set_defaults()
 
 	def set_defaults(self):
+		self.path_sub_type = 0
 		self.num_data = 0
-		self.num_data_copy = 0
 		self.padding = 0
 		self.elevated_mat = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.elevated_mat_valid = Pointer(self.context, 0, generated.formats.base.basic.ZString)
@@ -71,9 +71,9 @@ class PathMaterial(MemStruct):
 		instance.underside_mat_2 = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
 		instance.stairs_mat_1 = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
 		instance.stairs_mat_2 = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
-		instance.num_data = stream.read_uint64()
+		instance.path_sub_type = stream.read_uint64()
 		instance.mat_data = ArrayPointer.from_stream(stream, instance.context, instance.num_data, generated.formats.path.compound.PathMaterialData.PathMaterialData)
-		instance.num_data_copy = stream.read_uint64()
+		instance.num_data = stream.read_uint64()
 		instance.padding = stream.read_uint64()
 		instance.elevated_mat.arg = 0
 		instance.elevated_mat_valid.arg = 0
@@ -100,9 +100,9 @@ class PathMaterial(MemStruct):
 		Pointer.to_stream(stream, instance.underside_mat_2)
 		Pointer.to_stream(stream, instance.stairs_mat_1)
 		Pointer.to_stream(stream, instance.stairs_mat_2)
-		stream.write_uint64(instance.num_data)
+		stream.write_uint64(instance.path_sub_type)
 		ArrayPointer.to_stream(stream, instance.mat_data)
-		stream.write_uint64(instance.num_data_copy)
+		stream.write_uint64(instance.num_data)
 		stream.write_uint64(instance.padding)
 
 	@classmethod
@@ -136,9 +136,9 @@ class PathMaterial(MemStruct):
 		s += f'\n	* underside_mat_2 = {fmt_member(self.underside_mat_2, indent+1)}'
 		s += f'\n	* stairs_mat_1 = {fmt_member(self.stairs_mat_1, indent+1)}'
 		s += f'\n	* stairs_mat_2 = {fmt_member(self.stairs_mat_2, indent+1)}'
-		s += f'\n	* num_data = {fmt_member(self.num_data, indent+1)}'
+		s += f'\n	* path_sub_type = {fmt_member(self.path_sub_type, indent+1)}'
 		s += f'\n	* mat_data = {fmt_member(self.mat_data, indent+1)}'
-		s += f'\n	* num_data_copy = {fmt_member(self.num_data_copy, indent+1)}'
+		s += f'\n	* num_data = {fmt_member(self.num_data, indent+1)}'
 		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
 		return s
 

--- a/generated/formats/path/compound/PathMaterialData.py
+++ b/generated/formats/path/compound/PathMaterialData.py
@@ -1,0 +1,84 @@
+from source.formats.base.basic import fmt_member
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+
+
+class PathMaterialData(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.unk_int_1 = 0
+		self.unk_float_1 = 0.0
+		self.unk_int_2 = 0
+		self.unk_int_3 = 0
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.unk_int_1 = 0
+		self.unk_float_1 = 0.0
+		self.unk_int_2 = 0
+		self.unk_int_3 = 0
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.unk_int_1 = stream.read_uint()
+		instance.unk_float_1 = stream.read_float()
+		instance.unk_int_2 = stream.read_uint()
+		instance.unk_int_3 = stream.read_uint()
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		stream.write_uint(instance.unk_int_1)
+		stream.write_float(instance.unk_float_1)
+		stream.write_uint(instance.unk_int_2)
+		stream.write_uint(instance.unk_int_3)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'PathMaterialData [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* unk_int_1 = {fmt_member(self.unk_int_1, indent+1)}'
+		s += f'\n	* unk_float_1 = {fmt_member(self.unk_float_1, indent+1)}'
+		s += f'\n	* unk_int_2 = {fmt_member(self.unk_int_2, indent+1)}'
+		s += f'\n	* unk_int_3 = {fmt_member(self.unk_int_3, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/PathResource.py
+++ b/generated/formats/path/compound/PathResource.py
@@ -17,7 +17,6 @@ class PathResource(MemStruct):
 		self.path_sub_type = 0
 		self.unk_byte_1 = 0
 		self.unk_byte_2 = 0
-		self.padding = 0
 		self.pathmaterial = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.pathextrusion_kerb = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.pathextrusion_railing = Pointer(self.context, 0, generated.formats.base.basic.ZString)
@@ -31,7 +30,6 @@ class PathResource(MemStruct):
 		self.path_sub_type = 0
 		self.unk_byte_1 = 0
 		self.unk_byte_2 = 0
-		self.padding = 0
 		self.pathmaterial = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.pathextrusion_kerb = Pointer(self.context, 0, generated.formats.base.basic.ZString)
 		self.pathextrusion_railing = Pointer(self.context, 0, generated.formats.base.basic.ZString)
@@ -60,7 +58,6 @@ class PathResource(MemStruct):
 		instance.path_sub_type = stream.read_byte()
 		instance.unk_byte_1 = stream.read_byte()
 		instance.unk_byte_2 = stream.read_byte()
-		instance.padding = stream.read_uint()
 		instance.pathmaterial.arg = 0
 		instance.pathextrusion_kerb.arg = 0
 		instance.pathextrusion_railing.arg = 0
@@ -79,7 +76,6 @@ class PathResource(MemStruct):
 		stream.write_byte(instance.path_sub_type)
 		stream.write_byte(instance.unk_byte_1)
 		stream.write_byte(instance.unk_byte_2)
-		stream.write_uint(instance.padding)
 
 	@classmethod
 	def from_stream(cls, stream, context, arg=0, template=None):
@@ -111,7 +107,6 @@ class PathResource(MemStruct):
 		s += f'\n	* path_sub_type = {fmt_member(self.path_sub_type, indent+1)}'
 		s += f'\n	* unk_byte_1 = {fmt_member(self.unk_byte_1, indent+1)}'
 		s += f'\n	* unk_byte_2 = {fmt_member(self.unk_byte_2, indent+1)}'
-		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
 		return s
 
 	def __repr__(self, indent=0):

--- a/generated/formats/path/compound/PathResource.py
+++ b/generated/formats/path/compound/PathResource.py
@@ -1,0 +1,121 @@
+from source.formats.base.basic import fmt_member
+import generated.formats.base.basic
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.ovl_base.compound.Pointer import Pointer
+
+
+class PathResource(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.path_type = 0
+		self.path_sub_type = 0
+		self.unk_byte_1 = 0
+		self.unk_byte_2 = 0
+		self.padding = 0
+		self.pathmaterial = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.pathextrusion_kerb = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.pathextrusion_railing = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.pathextrusion_ground = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.pathsupport = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.path_type = 0
+		self.path_sub_type = 0
+		self.unk_byte_1 = 0
+		self.unk_byte_2 = 0
+		self.padding = 0
+		self.pathmaterial = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.pathextrusion_kerb = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.pathextrusion_railing = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.pathextrusion_ground = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		self.pathsupport = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.pathmaterial = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.pathextrusion_kerb = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.pathextrusion_railing = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.pathextrusion_ground = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.pathsupport = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.path_type = stream.read_byte()
+		instance.path_sub_type = stream.read_byte()
+		instance.unk_byte_1 = stream.read_byte()
+		instance.unk_byte_2 = stream.read_byte()
+		instance.padding = stream.read_uint()
+		instance.pathmaterial.arg = 0
+		instance.pathextrusion_kerb.arg = 0
+		instance.pathextrusion_railing.arg = 0
+		instance.pathextrusion_ground.arg = 0
+		instance.pathsupport.arg = 0
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		Pointer.to_stream(stream, instance.pathmaterial)
+		Pointer.to_stream(stream, instance.pathextrusion_kerb)
+		Pointer.to_stream(stream, instance.pathextrusion_railing)
+		Pointer.to_stream(stream, instance.pathextrusion_ground)
+		Pointer.to_stream(stream, instance.pathsupport)
+		stream.write_byte(instance.path_type)
+		stream.write_byte(instance.path_sub_type)
+		stream.write_byte(instance.unk_byte_1)
+		stream.write_byte(instance.unk_byte_2)
+		stream.write_uint(instance.padding)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'PathResource [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* pathmaterial = {fmt_member(self.pathmaterial, indent+1)}'
+		s += f'\n	* pathextrusion_kerb = {fmt_member(self.pathextrusion_kerb, indent+1)}'
+		s += f'\n	* pathextrusion_railing = {fmt_member(self.pathextrusion_railing, indent+1)}'
+		s += f'\n	* pathextrusion_ground = {fmt_member(self.pathextrusion_ground, indent+1)}'
+		s += f'\n	* pathsupport = {fmt_member(self.pathsupport, indent+1)}'
+		s += f'\n	* path_type = {fmt_member(self.path_type, indent+1)}'
+		s += f'\n	* path_sub_type = {fmt_member(self.path_sub_type, indent+1)}'
+		s += f'\n	* unk_byte_1 = {fmt_member(self.unk_byte_1, indent+1)}'
+		s += f'\n	* unk_byte_2 = {fmt_member(self.unk_byte_2, indent+1)}'
+		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/PathSupport.py
+++ b/generated/formats/path/compound/PathSupport.py
@@ -1,0 +1,82 @@
+from source.formats.base.basic import fmt_member
+import generated.formats.base.basic
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.ovl_base.compound.Pointer import Pointer
+
+
+class PathSupport(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.unk_float_1 = 0.0
+		self.unk_int_1 = 0
+		self.support = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.unk_float_1 = 0.0
+		self.unk_int_1 = 0
+		self.support = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.support = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.unk_float_1 = stream.read_float()
+		instance.unk_int_1 = stream.read_uint()
+		instance.support.arg = 0
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		Pointer.to_stream(stream, instance.support)
+		stream.write_float(instance.unk_float_1)
+		stream.write_uint(instance.unk_int_1)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'PathSupport [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* support = {fmt_member(self.support, indent+1)}'
+		s += f'\n	* unk_float_1 = {fmt_member(self.unk_float_1, indent+1)}'
+		s += f'\n	* unk_int_1 = {fmt_member(self.unk_int_1, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/PathType.py
+++ b/generated/formats/path/compound/PathType.py
@@ -1,0 +1,84 @@
+from source.formats.base.basic import fmt_member
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+
+
+class PathType(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.enum_value = 0
+		self.unk_float_1 = 0.0
+		self.unk_float_2 = 0.0
+		self.unk_int_2 = 0
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.enum_value = 0
+		self.unk_float_1 = 0.0
+		self.unk_float_2 = 0.0
+		self.unk_int_2 = 0
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.enum_value = stream.read_uint()
+		instance.unk_float_1 = stream.read_float()
+		instance.unk_float_2 = stream.read_float()
+		instance.unk_int_2 = stream.read_uint()
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		stream.write_uint(instance.enum_value)
+		stream.write_float(instance.unk_float_1)
+		stream.write_float(instance.unk_float_2)
+		stream.write_uint(instance.unk_int_2)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'PathType [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* enum_value = {fmt_member(self.enum_value, indent+1)}'
+		s += f'\n	* unk_float_1 = {fmt_member(self.unk_float_1, indent+1)}'
+		s += f'\n	* unk_float_2 = {fmt_member(self.unk_float_2, indent+1)}'
+		s += f'\n	* unk_int_2 = {fmt_member(self.unk_int_2, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/Pillar.py
+++ b/generated/formats/path/compound/Pillar.py
@@ -1,0 +1,67 @@
+from source.formats.base.basic import fmt_member
+from generated.formats.path.compound.SupportAttachExtra import SupportAttachExtra
+
+
+class Pillar(SupportAttachExtra):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		pass
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		pass
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		pass
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'Pillar [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/PointsList.py
+++ b/generated/formats/path/compound/PointsList.py
@@ -1,5 +1,4 @@
 from source.formats.base.basic import fmt_member
-import numpy
 from generated.array import Array
 from generated.formats.ovl_base.compound.MemStruct import MemStruct
 from generated.formats.path.compound.Vector3 import Vector3
@@ -15,13 +14,11 @@ class PointsList(MemStruct):
 		self.io_size = 0
 		self.io_start = 0
 		self.points = Array((self.arg,), Vector3, self.context, 0, None)
-		self.padding = numpy.zeros(((self.arg % 4) * 4,), dtype=numpy.dtype('int8'))
 		if set_default:
 			self.set_defaults()
 
 	def set_defaults(self):
 		self.points = Array((self.arg,), Vector3, self.context, 0, None)
-		self.padding = numpy.zeros(((self.arg % 4) * 4,), dtype=numpy.dtype('int8'))
 
 	def read(self, stream):
 		self.io_start = stream.tell()
@@ -37,13 +34,11 @@ class PointsList(MemStruct):
 	def read_fields(cls, stream, instance):
 		super().read_fields(stream, instance)
 		instance.points = Array.from_stream(stream, (instance.arg,), Vector3, instance.context, 0, None)
-		instance.padding = stream.read_bytes(((instance.arg % 4) * 4,))
 
 	@classmethod
 	def write_fields(cls, stream, instance):
 		super().write_fields(stream, instance)
 		Array.to_stream(stream, instance.points, (instance.arg,), Vector3, instance.context, 0, None)
-		stream.write_bytes(instance.padding)
 
 	@classmethod
 	def from_stream(cls, stream, context, arg=0, template=None):
@@ -67,7 +62,6 @@ class PointsList(MemStruct):
 		s = ''
 		s += super().get_fields_str()
 		s += f'\n	* points = {fmt_member(self.points, indent+1)}'
-		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
 		return s
 
 	def __repr__(self, indent=0):

--- a/generated/formats/path/compound/PointsList.py
+++ b/generated/formats/path/compound/PointsList.py
@@ -1,0 +1,77 @@
+from source.formats.base.basic import fmt_member
+import numpy
+from generated.array import Array
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.path.compound.Vector3 import Vector3
+
+
+class PointsList(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.points = Array((self.arg,), Vector3, self.context, 0, None)
+		self.padding = numpy.zeros(((self.arg % 4) * 4,), dtype=numpy.dtype('int8'))
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.points = Array((self.arg,), Vector3, self.context, 0, None)
+		self.padding = numpy.zeros(((self.arg % 4) * 4,), dtype=numpy.dtype('int8'))
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.points = Array.from_stream(stream, (instance.arg,), Vector3, instance.context, 0, None)
+		instance.padding = stream.read_bytes(((instance.arg % 4) * 4,))
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		Array.to_stream(stream, instance.points, (instance.arg,), Vector3, instance.context, 0, None)
+		stream.write_bytes(instance.padding)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'PointsList [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* points = {fmt_member(self.points, indent+1)}'
+		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/SupportAttach.py
+++ b/generated/formats/path/compound/SupportAttach.py
@@ -1,0 +1,88 @@
+from source.formats.base.basic import fmt_member
+import generated.formats.base.basic
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.ovl_base.compound.Pointer import Pointer
+from generated.formats.path.compound.Vector2 import Vector2
+
+
+class SupportAttach(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.unk_int_1 = 0
+		self.unk_int_2 = 0
+		self.unk_vector = Vector2(self.context, 0, None)
+		self.model_name = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.unk_int_1 = 0
+		self.unk_int_2 = 0
+		self.unk_vector = Vector2(self.context, 0, None)
+		self.model_name = Pointer(self.context, 0, generated.formats.base.basic.ZString)
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.model_name = Pointer.from_stream(stream, instance.context, 0, generated.formats.base.basic.ZString)
+		instance.unk_int_1 = stream.read_uint64()
+		instance.unk_int_2 = stream.read_uint64()
+		instance.unk_vector = Vector2.from_stream(stream, instance.context, 0, None)
+		instance.model_name.arg = 0
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		Pointer.to_stream(stream, instance.model_name)
+		stream.write_uint64(instance.unk_int_1)
+		stream.write_uint64(instance.unk_int_2)
+		Vector2.to_stream(stream, instance.unk_vector)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'SupportAttach [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* model_name = {fmt_member(self.model_name, indent+1)}'
+		s += f'\n	* unk_int_1 = {fmt_member(self.unk_int_1, indent+1)}'
+		s += f'\n	* unk_int_2 = {fmt_member(self.unk_int_2, indent+1)}'
+		s += f'\n	* unk_vector = {fmt_member(self.unk_vector, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/SupportAttachExtra.py
+++ b/generated/formats/path/compound/SupportAttachExtra.py
@@ -1,0 +1,79 @@
+from source.formats.base.basic import fmt_member
+from generated.formats.path.compound.SupportAttach import SupportAttach
+
+
+class SupportAttachExtra(SupportAttach):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.unk_float_1 = 0.0
+		self.unk_int_3 = 0
+		self.padding = 0
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.unk_float_1 = 0.0
+		self.unk_int_3 = 0
+		self.padding = 0
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.unk_float_1 = stream.read_float()
+		instance.unk_int_3 = stream.read_uint()
+		instance.padding = stream.read_uint64()
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		stream.write_float(instance.unk_float_1)
+		stream.write_uint(instance.unk_int_3)
+		stream.write_uint64(instance.padding)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'SupportAttachExtra [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* unk_float_1 = {fmt_member(self.unk_float_1, indent+1)}'
+		s += f'\n	* unk_int_3 = {fmt_member(self.unk_int_3, indent+1)}'
+		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/SupportSetData.py
+++ b/generated/formats/path/compound/SupportSetData.py
@@ -1,0 +1,84 @@
+from source.formats.base.basic import fmt_member
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+
+
+class SupportSetData(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.unk_index = 0
+		self.unk_int_1 = 0
+		self.unk_int_2 = 0
+		self.unk_float_1 = 0.0
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.unk_index = 0
+		self.unk_int_1 = 0
+		self.unk_int_2 = 0
+		self.unk_float_1 = 0.0
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.unk_index = stream.read_uint()
+		instance.unk_int_1 = stream.read_uint()
+		instance.unk_int_2 = stream.read_uint()
+		instance.unk_float_1 = stream.read_float()
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		stream.write_uint(instance.unk_index)
+		stream.write_uint(instance.unk_int_1)
+		stream.write_uint(instance.unk_int_2)
+		stream.write_float(instance.unk_float_1)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'SupportSetData [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* unk_index = {fmt_member(self.unk_index, indent+1)}'
+		s += f'\n	* unk_int_1 = {fmt_member(self.unk_int_1, indent+1)}'
+		s += f'\n	* unk_int_2 = {fmt_member(self.unk_int_2, indent+1)}'
+		s += f'\n	* unk_float_1 = {fmt_member(self.unk_float_1, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/SupportSetRoot.py
+++ b/generated/formats/path/compound/SupportSetRoot.py
@@ -25,13 +25,14 @@ class SupportSetRoot(MemStruct):
 		self.unk_vector_1 = Vector3(self.context, 0, None)
 		self.unk_vector_2 = Vector2(self.context, 0, None)
 		self.unk_vector_3 = Vector3(self.context, 0, None)
-		self.num_unk_1 = 0
+		self.unk_int_1 = 0
 		self.num_connector_1 = 0
-		self.unk_ints = numpy.zeros((8,), dtype=numpy.dtype('uint32'))
+		self.num_connector_2 = 0
+		self.unk_ints = numpy.zeros((7,), dtype=numpy.dtype('uint32'))
 		self.padding_2 = 0
 		self.num_data = 0
 		self.connector_1 = ArrayPointer(self.context, self.num_connector_1, generated.formats.path.compound.Connector.Connector)
-		self.connector_2 = Pointer(self.context, 0, generated.formats.path.compound.ConnectorMultiJoint.ConnectorMultiJoint)
+		self.connector_2 = ArrayPointer(self.context, self.num_connector_2, generated.formats.path.compound.ConnectorMultiJoint.ConnectorMultiJoint)
 		self.pillar = Pointer(self.context, 0, generated.formats.path.compound.Pillar.Pillar)
 		self.footer = Pointer(self.context, 0, generated.formats.path.compound.Footer.Footer)
 		self.data = ArrayPointer(self.context, self.num_data, generated.formats.path.compound.SupportSetData.SupportSetData)
@@ -43,13 +44,14 @@ class SupportSetRoot(MemStruct):
 		self.unk_vector_1 = Vector3(self.context, 0, None)
 		self.unk_vector_2 = Vector2(self.context, 0, None)
 		self.unk_vector_3 = Vector3(self.context, 0, None)
-		self.num_unk_1 = 0
+		self.unk_int_1 = 0
 		self.num_connector_1 = 0
-		self.unk_ints = numpy.zeros((8,), dtype=numpy.dtype('uint32'))
+		self.num_connector_2 = 0
+		self.unk_ints = numpy.zeros((7,), dtype=numpy.dtype('uint32'))
 		self.padding_2 = 0
 		self.num_data = 0
 		self.connector_1 = ArrayPointer(self.context, self.num_connector_1, generated.formats.path.compound.Connector.Connector)
-		self.connector_2 = Pointer(self.context, 0, generated.formats.path.compound.ConnectorMultiJoint.ConnectorMultiJoint)
+		self.connector_2 = ArrayPointer(self.context, self.num_connector_2, generated.formats.path.compound.ConnectorMultiJoint.ConnectorMultiJoint)
 		self.pillar = Pointer(self.context, 0, generated.formats.path.compound.Pillar.Pillar)
 		self.footer = Pointer(self.context, 0, generated.formats.path.compound.Footer.Footer)
 		self.data = ArrayPointer(self.context, self.num_data, generated.formats.path.compound.SupportSetData.SupportSetData)
@@ -68,21 +70,22 @@ class SupportSetRoot(MemStruct):
 	def read_fields(cls, stream, instance):
 		super().read_fields(stream, instance)
 		instance.connector_1 = ArrayPointer.from_stream(stream, instance.context, instance.num_connector_1, generated.formats.path.compound.Connector.Connector)
-		instance.connector_2 = Pointer.from_stream(stream, instance.context, 0, generated.formats.path.compound.ConnectorMultiJoint.ConnectorMultiJoint)
+		instance.connector_2 = ArrayPointer.from_stream(stream, instance.context, instance.num_connector_2, generated.formats.path.compound.ConnectorMultiJoint.ConnectorMultiJoint)
 		instance.pillar = Pointer.from_stream(stream, instance.context, 0, generated.formats.path.compound.Pillar.Pillar)
 		instance.footer = Pointer.from_stream(stream, instance.context, 0, generated.formats.path.compound.Footer.Footer)
 		instance.padding = stream.read_uint64()
 		instance.unk_vector_1 = Vector3.from_stream(stream, instance.context, 0, None)
 		instance.unk_vector_2 = Vector2.from_stream(stream, instance.context, 0, None)
 		instance.unk_vector_3 = Vector3.from_stream(stream, instance.context, 0, None)
-		instance.num_unk_1 = stream.read_uint()
+		instance.unk_int_1 = stream.read_uint()
 		instance.num_connector_1 = stream.read_uint()
-		instance.unk_ints = stream.read_uints((8,))
+		instance.num_connector_2 = stream.read_uint()
+		instance.unk_ints = stream.read_uints((7,))
 		instance.padding_2 = stream.read_uint64()
 		instance.data = ArrayPointer.from_stream(stream, instance.context, instance.num_data, generated.formats.path.compound.SupportSetData.SupportSetData)
 		instance.num_data = stream.read_uint()
 		instance.connector_1.arg = instance.num_connector_1
-		instance.connector_2.arg = 0
+		instance.connector_2.arg = instance.num_connector_2
 		instance.pillar.arg = 0
 		instance.footer.arg = 0
 		instance.data.arg = instance.num_data
@@ -91,15 +94,16 @@ class SupportSetRoot(MemStruct):
 	def write_fields(cls, stream, instance):
 		super().write_fields(stream, instance)
 		ArrayPointer.to_stream(stream, instance.connector_1)
-		Pointer.to_stream(stream, instance.connector_2)
+		ArrayPointer.to_stream(stream, instance.connector_2)
 		Pointer.to_stream(stream, instance.pillar)
 		Pointer.to_stream(stream, instance.footer)
 		stream.write_uint64(instance.padding)
 		Vector3.to_stream(stream, instance.unk_vector_1)
 		Vector2.to_stream(stream, instance.unk_vector_2)
 		Vector3.to_stream(stream, instance.unk_vector_3)
-		stream.write_uint(instance.num_unk_1)
+		stream.write_uint(instance.unk_int_1)
 		stream.write_uint(instance.num_connector_1)
+		stream.write_uint(instance.num_connector_2)
 		stream.write_uints(instance.unk_ints)
 		stream.write_uint64(instance.padding_2)
 		ArrayPointer.to_stream(stream, instance.data)
@@ -134,8 +138,9 @@ class SupportSetRoot(MemStruct):
 		s += f'\n	* unk_vector_1 = {fmt_member(self.unk_vector_1, indent+1)}'
 		s += f'\n	* unk_vector_2 = {fmt_member(self.unk_vector_2, indent+1)}'
 		s += f'\n	* unk_vector_3 = {fmt_member(self.unk_vector_3, indent+1)}'
-		s += f'\n	* num_unk_1 = {fmt_member(self.num_unk_1, indent+1)}'
+		s += f'\n	* unk_int_1 = {fmt_member(self.unk_int_1, indent+1)}'
 		s += f'\n	* num_connector_1 = {fmt_member(self.num_connector_1, indent+1)}'
+		s += f'\n	* num_connector_2 = {fmt_member(self.num_connector_2, indent+1)}'
 		s += f'\n	* unk_ints = {fmt_member(self.unk_ints, indent+1)}'
 		s += f'\n	* padding_2 = {fmt_member(self.padding_2, indent+1)}'
 		s += f'\n	* data = {fmt_member(self.data, indent+1)}'

--- a/generated/formats/path/compound/SupportSetRoot.py
+++ b/generated/formats/path/compound/SupportSetRoot.py
@@ -1,0 +1,149 @@
+from source.formats.base.basic import fmt_member
+import generated.formats.path.compound.Connector
+import generated.formats.path.compound.ConnectorMultiJoint
+import generated.formats.path.compound.Footer
+import generated.formats.path.compound.Pillar
+import generated.formats.path.compound.SupportSetData
+import numpy
+from generated.formats.ovl_base.compound.ArrayPointer import ArrayPointer
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+from generated.formats.ovl_base.compound.Pointer import Pointer
+from generated.formats.path.compound.Vector2 import Vector2
+from generated.formats.path.compound.Vector3 import Vector3
+
+
+class SupportSetRoot(MemStruct):
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+		self.padding = 0
+		self.unk_vector_1 = Vector3(self.context, 0, None)
+		self.unk_vector_2 = Vector2(self.context, 0, None)
+		self.unk_vector_3 = Vector3(self.context, 0, None)
+		self.num_unk_1 = 0
+		self.num_connector_1 = 0
+		self.unk_ints = numpy.zeros((8,), dtype=numpy.dtype('uint32'))
+		self.padding_2 = 0
+		self.num_data = 0
+		self.connector_1 = ArrayPointer(self.context, self.num_connector_1, generated.formats.path.compound.Connector.Connector)
+		self.connector_2 = Pointer(self.context, 0, generated.formats.path.compound.ConnectorMultiJoint.ConnectorMultiJoint)
+		self.pillar = Pointer(self.context, 0, generated.formats.path.compound.Pillar.Pillar)
+		self.footer = Pointer(self.context, 0, generated.formats.path.compound.Footer.Footer)
+		self.data = ArrayPointer(self.context, self.num_data, generated.formats.path.compound.SupportSetData.SupportSetData)
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.padding = 0
+		self.unk_vector_1 = Vector3(self.context, 0, None)
+		self.unk_vector_2 = Vector2(self.context, 0, None)
+		self.unk_vector_3 = Vector3(self.context, 0, None)
+		self.num_unk_1 = 0
+		self.num_connector_1 = 0
+		self.unk_ints = numpy.zeros((8,), dtype=numpy.dtype('uint32'))
+		self.padding_2 = 0
+		self.num_data = 0
+		self.connector_1 = ArrayPointer(self.context, self.num_connector_1, generated.formats.path.compound.Connector.Connector)
+		self.connector_2 = Pointer(self.context, 0, generated.formats.path.compound.ConnectorMultiJoint.ConnectorMultiJoint)
+		self.pillar = Pointer(self.context, 0, generated.formats.path.compound.Pillar.Pillar)
+		self.footer = Pointer(self.context, 0, generated.formats.path.compound.Footer.Footer)
+		self.data = ArrayPointer(self.context, self.num_data, generated.formats.path.compound.SupportSetData.SupportSetData)
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.connector_1 = ArrayPointer.from_stream(stream, instance.context, instance.num_connector_1, generated.formats.path.compound.Connector.Connector)
+		instance.connector_2 = Pointer.from_stream(stream, instance.context, 0, generated.formats.path.compound.ConnectorMultiJoint.ConnectorMultiJoint)
+		instance.pillar = Pointer.from_stream(stream, instance.context, 0, generated.formats.path.compound.Pillar.Pillar)
+		instance.footer = Pointer.from_stream(stream, instance.context, 0, generated.formats.path.compound.Footer.Footer)
+		instance.padding = stream.read_uint64()
+		instance.unk_vector_1 = Vector3.from_stream(stream, instance.context, 0, None)
+		instance.unk_vector_2 = Vector2.from_stream(stream, instance.context, 0, None)
+		instance.unk_vector_3 = Vector3.from_stream(stream, instance.context, 0, None)
+		instance.num_unk_1 = stream.read_uint()
+		instance.num_connector_1 = stream.read_uint()
+		instance.unk_ints = stream.read_uints((8,))
+		instance.padding_2 = stream.read_uint64()
+		instance.data = ArrayPointer.from_stream(stream, instance.context, instance.num_data, generated.formats.path.compound.SupportSetData.SupportSetData)
+		instance.num_data = stream.read_uint()
+		instance.connector_1.arg = instance.num_connector_1
+		instance.connector_2.arg = 0
+		instance.pillar.arg = 0
+		instance.footer.arg = 0
+		instance.data.arg = instance.num_data
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		ArrayPointer.to_stream(stream, instance.connector_1)
+		Pointer.to_stream(stream, instance.connector_2)
+		Pointer.to_stream(stream, instance.pillar)
+		Pointer.to_stream(stream, instance.footer)
+		stream.write_uint64(instance.padding)
+		Vector3.to_stream(stream, instance.unk_vector_1)
+		Vector2.to_stream(stream, instance.unk_vector_2)
+		Vector3.to_stream(stream, instance.unk_vector_3)
+		stream.write_uint(instance.num_unk_1)
+		stream.write_uint(instance.num_connector_1)
+		stream.write_uints(instance.unk_ints)
+		stream.write_uint64(instance.padding_2)
+		ArrayPointer.to_stream(stream, instance.data)
+		stream.write_uint(instance.num_data)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'SupportSetRoot [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* connector_1 = {fmt_member(self.connector_1, indent+1)}'
+		s += f'\n	* connector_2 = {fmt_member(self.connector_2, indent+1)}'
+		s += f'\n	* pillar = {fmt_member(self.pillar, indent+1)}'
+		s += f'\n	* footer = {fmt_member(self.footer, indent+1)}'
+		s += f'\n	* padding = {fmt_member(self.padding, indent+1)}'
+		s += f'\n	* unk_vector_1 = {fmt_member(self.unk_vector_1, indent+1)}'
+		s += f'\n	* unk_vector_2 = {fmt_member(self.unk_vector_2, indent+1)}'
+		s += f'\n	* unk_vector_3 = {fmt_member(self.unk_vector_3, indent+1)}'
+		s += f'\n	* num_unk_1 = {fmt_member(self.num_unk_1, indent+1)}'
+		s += f'\n	* num_connector_1 = {fmt_member(self.num_connector_1, indent+1)}'
+		s += f'\n	* unk_ints = {fmt_member(self.unk_ints, indent+1)}'
+		s += f'\n	* padding_2 = {fmt_member(self.padding_2, indent+1)}'
+		s += f'\n	* data = {fmt_member(self.data, indent+1)}'
+		s += f'\n	* num_data = {fmt_member(self.num_data, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/Vector2.py
+++ b/generated/formats/path/compound/Vector2.py
@@ -1,0 +1,82 @@
+from source.formats.base.basic import fmt_member
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+
+
+class Vector2(MemStruct):
+
+	"""
+	A vector in 2D space (x,y).
+	"""
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+
+		# First coordinate.
+		self.x = 0.0
+
+		# Second coordinate.
+		self.y = 0.0
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.x = 0.0
+		self.y = 0.0
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.x = stream.read_float()
+		instance.y = stream.read_float()
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		stream.write_float(instance.x)
+		stream.write_float(instance.y)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'Vector2 [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* x = {fmt_member(self.x, indent+1)}'
+		s += f'\n	* y = {fmt_member(self.y, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/Vector3.py
+++ b/generated/formats/path/compound/Vector3.py
@@ -1,0 +1,89 @@
+from source.formats.base.basic import fmt_member
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+
+
+class Vector3(MemStruct):
+
+	"""
+	A vector in 3D space (x,y,z).
+	"""
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+
+		# First coordinate.
+		self.x = 0.0
+
+		# Second coordinate.
+		self.y = 0.0
+
+		# Third coordinate.
+		self.z = 0.0
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.x = 0.0
+		self.y = 0.0
+		self.z = 0.0
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.x = stream.read_float()
+		instance.y = stream.read_float()
+		instance.z = stream.read_float()
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		stream.write_float(instance.x)
+		stream.write_float(instance.y)
+		stream.write_float(instance.z)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'Vector3 [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* x = {fmt_member(self.x, indent+1)}'
+		s += f'\n	* y = {fmt_member(self.y, indent+1)}'
+		s += f'\n	* z = {fmt_member(self.z, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/compound/Vector4.py
+++ b/generated/formats/path/compound/Vector4.py
@@ -1,0 +1,96 @@
+from source.formats.base.basic import fmt_member
+from generated.formats.ovl_base.compound.MemStruct import MemStruct
+
+
+class Vector4(MemStruct):
+
+	"""
+	A vector in 3D space (x,y,z).
+	"""
+
+	def __init__(self, context, arg=0, template=None, set_default=True):
+		self.name = ''
+		super().__init__(context, arg, template, set_default)
+		self.arg = arg
+		self.template = template
+		self.io_size = 0
+		self.io_start = 0
+
+		# First coordinate.
+		self.x = 0.0
+
+		# Second coordinate.
+		self.y = 0.0
+
+		# Third coordinate.
+		self.z = 0.0
+
+		# Fourth coordinate.
+		self.w = 0.0
+		if set_default:
+			self.set_defaults()
+
+	def set_defaults(self):
+		self.x = 0.0
+		self.y = 0.0
+		self.z = 0.0
+		self.w = 0.0
+
+	def read(self, stream):
+		self.io_start = stream.tell()
+		self.read_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	def write(self, stream):
+		self.io_start = stream.tell()
+		self.write_fields(stream, self)
+		self.io_size = stream.tell() - self.io_start
+
+	@classmethod
+	def read_fields(cls, stream, instance):
+		super().read_fields(stream, instance)
+		instance.x = stream.read_float()
+		instance.y = stream.read_float()
+		instance.z = stream.read_float()
+		instance.w = stream.read_float()
+
+	@classmethod
+	def write_fields(cls, stream, instance):
+		super().write_fields(stream, instance)
+		stream.write_float(instance.x)
+		stream.write_float(instance.y)
+		stream.write_float(instance.z)
+		stream.write_float(instance.w)
+
+	@classmethod
+	def from_stream(cls, stream, context, arg=0, template=None):
+		instance = cls(context, arg, template, set_default=False)
+		instance.io_start = stream.tell()
+		cls.read_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	@classmethod
+	def to_stream(cls, stream, instance):
+		instance.io_start = stream.tell()
+		cls.write_fields(stream, instance)
+		instance.io_size = stream.tell() - instance.io_start
+		return instance
+
+	def get_info_str(self, indent=0):
+		return f'Vector4 [Size: {self.io_size}, Address: {self.io_start}] {self.name}'
+
+	def get_fields_str(self, indent=0):
+		s = ''
+		s += super().get_fields_str()
+		s += f'\n	* x = {fmt_member(self.x, indent+1)}'
+		s += f'\n	* y = {fmt_member(self.y, indent+1)}'
+		s += f'\n	* z = {fmt_member(self.z, indent+1)}'
+		s += f'\n	* w = {fmt_member(self.w, indent+1)}'
+		return s
+
+	def __repr__(self, indent=0):
+		s = self.get_info_str(indent)
+		s += self.get_fields_str(indent)
+		s += '\n'
+		return s

--- a/generated/formats/path/path.xml
+++ b/generated/formats/path/path.xml
@@ -4,6 +4,12 @@
 
     <xi:include href="../ovl_base/ovl_base.xml" xmlns:xi="http://www.w3.org/2001/XInclude" xpointer="xpointer(*/*)" />
 
+    <compound name="Vector2" size="8" inherit="MemStruct">
+        A vector in 2D space (x,y).
+        <field name="x" type="float">First coordinate.</field>
+        <field name="y" type="float">Second coordinate.</field>
+    </compound>
+
     <compound name="Vector3" size="12" inherit="MemStruct">
         A vector in 3D space (x,y,z).
         <field name="x" type="float">First coordinate.</field>
@@ -122,6 +128,77 @@
         <add name="unkFloat1" type="float" />
         <add name="unkFloat2" type="float" />
         <add name="unkInt2" type="uint" />
+    </compound>
+
+    <compound name="SupportSetRoot" inherit="MemStruct">
+        <!-- Size 144 -->
+        <add name="connector_1" type="ArrayPointer" template="Connector" arg="num_connector_1" />
+        <add name="connector_2" type="Pointer" template="ConnectorMultiJoint" />
+        <add name="pillar" type="Pointer" template="Pillar" />
+        <add name="footer" type="Pointer" template="Footer" />
+        <add name="padding" type="uint64" />
+        <add name="unkVector1" type="Vector3" />
+        <add name="unkVector2" type="Vector2" />
+        <add name="unkVector3" type="Vector3" />
+        <add name="numUnk1" type="uint" />
+        <add name="num_connector_1" type="uint" />
+        <add name="unkInts" type="uint" arr1="8" />
+        <add name="padding_2" type="uint64" />
+        <add name="data" type="ArrayPointer" template="SupportSetData" arg="num_data" />
+        <add name="num_data" type="uint" />
+    </compound>
+
+    <compound name="Connector" inherit="MemStruct">
+        <!-- Size 24 -->
+        <add name="model_name" type="Pointer" template="ZString"/>
+        <add name="joint_name" type="Pointer" template="ZString"/>
+        <add name="unkVector" type="Vector2" />
+    </compound>
+
+    <compound name="ConnectorMultiJoint" inherit="MemStruct">
+        <!-- Size 48 -->
+        <add name="model_name" type="Pointer" template="ZString"/>
+        <add name="padding" type="uint64" />
+        <add name="joints" type="ArrayPointer" template="Joint" arg="num_joints" />
+        <add name="num_joints" type="uint64" />
+        <add name="unkFloat1" type="float" />
+        <add name="unkInt1" type="uint" />
+        <add name="padding" type="uint64" />
+    </compound>
+
+    <compound name="SupportAttach" inherit="MemStruct">
+        <!-- Size 32 -->
+        <add name="model_name" type="Pointer" template="ZString"/>
+        <add name="unkInt1" type="uint64" />
+        <add name="unkInt2" type="uint64" />
+        <add name="unkVector" type="Vector2" />
+    </compound>
+
+    <compound name="SupportAttachExtra" inherit="SupportAttach">
+        <!-- Size 16 -->
+        <add name="unkFloat1" type="float" />
+        <add name="unkInt3" type="uint" />
+        <add name="padding" type="uint64" />
+    </compound>
+
+    <compound name="Joint" inherit="SupportAttachExtra">
+        <!-- Size 48 -->
+    </compound>
+
+    <compound name="Pillar" inherit="SupportAttachExtra">
+        <!-- Size 48 -->
+    </compound>
+
+    <compound name="Footer" inherit="SupportAttach">
+        <!-- Size 32 -->
+    </compound>
+
+    <compound name="SupportSetData" inherit="MemStruct">
+        <!-- Size 16 -->
+        <add name="unkIndex" type="uint" />
+        <add name="unkInt1" type="uint" />
+        <add name="unkInt2" type="uint" />
+        <add name="unkFloat1" type="float" />
     </compound>
 
 </niftoolsxml>

--- a/generated/formats/path/path.xml
+++ b/generated/formats/path/path.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE niftoolsxml>
+<niftoolsxml version="0.7.1.0">
+
+    <xi:include href="../ovl_base/ovl_base.xml" xmlns:xi="http://www.w3.org/2001/XInclude" xpointer="xpointer(*/*)" />
+
+    <compound name="Vector3" size="12" inherit="MemStruct">
+        A vector in 3D space (x,y,z).
+        <field name="x" type="float">First coordinate.</field>
+        <field name="y" type="float">Second coordinate.</field>
+        <field name="z" type="float">Third coordinate.</field>
+    </compound>
+
+    <compound name="Vector4" size="16" inherit="MemStruct">
+        A vector in 3D space (x,y,z).
+        <field name="x" type="float">First coordinate.</field>
+        <field name="y" type="float">Second coordinate.</field>
+        <field name="z" type="float">Third coordinate.</field>
+        <field name="w" type="float">Fourth coordinate.</field>
+    </compound>
+
+    <compound name="PathExtrusion" inherit="MemStruct">
+        <!-- Size 48 -->
+        <add name="model" type="Pointer" template="ZString"/>
+        <add name="post_model" type="Pointer" template="ZString"/>
+        <add name="endcap_model" type="Pointer" template="ZString"/>
+        <add name="unkFloat1" type="float" />
+        <add name="unkFloat2" type="float" />
+        <add name="is_kerb" type="bool" />
+        <add name="unkBool" type="bool" /> <!-- Only False values are natural ground paths _ground.pathextrusion -->
+        <add name="padding" type="byte" arr1="14" />
+    </compound>
+
+    <compound name="PathMaterial" inherit="MemStruct">
+        <!-- Size 112 -->
+        <add name="elevated_mat" type="Pointer" template="ZString"/>
+        <add name="elevated_mat_valid" type="Pointer" template="ZString"/>
+        <add name="elevated_mat_invalid" type="Pointer" template="ZString"/>
+        <add name="terrain_mat" type="Pointer" template="ZString"/>
+        <add name="terrain_mat_valid" type="Pointer" template="ZString"/>
+        <add name="terrain_mat_invalid" type="Pointer" template="ZString"/>
+        <add name="underside_mat_1" type="Pointer" template="ZString"/>
+        <add name="underside_mat_2" type="Pointer" template="ZString"/>
+        <add name="stairs_mat_1" type="Pointer" template="ZString"/>
+        <add name="stairs_mat_2" type="Pointer" template="ZString"/>
+        <add name="num_data" type="uint64" />
+        <add name="mat_data" type="ArrayPointer" template="PathMaterialData" arg="num_data" />
+        <add name="num_data_copy" type="uint64" />
+        <add name="padding" type="uint64" />
+    </compound>
+
+    <compound name="PathMaterialData" inherit="MemStruct">
+        <!-- Size 16 -->
+        <add name="unkInt1" type="uint" />
+        <add name="unkFloat1" type="float" />
+        <add name="unkInt2" type="uint" />
+        <add name="unkInt3" type="uint" />
+    </compound>
+
+    <compound name="PathResource" inherit="MemStruct">
+        <!-- Size 48 -->
+        <add name="pathmaterial" type="Pointer" template="ZString"/>
+        <add name="pathextrusion_kerb" type="Pointer" template="ZString"/>
+        <add name="pathextrusion_railing" type="Pointer" template="ZString"/>
+        <add name="pathextrusion_ground" type="Pointer" template="ZString"/>
+        <add name="pathsupport" type="Pointer" template="ZString"/>
+        <add name="path_type" type="byte" /> <!-- 0 for Guest, 1 for Queue, 2 for Staff -->
+        <add name="path_sub_type" type="byte" /> <!-- 0 = None, 1 = Natural, matches PathSubType column in c0paths.fdb -->
+        <add name="unkByte1" type="byte" /> <!-- Always 1 -->
+        <add name="unkByte2" type="byte" />
+        <add name="padding" type="uint" />
+    </compound>
+
+    <compound name="PathJoinPartResourceRoot" inherit="MemStruct">
+        <!-- Size 16 -->
+        <add name="resources_list" type="Pointer" template="PathJoinPartResourceList" arg="num_res" />
+        <add name="num_res" type="uint64" />
+    </compound>
+
+    <compound name="PathJoinPartResourceList" inherit="MemStruct">
+        <!-- Size 72 * #ARG# + 16-byte alignment padding -->
+        <add name="resources" type="PathJoinPartResource" arr1="#ARG#" />
+        <add name="padding" type="byte" arr1="(#ARG# % 2) * 8" />
+    </compound>
+
+    <compound name="PathJoinPartResource" inherit="MemStruct">
+        <!-- Size 72 -->
+        <add name="unkPoints1" type="Pointer" template="PointsList" arg="num_points_1" />
+        <add name="unkPoints2" type="Pointer" template="PointsList" arg="num_points_2" />
+        <add name="unkVector" type="ArrayPointer" template="Vector4" arg="1" />
+        <add name="unkShorts" type="ArrayPointer" template="ushort" arg="8" />
+        <add name="unkPoints3" type="Pointer" template="PointsList" arg="num_points_3" />
+        <add name="padding_1" type="uint64" />
+        <add name="pathresource" type="Pointer" template="ZString"/>
+        <add name="unkByte1" type="byte" />
+        <add name="unkByte2" type="byte" />
+        <add name="unkByte3" type="byte" />
+        <add name="num_points_1" type="byte" />
+        <add name="num_points_1_copy" type="byte" />
+        <add name="num_points_2" type="byte" />
+        <add name="num_points_2_copy" type="byte" />
+        <add name="num_points_3" type="byte" />
+        <add name="padding_2" type="uint64" />
+    </compound>
+
+    <compound name="PointsList" inherit="MemStruct">
+        <!-- Size 12 * #ARG# + 16-byte alignment padding -->
+        <add name="points" type="Vector3" arr1="#ARG#" />
+        <add name="padding" type="byte" arr1="(#ARG# % 4) * 4" />
+    </compound>
+
+    <compound name="PathSupport" inherit="MemStruct">
+        <!-- Size 16 -->
+        <add name="support" type="Pointer" template="ZString"/>
+        <add name="unkFloat1" type="float" />
+        <add name="unkInt1" type="uint" />
+    </compound>
+
+    <compound name="PathType" inherit="MemStruct">
+        <!-- Size 16 -->
+        <add name="enum_value" type="uint" /> <!-- Matches the EnumValue column in c0paths.fdb -->
+        <add name="unkFloat1" type="float" />
+        <add name="unkFloat2" type="float" />
+        <add name="unkInt2" type="uint" />
+    </compound>
+
+</niftoolsxml>

--- a/generated/formats/path/path.xml
+++ b/generated/formats/path/path.xml
@@ -48,9 +48,9 @@
         <add name="underside_mat_2" type="Pointer" template="ZString"/>
         <add name="stairs_mat_1" type="Pointer" template="ZString"/>
         <add name="stairs_mat_2" type="Pointer" template="ZString"/>
-        <add name="num_data" type="uint64" />
+        <add name="path_sub_type" type="uint64" /> <!-- 0 = None, 1 = Natural, matches PathSubType column in c0paths.fdb -->
         <add name="mat_data" type="ArrayPointer" template="PathMaterialData" arg="num_data" />
-        <add name="num_data_copy" type="uint64" />
+        <add name="num_data" type="uint64" />
         <add name="padding" type="uint64" />
     </compound>
 

--- a/generated/formats/path/path.xml
+++ b/generated/formats/path/path.xml
@@ -34,7 +34,6 @@
         <add name="unkFloat2" type="float" />
         <add name="is_kerb" type="bool" />
         <add name="unkBool" type="bool" /> <!-- Only False values are natural ground paths _ground.pathextrusion -->
-        <add name="padding" type="byte" arr1="14" />
     </compound>
 
     <compound name="PathMaterial" inherit="MemStruct">
@@ -86,7 +85,6 @@
     <compound name="PathJoinPartResourceList" inherit="MemStruct">
         <!-- Size 72 * #ARG# + 16-byte alignment padding -->
         <add name="resources" type="PathJoinPartResource" arr1="#ARG#" />
-        <add name="padding" type="byte" arr1="(#ARG# % 2) * 8" />
     </compound>
 
     <compound name="PathJoinPartResource" inherit="MemStruct">
@@ -112,7 +110,6 @@
     <compound name="PointsList" inherit="MemStruct">
         <!-- Size 12 * #ARG# + 16-byte alignment padding -->
         <add name="points" type="Vector3" arr1="#ARG#" />
-        <add name="padding" type="byte" arr1="(#ARG# % 4) * 4" />
     </compound>
 
     <compound name="PathSupport" inherit="MemStruct">

--- a/generated/formats/path/path.xml
+++ b/generated/formats/path/path.xml
@@ -33,7 +33,7 @@
         <add name="unkFloat1" type="float" />
         <add name="unkFloat2" type="float" />
         <add name="is_kerb" type="bool" />
-        <add name="unkBool" type="bool" /> <!-- Only False values are natural ground paths _ground.pathextrusion -->
+        <add name="is_not_ground" type="bool" /> <!-- Only False values are natural ground paths _ground.pathextrusion -->
     </compound>
 
     <compound name="PathMaterial" inherit="MemStruct">
@@ -128,16 +128,17 @@
     <compound name="SupportSetRoot" inherit="MemStruct">
         <!-- Size 144 -->
         <add name="connector_1" type="ArrayPointer" template="Connector" arg="num_connector_1" />
-        <add name="connector_2" type="Pointer" template="ConnectorMultiJoint" />
+        <add name="connector_2" type="ArrayPointer" template="ConnectorMultiJoint" arg="num_connector_2" />
         <add name="pillar" type="Pointer" template="Pillar" />
         <add name="footer" type="Pointer" template="Footer" />
         <add name="padding" type="uint64" />
         <add name="unkVector1" type="Vector3" />
         <add name="unkVector2" type="Vector2" />
         <add name="unkVector3" type="Vector3" />
-        <add name="numUnk1" type="uint" />
+        <add name="unkInt1" type="uint" />
         <add name="num_connector_1" type="uint" />
-        <add name="unkInts" type="uint" arr1="8" />
+        <add name="num_connector_2" type="uint" />
+        <add name="unkInts" type="uint" arr1="7" />
         <add name="padding_2" type="uint64" />
         <add name="data" type="ArrayPointer" template="SupportSetData" arg="num_data" />
         <add name="num_data" type="uint" />

--- a/generated/formats/path/path.xml
+++ b/generated/formats/path/path.xml
@@ -51,7 +51,6 @@
         <add name="path_sub_type" type="uint64" /> <!-- 0 = None, 1 = Natural, matches PathSubType column in c0paths.fdb -->
         <add name="mat_data" type="ArrayPointer" template="PathMaterialData" arg="num_data" />
         <add name="num_data" type="uint64" />
-        <add name="padding" type="uint64" />
     </compound>
 
     <compound name="PathMaterialData" inherit="MemStruct">
@@ -73,7 +72,6 @@
         <add name="path_sub_type" type="byte" /> <!-- 0 = None, 1 = Natural, matches PathSubType column in c0paths.fdb -->
         <add name="unkByte1" type="byte" /> <!-- Always 1 -->
         <add name="unkByte2" type="byte" />
-        <add name="padding" type="uint" />
     </compound>
 
     <compound name="PathJoinPartResourceRoot" inherit="MemStruct">
@@ -104,7 +102,7 @@
         <add name="num_points_2" type="byte" />
         <add name="num_points_2_copy" type="byte" />
         <add name="num_points_3" type="byte" />
-        <add name="padding_2" type="uint64" />
+        <add name="padding_2" type="uint64" /> <!-- Required as part of list -->
     </compound>
 
     <compound name="PointsList" inherit="MemStruct">
@@ -160,7 +158,7 @@
         <add name="num_joints" type="uint64" />
         <add name="unkFloat1" type="float" />
         <add name="unkInt1" type="uint" />
-        <add name="padding" type="uint64" />
+        <add name="padding" type="uint64" /> <!-- Unsure if padding, keep -->
     </compound>
 
     <compound name="SupportAttach" inherit="MemStruct">
@@ -175,7 +173,7 @@
         <!-- Size 16 -->
         <add name="unkFloat1" type="float" />
         <add name="unkInt3" type="uint" />
-        <add name="padding" type="uint64" />
+        <add name="padding" type="uint64" /> <!-- Unsure if padding, keep -->
     </compound>
 
     <compound name="Joint" inherit="SupportAttachExtra">

--- a/generated/formats/path/versions.py
+++ b/generated/formats/path/versions.py
@@ -1,0 +1,112 @@
+from enum import Enum
+
+
+def is_dla(context):
+	if context.version == 15:
+		return True
+
+
+def set_dla(context):
+	context.version = 15
+
+
+def is_ztuac(context):
+	if context.version == 17:
+		return True
+
+
+def set_ztuac(context):
+	context.version = 17
+
+
+def is_pc(context):
+	if context.version == 18 and context.user_version in (8340, 8724, 8212) and context.version_flag == 8:
+		return True
+
+
+def set_pc(context):
+	context.version = 18
+	context.user_version._value = 8340
+	context.version_flag = 8
+
+
+def is_pz(context):
+	if context.version == 19 and context.user_version in (8340, 8724, 8212):
+		return True
+
+
+def set_pz(context):
+	context.version = 19
+	context.user_version._value = 8340
+
+
+def is_pz16(context):
+	if context.version == 20 and context.user_version in (8340, 8724, 8212):
+		return True
+
+
+def set_pz16(context):
+	context.version = 20
+	context.user_version._value = 8340
+
+
+def is_jwe(context):
+	if context.version == 19 and context.user_version in (24724, 25108, 24596):
+		return True
+
+
+def set_jwe(context):
+	context.version = 19
+	context.user_version._value = 24724
+
+
+def is_jwe2(context):
+	if context.version == 20 and context.user_version in (24724, 25108, 24596):
+		return True
+
+
+def set_jwe2(context):
+	context.version = 20
+	context.user_version._value = 24724
+
+
+games = Enum('Games',[('DISNEYLAND_ADVENTURE', 'Disneyland Adventure'), ('JURASSIC_WORLD_EVOLUTION', 'Jurassic World Evolution'), ('JURASSIC_WORLD_EVOLUTION_2', 'Jurassic World Evolution 2'), ('PLANET_COASTER', 'Planet Coaster'), ('PLANET_ZOO', 'Planet Zoo'), ('PLANET_ZOO_PRE_1_6', 'Planet Zoo pre-1.6'), ('ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION', 'Zoo Tycoon Ultimate Animal Collection'), ('UNKNOWN_GAME', 'Unknown Game')])
+
+
+def get_game(context):
+	if is_dla(context):
+		return [games.DISNEYLAND_ADVENTURE]
+	if is_ztuac(context):
+		return [games.ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION]
+	if is_pc(context):
+		return [games.PLANET_COASTER]
+	if is_pz(context):
+		return [games.PLANET_ZOO_PRE_1_6]
+	if is_pz16(context):
+		return [games.PLANET_ZOO]
+	if is_jwe(context):
+		return [games.JURASSIC_WORLD_EVOLUTION]
+	if is_jwe2(context):
+		return [games.JURASSIC_WORLD_EVOLUTION_2]
+	return [games.UNKOWN_GAME]
+
+
+def set_game(context, game):
+	if isinstance(game, str):
+		game = games(game)
+	if game in {games.DISNEYLAND_ADVENTURE}:
+		return set_dla(context)
+	if game in {games.ZOO_TYCOON_ULTIMATE_ANIMAL_COLLECTION}:
+		return set_ztuac(context)
+	if game in {games.PLANET_COASTER}:
+		return set_pc(context)
+	if game in {games.PLANET_ZOO_PRE_1_6}:
+		return set_pz(context)
+	if game in {games.PLANET_ZOO}:
+		return set_pz16(context)
+	if game in {games.JURASSIC_WORLD_EVOLUTION}:
+		return set_jwe(context)
+	if game in {games.JURASSIC_WORLD_EVOLUTION_2}:
+		return set_jwe2(context)
+
+

--- a/modules/formats/PATH.py
+++ b/modules/formats/PATH.py
@@ -3,6 +3,7 @@ from generated.formats.path.compound.PathMaterial import PathMaterial
 from generated.formats.path.compound.PathResource import PathResource
 from generated.formats.path.compound.PathSupport import PathSupport
 from generated.formats.path.compound.PathType import PathType
+from generated.formats.path.compound.SupportSetRoot import SupportSetRoot
 from generated.formats.path.compound.PathJoinPartResourceRoot import PathJoinPartResourceRoot
 from modules.formats.BaseFormat import MemStructLoader
 
@@ -42,3 +43,7 @@ class PathSupportLoader(MemStructLoader):
 class PathTypeLoader(MemStructLoader):
 	target_class = PathType
 	extension = ".pathtype"
+
+class SupportSetLoader(MemStructLoader):
+	target_class = SupportSetRoot
+	extension = ".supportset"

--- a/modules/formats/PATH.py
+++ b/modules/formats/PATH.py
@@ -1,0 +1,44 @@
+from generated.formats.path.compound.PathExtrusion import PathExtrusion
+from generated.formats.path.compound.PathMaterial import PathMaterial
+from generated.formats.path.compound.PathResource import PathResource
+from generated.formats.path.compound.PathSupport import PathSupport
+from generated.formats.path.compound.PathType import PathType
+from generated.formats.path.compound.PathJoinPartResourceRoot import PathJoinPartResourceRoot
+from modules.formats.BaseFormat import MemStructLoader
+
+
+class PathExtrusionLoader(MemStructLoader):
+	target_class = PathExtrusion
+	extension = ".pathextrusion"
+
+class PathMaterialLoader(MemStructLoader):
+	target_class = PathMaterial
+	extension = ".pathmaterial"
+
+	def prep(self):
+		# avoid generating pointers for these
+		if not self.header.num_data:
+			self.header.mat_data.data = None
+
+	def create(self):
+		self.create_root_entry()
+		self.header = self.target_class.from_xml_file(self.file_entry.path, self.ovl.context)
+		self.prep()
+		# print(self.header)
+		self.header.write_ptrs(self, self.root_ptr, self.file_entry.pool_type)
+
+class PathResourceLoader(MemStructLoader):
+	target_class = PathResource
+	extension = ".pathresource"
+
+class PathJoinPartResourceLoader(MemStructLoader):
+	target_class = PathJoinPartResourceRoot
+	extension = ".pathjoinpartresource"
+
+class PathSupportLoader(MemStructLoader):
+	target_class = PathSupport
+	extension = ".pathsupport"
+
+class PathTypeLoader(MemStructLoader):
+	target_class = PathType
+	extension = ".pathtype"

--- a/modules/formats/PATH.py
+++ b/modules/formats/PATH.py
@@ -64,3 +64,17 @@ class PathTypeLoader(MemStructLoader):
 class SupportSetLoader(MemStructLoader):
 	target_class = SupportSetRoot
 	extension = ".supportset"
+
+	def prep(self):
+		# avoid generating pointers for these
+		if not self.header.num_connector_1:
+			self.header.connector_1.data = None
+		if not self.header.num_connector_2:
+			self.header.connector_2.data = None
+
+	def create(self):
+		self.create_root_entry()
+		self.header = self.target_class.from_xml_file(self.file_entry.path, self.ovl.context)
+		self.prep()
+		# print(self.header)
+		self.header.write_ptrs(self, self.root_ptr, self.file_entry.pool_type)

--- a/modules/formats/PATH.py
+++ b/modules/formats/PATH.py
@@ -36,6 +36,23 @@ class PathJoinPartResourceLoader(MemStructLoader):
 	target_class = PathJoinPartResourceRoot
 	extension = ".pathjoinpartresource"
 
+	def prep(self):
+		# avoid generating pointers for these
+		for res in self.header.resources_list.data.resources:
+			if not res.num_points_1:
+				res.unk_points_1.data = None
+			if not res.num_points_2:
+				res.unk_points_2.data = None
+			if not res.num_points_3:
+				res.unk_points_3.data = None
+
+	def create(self):
+		self.create_root_entry()
+		self.header = self.target_class.from_xml_file(self.file_entry.path, self.ovl.context)
+		self.prep()
+		# print(self.header)
+		self.header.write_ptrs(self, self.root_ptr, self.file_entry.pool_type)
+
 class PathSupportLoader(MemStructLoader):
 	target_class = PathSupport
 	extension = ".pathsupport"

--- a/source/formats/path/path.xml
+++ b/source/formats/path/path.xml
@@ -4,6 +4,12 @@
 
     <xi:include href="../ovl_base/ovl_base.xml" xmlns:xi="http://www.w3.org/2001/XInclude" xpointer="xpointer(*/*)" />
 
+    <compound name="Vector2" size="8" inherit="MemStruct">
+        A vector in 2D space (x,y).
+        <field name="x" type="float">First coordinate.</field>
+        <field name="y" type="float">Second coordinate.</field>
+    </compound>
+
     <compound name="Vector3" size="12" inherit="MemStruct">
         A vector in 3D space (x,y,z).
         <field name="x" type="float">First coordinate.</field>
@@ -122,6 +128,77 @@
         <add name="unkFloat1" type="float" />
         <add name="unkFloat2" type="float" />
         <add name="unkInt2" type="uint" />
+    </compound>
+
+    <compound name="SupportSetRoot" inherit="MemStruct">
+        <!-- Size 144 -->
+        <add name="connector_1" type="ArrayPointer" template="Connector" arg="num_connector_1" />
+        <add name="connector_2" type="Pointer" template="ConnectorMultiJoint" />
+        <add name="pillar" type="Pointer" template="Pillar" />
+        <add name="footer" type="Pointer" template="Footer" />
+        <add name="padding" type="uint64" />
+        <add name="unkVector1" type="Vector3" />
+        <add name="unkVector2" type="Vector2" />
+        <add name="unkVector3" type="Vector3" />
+        <add name="numUnk1" type="uint" />
+        <add name="num_connector_1" type="uint" />
+        <add name="unkInts" type="uint" arr1="8" />
+        <add name="padding_2" type="uint64" />
+        <add name="data" type="ArrayPointer" template="SupportSetData" arg="num_data" />
+        <add name="num_data" type="uint" />
+    </compound>
+
+    <compound name="Connector" inherit="MemStruct">
+        <!-- Size 24 -->
+        <add name="model_name" type="Pointer" template="ZString"/>
+        <add name="joint_name" type="Pointer" template="ZString"/>
+        <add name="unkVector" type="Vector2" />
+    </compound>
+
+    <compound name="ConnectorMultiJoint" inherit="MemStruct">
+        <!-- Size 48 -->
+        <add name="model_name" type="Pointer" template="ZString"/>
+        <add name="padding" type="uint64" />
+        <add name="joints" type="ArrayPointer" template="Joint" arg="num_joints" />
+        <add name="num_joints" type="uint64" />
+        <add name="unkFloat1" type="float" />
+        <add name="unkInt1" type="uint" />
+        <add name="padding" type="uint64" />
+    </compound>
+
+    <compound name="SupportAttach" inherit="MemStruct">
+        <!-- Size 32 -->
+        <add name="model_name" type="Pointer" template="ZString"/>
+        <add name="unkInt1" type="uint64" />
+        <add name="unkInt2" type="uint64" />
+        <add name="unkVector" type="Vector2" />
+    </compound>
+
+    <compound name="SupportAttachExtra" inherit="SupportAttach">
+        <!-- Size 16 -->
+        <add name="unkFloat1" type="float" />
+        <add name="unkInt3" type="uint" />
+        <add name="padding" type="uint64" />
+    </compound>
+
+    <compound name="Joint" inherit="SupportAttachExtra">
+        <!-- Size 48 -->
+    </compound>
+
+    <compound name="Pillar" inherit="SupportAttachExtra">
+        <!-- Size 48 -->
+    </compound>
+
+    <compound name="Footer" inherit="SupportAttach">
+        <!-- Size 32 -->
+    </compound>
+
+    <compound name="SupportSetData" inherit="MemStruct">
+        <!-- Size 16 -->
+        <add name="unkIndex" type="uint" />
+        <add name="unkInt1" type="uint" />
+        <add name="unkInt2" type="uint" />
+        <add name="unkFloat1" type="float" />
     </compound>
 
 </niftoolsxml>

--- a/source/formats/path/path.xml
+++ b/source/formats/path/path.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE niftoolsxml>
+<niftoolsxml version="0.7.1.0">
+
+    <xi:include href="../ovl_base/ovl_base.xml" xmlns:xi="http://www.w3.org/2001/XInclude" xpointer="xpointer(*/*)" />
+
+    <compound name="Vector3" size="12" inherit="MemStruct">
+        A vector in 3D space (x,y,z).
+        <field name="x" type="float">First coordinate.</field>
+        <field name="y" type="float">Second coordinate.</field>
+        <field name="z" type="float">Third coordinate.</field>
+    </compound>
+
+    <compound name="Vector4" size="16" inherit="MemStruct">
+        A vector in 3D space (x,y,z).
+        <field name="x" type="float">First coordinate.</field>
+        <field name="y" type="float">Second coordinate.</field>
+        <field name="z" type="float">Third coordinate.</field>
+        <field name="w" type="float">Fourth coordinate.</field>
+    </compound>
+
+    <compound name="PathExtrusion" inherit="MemStruct">
+        <!-- Size 48 -->
+        <add name="model" type="Pointer" template="ZString"/>
+        <add name="post_model" type="Pointer" template="ZString"/>
+        <add name="endcap_model" type="Pointer" template="ZString"/>
+        <add name="unkFloat1" type="float" />
+        <add name="unkFloat2" type="float" />
+        <add name="is_kerb" type="bool" />
+        <add name="unkBool" type="bool" /> <!-- Only False values are natural ground paths _ground.pathextrusion -->
+        <add name="padding" type="byte" arr1="14" />
+    </compound>
+
+    <compound name="PathMaterial" inherit="MemStruct">
+        <!-- Size 112 -->
+        <add name="elevated_mat" type="Pointer" template="ZString"/>
+        <add name="elevated_mat_valid" type="Pointer" template="ZString"/>
+        <add name="elevated_mat_invalid" type="Pointer" template="ZString"/>
+        <add name="terrain_mat" type="Pointer" template="ZString"/>
+        <add name="terrain_mat_valid" type="Pointer" template="ZString"/>
+        <add name="terrain_mat_invalid" type="Pointer" template="ZString"/>
+        <add name="underside_mat_1" type="Pointer" template="ZString"/>
+        <add name="underside_mat_2" type="Pointer" template="ZString"/>
+        <add name="stairs_mat_1" type="Pointer" template="ZString"/>
+        <add name="stairs_mat_2" type="Pointer" template="ZString"/>
+        <add name="num_data" type="uint64" />
+        <add name="mat_data" type="ArrayPointer" template="PathMaterialData" arg="num_data" />
+        <add name="num_data_copy" type="uint64" />
+        <add name="padding" type="uint64" />
+    </compound>
+
+    <compound name="PathMaterialData" inherit="MemStruct">
+        <!-- Size 16 -->
+        <add name="unkInt1" type="uint" />
+        <add name="unkFloat1" type="float" />
+        <add name="unkInt2" type="uint" />
+        <add name="unkInt3" type="uint" />
+    </compound>
+
+    <compound name="PathResource" inherit="MemStruct">
+        <!-- Size 48 -->
+        <add name="pathmaterial" type="Pointer" template="ZString"/>
+        <add name="pathextrusion_kerb" type="Pointer" template="ZString"/>
+        <add name="pathextrusion_railing" type="Pointer" template="ZString"/>
+        <add name="pathextrusion_ground" type="Pointer" template="ZString"/>
+        <add name="pathsupport" type="Pointer" template="ZString"/>
+        <add name="path_type" type="byte" /> <!-- 0 for Guest, 1 for Queue, 2 for Staff -->
+        <add name="path_sub_type" type="byte" /> <!-- 0 = None, 1 = Natural, matches PathSubType column in c0paths.fdb -->
+        <add name="unkByte1" type="byte" /> <!-- Always 1 -->
+        <add name="unkByte2" type="byte" />
+        <add name="padding" type="uint" />
+    </compound>
+
+    <compound name="PathJoinPartResourceRoot" inherit="MemStruct">
+        <!-- Size 16 -->
+        <add name="resources_list" type="Pointer" template="PathJoinPartResourceList" arg="num_res" />
+        <add name="num_res" type="uint64" />
+    </compound>
+
+    <compound name="PathJoinPartResourceList" inherit="MemStruct">
+        <!-- Size 72 * #ARG# + 16-byte alignment padding -->
+        <add name="resources" type="PathJoinPartResource" arr1="#ARG#" />
+        <add name="padding" type="byte" arr1="(#ARG# % 2) * 8" />
+    </compound>
+
+    <compound name="PathJoinPartResource" inherit="MemStruct">
+        <!-- Size 72 -->
+        <add name="unkPoints1" type="Pointer" template="PointsList" arg="num_points_1" />
+        <add name="unkPoints2" type="Pointer" template="PointsList" arg="num_points_2" />
+        <add name="unkVector" type="ArrayPointer" template="Vector4" arg="1" />
+        <add name="unkShorts" type="ArrayPointer" template="ushort" arg="8" />
+        <add name="unkPoints3" type="Pointer" template="PointsList" arg="num_points_3" />
+        <add name="padding_1" type="uint64" />
+        <add name="pathresource" type="Pointer" template="ZString"/>
+        <add name="unkByte1" type="byte" />
+        <add name="unkByte2" type="byte" />
+        <add name="unkByte3" type="byte" />
+        <add name="num_points_1" type="byte" />
+        <add name="num_points_1_copy" type="byte" />
+        <add name="num_points_2" type="byte" />
+        <add name="num_points_2_copy" type="byte" />
+        <add name="num_points_3" type="byte" />
+        <add name="padding_2" type="uint64" />
+    </compound>
+
+    <compound name="PointsList" inherit="MemStruct">
+        <!-- Size 12 * #ARG# + 16-byte alignment padding -->
+        <add name="points" type="Vector3" arr1="#ARG#" />
+        <add name="padding" type="byte" arr1="(#ARG# % 4) * 4" />
+    </compound>
+
+    <compound name="PathSupport" inherit="MemStruct">
+        <!-- Size 16 -->
+        <add name="support" type="Pointer" template="ZString"/>
+        <add name="unkFloat1" type="float" />
+        <add name="unkInt1" type="uint" />
+    </compound>
+
+    <compound name="PathType" inherit="MemStruct">
+        <!-- Size 16 -->
+        <add name="enum_value" type="uint" /> <!-- Matches the EnumValue column in c0paths.fdb -->
+        <add name="unkFloat1" type="float" />
+        <add name="unkFloat2" type="float" />
+        <add name="unkInt2" type="uint" />
+    </compound>
+
+</niftoolsxml>

--- a/source/formats/path/path.xml
+++ b/source/formats/path/path.xml
@@ -48,9 +48,9 @@
         <add name="underside_mat_2" type="Pointer" template="ZString"/>
         <add name="stairs_mat_1" type="Pointer" template="ZString"/>
         <add name="stairs_mat_2" type="Pointer" template="ZString"/>
-        <add name="num_data" type="uint64" />
+        <add name="path_sub_type" type="uint64" /> <!-- 0 = None, 1 = Natural, matches PathSubType column in c0paths.fdb -->
         <add name="mat_data" type="ArrayPointer" template="PathMaterialData" arg="num_data" />
-        <add name="num_data_copy" type="uint64" />
+        <add name="num_data" type="uint64" />
         <add name="padding" type="uint64" />
     </compound>
 

--- a/source/formats/path/path.xml
+++ b/source/formats/path/path.xml
@@ -34,7 +34,6 @@
         <add name="unkFloat2" type="float" />
         <add name="is_kerb" type="bool" />
         <add name="unkBool" type="bool" /> <!-- Only False values are natural ground paths _ground.pathextrusion -->
-        <add name="padding" type="byte" arr1="14" />
     </compound>
 
     <compound name="PathMaterial" inherit="MemStruct">
@@ -86,7 +85,6 @@
     <compound name="PathJoinPartResourceList" inherit="MemStruct">
         <!-- Size 72 * #ARG# + 16-byte alignment padding -->
         <add name="resources" type="PathJoinPartResource" arr1="#ARG#" />
-        <add name="padding" type="byte" arr1="(#ARG# % 2) * 8" />
     </compound>
 
     <compound name="PathJoinPartResource" inherit="MemStruct">
@@ -112,7 +110,6 @@
     <compound name="PointsList" inherit="MemStruct">
         <!-- Size 12 * #ARG# + 16-byte alignment padding -->
         <add name="points" type="Vector3" arr1="#ARG#" />
-        <add name="padding" type="byte" arr1="(#ARG# % 4) * 4" />
     </compound>
 
     <compound name="PathSupport" inherit="MemStruct">

--- a/source/formats/path/path.xml
+++ b/source/formats/path/path.xml
@@ -33,7 +33,7 @@
         <add name="unkFloat1" type="float" />
         <add name="unkFloat2" type="float" />
         <add name="is_kerb" type="bool" />
-        <add name="unkBool" type="bool" /> <!-- Only False values are natural ground paths _ground.pathextrusion -->
+        <add name="is_not_ground" type="bool" /> <!-- Only False values are natural ground paths _ground.pathextrusion -->
     </compound>
 
     <compound name="PathMaterial" inherit="MemStruct">
@@ -128,16 +128,17 @@
     <compound name="SupportSetRoot" inherit="MemStruct">
         <!-- Size 144 -->
         <add name="connector_1" type="ArrayPointer" template="Connector" arg="num_connector_1" />
-        <add name="connector_2" type="Pointer" template="ConnectorMultiJoint" />
+        <add name="connector_2" type="ArrayPointer" template="ConnectorMultiJoint" arg="num_connector_2" />
         <add name="pillar" type="Pointer" template="Pillar" />
         <add name="footer" type="Pointer" template="Footer" />
         <add name="padding" type="uint64" />
         <add name="unkVector1" type="Vector3" />
         <add name="unkVector2" type="Vector2" />
         <add name="unkVector3" type="Vector3" />
-        <add name="numUnk1" type="uint" />
+        <add name="unkInt1" type="uint" />
         <add name="num_connector_1" type="uint" />
-        <add name="unkInts" type="uint" arr1="8" />
+        <add name="num_connector_2" type="uint" />
+        <add name="unkInts" type="uint" arr1="7" />
         <add name="padding_2" type="uint64" />
         <add name="data" type="ArrayPointer" template="SupportSetData" arg="num_data" />
         <add name="num_data" type="uint" />

--- a/source/formats/path/path.xml
+++ b/source/formats/path/path.xml
@@ -51,7 +51,6 @@
         <add name="path_sub_type" type="uint64" /> <!-- 0 = None, 1 = Natural, matches PathSubType column in c0paths.fdb -->
         <add name="mat_data" type="ArrayPointer" template="PathMaterialData" arg="num_data" />
         <add name="num_data" type="uint64" />
-        <add name="padding" type="uint64" />
     </compound>
 
     <compound name="PathMaterialData" inherit="MemStruct">
@@ -73,7 +72,6 @@
         <add name="path_sub_type" type="byte" /> <!-- 0 = None, 1 = Natural, matches PathSubType column in c0paths.fdb -->
         <add name="unkByte1" type="byte" /> <!-- Always 1 -->
         <add name="unkByte2" type="byte" />
-        <add name="padding" type="uint" />
     </compound>
 
     <compound name="PathJoinPartResourceRoot" inherit="MemStruct">
@@ -104,7 +102,7 @@
         <add name="num_points_2" type="byte" />
         <add name="num_points_2_copy" type="byte" />
         <add name="num_points_3" type="byte" />
-        <add name="padding_2" type="uint64" />
+        <add name="padding_2" type="uint64" /> <!-- Required as part of list -->
     </compound>
 
     <compound name="PointsList" inherit="MemStruct">
@@ -160,7 +158,7 @@
         <add name="num_joints" type="uint64" />
         <add name="unkFloat1" type="float" />
         <add name="unkInt1" type="uint" />
-        <add name="padding" type="uint64" />
+        <add name="padding" type="uint64" /> <!-- Unsure if padding, keep -->
     </compound>
 
     <compound name="SupportAttach" inherit="MemStruct">
@@ -175,7 +173,7 @@
         <!-- Size 16 -->
         <add name="unkFloat1" type="float" />
         <add name="unkInt3" type="uint" />
-        <add name="padding" type="uint64" />
+        <add name="padding" type="uint64" /> <!-- Unsure if padding, keep -->
     </compound>
 
     <compound name="Joint" inherit="SupportAttachExtra">


### PR DESCRIPTION
Decoding for .pathtype, .pathmaterial, .pathextrusion, .pathsupport, .pathresource, .pathjoinpartresource, .supportset

TODO:  

- [X] A few other filetypes in other OVL related to paths
- [x] Remove any unnecessary padding definitions
- [x] Figure out injection tracebacks for .pathjoinpartresource

GAME STATUS:

- [X] .pathextrusion injecting, no crashes
- [X] .pathmaterial injecting, no crashes
- [X] .pathresource injecting, no crashes
- [X] .pathsupport injecting, no crashes
- [X] .pathtype injecting, no crashes
- [x] .pathjoinpartresource injecting, no crashes (see comments)
- [X] .supportset injecting, no crashes  (see comments)
