### PR TITLE
Added enter_condition argument to get_condition_attributes_recursive …

### DIFF
--- a/generated/base_struct.py
+++ b/generated/base_struct.py
@@ -279,12 +279,12 @@ class BaseStruct(metaclass=StructMetaClass):
 
 	@classmethod
 	def get_condition_attributes_recursive(cls, struct_type, struct_instance, condition_function, arguments=(),
-										   include_abstract=True):
+										   include_abstract=True, enter_condition=lambda x: True):
 		for attribute in struct_type._get_filtered_attribute_list(struct_instance, *arguments[3:4], include_abstract):
 			field_name, field_type, field_arguments = attribute[0:3]
 			if condition_function(attribute):
 				yield struct_type, struct_instance, attribute
-			if callable(getattr(field_type, "_get_filtered_attribute_list", None)):
+			if callable(getattr(field_type, "_get_filtered_attribute_list", None)) and enter_condition(attribute):
 				yield from cls.get_condition_attributes_recursive(field_type,
 														  struct_type.get_field(struct_instance, field_name),
 														  condition_function,
@@ -292,12 +292,14 @@ class BaseStruct(metaclass=StructMetaClass):
 														  include_abstract)
 
 	@classmethod
-	def get_condition_values_recursive(cls, instance, condition_function, arguments=(), include_abstract=True):
+	def get_condition_values_recursive(cls, instance, condition_function, arguments=(), include_abstract=True,
+									   enter_condition=lambda x: True):
 		for s_type, s_inst, (f_name, f_type, arguments, _) in cls.get_condition_attributes_recursive(type(instance),
 																								 instance,
 																								 condition_function,
 																								 arguments,
-																								 include_abstract):
+																								 include_abstract,
+																								 enter_condition):
 			val = s_type.get_field(s_inst, f_name)
 			yield val
 

--- a/source/base_struct.py
+++ b/source/base_struct.py
@@ -279,12 +279,12 @@ class BaseStruct(metaclass=StructMetaClass):
 
 	@classmethod
 	def get_condition_attributes_recursive(cls, struct_type, struct_instance, condition_function, arguments=(),
-										   include_abstract=True):
+										   include_abstract=True, enter_condition=lambda x: True):
 		for attribute in struct_type._get_filtered_attribute_list(struct_instance, *arguments[3:4], include_abstract):
 			field_name, field_type, field_arguments = attribute[0:3]
 			if condition_function(attribute):
 				yield struct_type, struct_instance, attribute
-			if callable(getattr(field_type, "_get_filtered_attribute_list", None)):
+			if callable(getattr(field_type, "_get_filtered_attribute_list", None)) and enter_condition(attribute):
 				yield from cls.get_condition_attributes_recursive(field_type,
 														  struct_type.get_field(struct_instance, field_name),
 														  condition_function,
@@ -292,12 +292,14 @@ class BaseStruct(metaclass=StructMetaClass):
 														  include_abstract)
 
 	@classmethod
-	def get_condition_values_recursive(cls, instance, condition_function, arguments=(), include_abstract=True):
+	def get_condition_values_recursive(cls, instance, condition_function, arguments=(), include_abstract=True,
+									   enter_condition=lambda x: True):
 		for s_type, s_inst, (f_name, f_type, arguments, _) in cls.get_condition_attributes_recursive(type(instance),
 																								 instance,
 																								 condition_function,
 																								 arguments,
-																								 include_abstract):
+																								 include_abstract,
+																								 enter_condition):
 			val = s_type.get_field(s_inst, f_name)
 			yield val
 


### PR DESCRIPTION
…and get_condition_values_recursive.

The extra parameter can be used for extra performance. It's used by the nif library to prevent recursion through classes when you know they don't have the attributes you're looking for.