### PR TITLE
Small additions to codegen and one fix.

### DIFF
--- a/codegen/BaseClass.py
+++ b/codegen/BaseClass.py
@@ -84,6 +84,9 @@ class BaseClass:
         self.write_line(stream)
         self.write_line(stream, 1, f"__name__ = '{self.struct.attrib.get('__name__')}'")
 
+    def write_src_body(self, stream):
+        stream.write(self.grab_src_snippet("# START_CLASS"))
+
     def write_line(self, stream, indent=0, line=""):
         stream.write("\n" + indent*"\t" + line)
 

--- a/codegen/Bitfield.py
+++ b/codegen/Bitfield.py
@@ -76,5 +76,6 @@ class Bitfield(BaseClass):
             else:
                 f.write(f"\n\t\tpass")
 
-            f.write(f"\n")
+            self.write_src_body(f)
+            self.write_line(f)
 

--- a/codegen/Compound.py
+++ b/codegen/Compound.py
@@ -80,5 +80,5 @@ class Compound(BaseClass):
                 for union in self.field_unions:
                     condition = union.write_filtered_attributes(f, condition, target_variable="instance")
 
-            f.write(self.grab_src_snippet("# START_CLASS"))
+            self.write_src_body(f)
             self.write_line(f)

--- a/codegen/Enum.py
+++ b/codegen/Enum.py
@@ -23,4 +23,5 @@ class Enum(BaseClass):
                 if option.text:
                     f.write(clean_comment_str(option.text, indent="\t"))
                 f.write(f"\n\t{option.attrib['name']} = {option.attrib['value']}")
-            f.write(f"\n")
+            self.write_src_body(f)
+            self.write_line(f)

--- a/generated/array.py
+++ b/generated/array.py
@@ -50,6 +50,10 @@ class Array(list):
         if set_default:
             self.set_defaults()
 
+    def __str__(self):
+        fields_str = ',\n'.join([f_type.fmt_member(self[f_name]) for f_name, f_type, _, _ in self._get_filtered_attribute_list(self, self.dtype)])
+        return f"[{fields_str}]"
+
     def set_defaults(self):
         self[:] = self.fill(lambda: self.dtype(self.context, self.arg, self.template))
 
@@ -123,7 +127,7 @@ class Array(list):
         elif callable(getattr(dtype, 'create_array', None)):
             return dtype.create_array(shape, default=value)
         else:
-            new_array = cls(shape, dtype, None, set_default=False)
+            new_array = cls(None, 0, None, shape, dtype, set_default=False)
             new_array.fill(lambda: dtype.from_value(value))
             return new_array
 
@@ -192,11 +196,13 @@ class Array(list):
         elif callable(getattr(dtype, "validate_array", None)):
             return dtype.validate_array(instance, context, arg, template, shape)
         try:
-	        assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
-	        assert instance.arg == arg, f"argument {instance.arg} doesn't match {arg} on {cls}"
-	        assert instance.template == template, f"template {instance.template} doesn't match {template} on {cls}"
-	        assert instance.shape == shape, f"shape {instance.shape} doesn't match {shape} on {cls}"
-	        assert instance.dtype == dtype, f"dtype {instance.dtype} doesn't match {dtype} on {cls}"
+            if not callable(getattr(dtype, 'from_value', None)):
+                # if the dtype has from_value, the context on that type doesn't matter
+                assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
+            assert instance.arg == arg, f"argument {instance.arg} doesn't match {arg} on {cls}"
+            assert instance.template == template, f"template {instance.template} doesn't match {template} on {cls}"
+            assert instance.shape == shape, f"shape {instance.shape} doesn't match {shape} on {cls}"
+            assert instance.dtype == dtype, f"dtype {instance.dtype} doesn't match {dtype} on {cls}"
         except AssertionError:
             logging.error(f"validation failed on {cls}[{dtype}]")
             raise
@@ -361,11 +367,13 @@ class RaggedArray(Array):
         if callable(getattr(dtype, "validate_ragged_array", None)):
             return dtype.validate_ragged_array(instance, context, arg, template, shape)
         try:
-	        assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
-	        assert instance.arg == arg, f"argument {instance.arg} doesn't match {arg} on {cls}"
-	        assert instance.template == template, f"template {instance.template} doesn't match {template} on {cls}"
-	        assert instance.shape == shape, f"shape {instance.shape} doesn't match {shape} on {cls}"
-	        assert instance.dtype == dtype, f"dtype {instance.dtype} doesn't match {dtype} on {cls}"
+            if not callable(getattr(dtype, 'from_value', None)):
+                # if the dtype has from_value, the context on that type doesn't matter
+                assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
+            assert instance.arg == arg, f"argument {instance.arg} doesn't match {arg} on {cls}"
+            assert instance.template == template, f"template {instance.template} doesn't match {template} on {cls}"
+            assert instance.shape == shape, f"shape {instance.shape} doesn't match {shape} on {cls}"
+            assert instance.dtype == dtype, f"dtype {instance.dtype} doesn't match {dtype} on {cls}"
         except AssertionError:
             logging.error(f"validation failed on {cls}[{dtype}]")
             raise

--- a/generated/base_struct.py
+++ b/generated/base_struct.py
@@ -249,20 +249,25 @@ class BaseStruct(metaclass=StructMetaClass):
 				else:
 					field_value = field_type.from_value(*arguments[2:4], default)
 				type(self).set_field(self, field_name, field_value)
+				return field_value
+		else:
+			logging.warning(f"Field {field_name} was not evaluated to be on type {type(self).__name__}")
 
 	@classmethod
 	def validate_instance(cls, instance, context, arg, template):
 		try:
-			assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
+			if not callable(getattr(cls, 'from_value', None)):
+				# if cls has from_value, the context on that type doesn't matter
+				assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
 			assert instance.arg == arg, f"argument {instance.argument} doesn't match {arg} on {cls}"
 			assert instance.template == template, f"template {instance.template} doesn't match {template} on {cls}"
-		except AssertionError:
+		except:
 			logging.error(f"validation failed on {cls}")
 			raise
 		for f_name, f_type, f_arguments, _ in cls._get_filtered_attribute_list(instance):
 			try:
 				f_type.validate_instance(cls.get_field(instance, f_name), context, *f_arguments)
-			except AssertionError:
+			except:
 				logging.error(f"validation failed on field {f_name} on type {cls}")
 				raise
 
@@ -303,8 +308,9 @@ class BaseStruct(metaclass=StructMetaClass):
 			try:
 				val = s_type.get_field(s_inst, f_name)
 				yield val
-			except:
-				logging.exception(f"Struct: Could not get {f_name} of {s_inst} of type {s_type}")
+			except (AttributeError, KeyError):
+				logging.exception(f"Struct: Could not get {f_name} of {s_inst} of type {s_type}{'[' + str(s_inst.dtype) + ']' if issubclass(s_type, list) else ''}")
+				raise
 
 	@staticmethod
 	def get_field(instance, key):

--- a/source/array.py
+++ b/source/array.py
@@ -50,6 +50,10 @@ class Array(list):
         if set_default:
             self.set_defaults()
 
+    def __str__(self):
+        fields_str = ',\n'.join([f_type.fmt_member(self[f_name]) for f_name, f_type, _, _ in self._get_filtered_attribute_list(self, self.dtype)])
+        return f"[{fields_str}]"
+
     def set_defaults(self):
         self[:] = self.fill(lambda: self.dtype(self.context, self.arg, self.template))
 
@@ -123,7 +127,7 @@ class Array(list):
         elif callable(getattr(dtype, 'create_array', None)):
             return dtype.create_array(shape, default=value)
         else:
-            new_array = cls(shape, dtype, None, set_default=False)
+            new_array = cls(None, 0, None, shape, dtype, set_default=False)
             new_array.fill(lambda: dtype.from_value(value))
             return new_array
 
@@ -192,11 +196,13 @@ class Array(list):
         elif callable(getattr(dtype, "validate_array", None)):
             return dtype.validate_array(instance, context, arg, template, shape)
         try:
-	        assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
-	        assert instance.arg == arg, f"argument {instance.arg} doesn't match {arg} on {cls}"
-	        assert instance.template == template, f"template {instance.template} doesn't match {template} on {cls}"
-	        assert instance.shape == shape, f"shape {instance.shape} doesn't match {shape} on {cls}"
-	        assert instance.dtype == dtype, f"dtype {instance.dtype} doesn't match {dtype} on {cls}"
+            if not callable(getattr(dtype, 'from_value', None)):
+                # if the dtype has from_value, the context on that type doesn't matter
+                assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
+            assert instance.arg == arg, f"argument {instance.arg} doesn't match {arg} on {cls}"
+            assert instance.template == template, f"template {instance.template} doesn't match {template} on {cls}"
+            assert instance.shape == shape, f"shape {instance.shape} doesn't match {shape} on {cls}"
+            assert instance.dtype == dtype, f"dtype {instance.dtype} doesn't match {dtype} on {cls}"
         except AssertionError:
             logging.error(f"validation failed on {cls}[{dtype}]")
             raise
@@ -361,11 +367,13 @@ class RaggedArray(Array):
         if callable(getattr(dtype, "validate_ragged_array", None)):
             return dtype.validate_ragged_array(instance, context, arg, template, shape)
         try:
-	        assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
-	        assert instance.arg == arg, f"argument {instance.arg} doesn't match {arg} on {cls}"
-	        assert instance.template == template, f"template {instance.template} doesn't match {template} on {cls}"
-	        assert instance.shape == shape, f"shape {instance.shape} doesn't match {shape} on {cls}"
-	        assert instance.dtype == dtype, f"dtype {instance.dtype} doesn't match {dtype} on {cls}"
+            if not callable(getattr(dtype, 'from_value', None)):
+                # if the dtype has from_value, the context on that type doesn't matter
+                assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
+            assert instance.arg == arg, f"argument {instance.arg} doesn't match {arg} on {cls}"
+            assert instance.template == template, f"template {instance.template} doesn't match {template} on {cls}"
+            assert instance.shape == shape, f"shape {instance.shape} doesn't match {shape} on {cls}"
+            assert instance.dtype == dtype, f"dtype {instance.dtype} doesn't match {dtype} on {cls}"
         except AssertionError:
             logging.error(f"validation failed on {cls}[{dtype}]")
             raise

--- a/source/base_struct.py
+++ b/source/base_struct.py
@@ -249,20 +249,25 @@ class BaseStruct(metaclass=StructMetaClass):
 				else:
 					field_value = field_type.from_value(*arguments[2:4], default)
 				type(self).set_field(self, field_name, field_value)
+				return field_value
+		else:
+			logging.warning(f"Field {field_name} was not evaluated to be on type {type(self).__name__}")
 
 	@classmethod
 	def validate_instance(cls, instance, context, arg, template):
 		try:
-			assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
+			if not callable(getattr(cls, 'from_value', None)):
+				# if cls has from_value, the context on that type doesn't matter
+				assert instance.context == context, f"context {instance.context} doesn't match {context} on {cls}"
 			assert instance.arg == arg, f"argument {instance.argument} doesn't match {arg} on {cls}"
 			assert instance.template == template, f"template {instance.template} doesn't match {template} on {cls}"
-		except AssertionError:
+		except:
 			logging.error(f"validation failed on {cls}")
 			raise
 		for f_name, f_type, f_arguments, _ in cls._get_filtered_attribute_list(instance):
 			try:
 				f_type.validate_instance(cls.get_field(instance, f_name), context, *f_arguments)
-			except AssertionError:
+			except:
 				logging.error(f"validation failed on field {f_name} on type {cls}")
 				raise
 
@@ -303,8 +308,9 @@ class BaseStruct(metaclass=StructMetaClass):
 			try:
 				val = s_type.get_field(s_inst, f_name)
 				yield val
-			except:
-				logging.exception(f"Struct: Could not get {f_name} of {s_inst} of type {s_type}")
+			except (AttributeError, KeyError):
+				logging.exception(f"Struct: Could not get {f_name} of {s_inst} of type {s_type}{'[' + str(s_inst.dtype) + ']' if issubclass(s_type, list) else ''}")
+				raise
 
 	@staticmethod
 	def get_field(instance, key):


### PR DESCRIPTION
Changes:
1. Enums and Bitfields can now also use custom class code, with the same syntax as Structs (everything after # START_CLASS is copied).
2. Because from_value on a class indicates a class doesn't use context, and objects created with from_value don't have context, context is no longer taken into account with validation on classes that have from_value.
3. Exception in validate_instance that are not the AssertionError were difficult to diagnose, because they didn't log the field or type - now every exception logs them.
4. Added warning for reset_field when the field in question either doesn't exist on the struct or is not active to prevent silent failures that are difficult to track down, but still allow it to pass if that's the intended behaviour. Reset_field, if successful, also returns the value of the field.
5. Fixed Array.from_value function that wasn't working properly due to array mismatch.