### PR TITLE
Recursive fix

### DIFF
--- a/codegen.py
+++ b/codegen.py
@@ -56,6 +56,8 @@ class XmlParser:
         # maps each type to its member tag type
         self.tag_dict = {}
 
+        self.processed_types = {"self.template"}
+
         self.basics = None
 
     def generate_module_paths(self, root, xml_path, parsed_xmls):
@@ -290,6 +292,7 @@ class XmlParser:
         self.copy_dict_info(self.path_dict, other_parser.path_dict)
         self.copy_dict_info(self.tag_dict, other_parser.tag_dict)
         self.basics.add_other_basics(other_parser.basics, other_parser.path_dict["basic_map"])
+        self.processed_types.update(other_parser.processed_types)
 
 
 def copy_src_to_generated(src_dir, trg_dir):

--- a/codegen.py
+++ b/codegen.py
@@ -232,7 +232,6 @@ class XmlParser:
         return arr_str
 
     def map_type(self, in_type, array=False):
-        has_stream_functions = False
         if array:
             out_type = ('Array', in_type)
         else:
@@ -243,19 +242,17 @@ class XmlParser:
                 basic_class = self.basics.basic_map[in_type]
                 if array:
                     if callable(getattr(basic_class, "create_array", None)):
-                        has_stream_functions = True
                         test = basic_class.create_array(1)
                         if isinstance(test, ndarray):
                             out_type = ('numpy', f'numpy.{repr(test.dtype)}')
                 else:
                     if callable(getattr(basic_class, "from_value", None)):
-                        has_stream_functions = True
                         # check from_value to see which builtin it returns
                         test = basic_class.from_value(0)
                         test_type = type(test).__name__
                         if test_type in self.builtin_literals:
                             out_type = test_type
-        return has_stream_functions, out_type
+        return out_type
 
     def replace_tokens(self, xml_struct):
         """Update xml_struct's (and all of its children's) attrib dict with content of tokens+versions list."""

--- a/codegen.py
+++ b/codegen.py
@@ -56,7 +56,7 @@ class XmlParser:
         # maps each type to its member tag type
         self.tag_dict = {}
 
-        self.processed_types = {"self.template"}
+        self.processed_types = {"template"}
 
         self.basics = None
 
@@ -216,7 +216,7 @@ class XmlParser:
                 for field in struct:
                     self.apply_convention(field, convention.name_attribute, ("name",))
                     self.apply_convention(field, convention.name_class, ("type", "onlyT", "excludeT"))
-                    self.apply_convention(field, convention.force_bool, ("optional", "abstract"))
+                    self.apply_convention(field, convention.force_bool, ("optional", "abstract", "recursive"))
                     # template can refer to a type of an attribute
                     self.apply_convention(field, convention.format_potential_tuple, ("default",))
                     for default in field:

--- a/codegen/BaseClass.py
+++ b/codegen/BaseClass.py
@@ -28,6 +28,8 @@ class BaseClass:
         # handle imports
         self.imports = Imports(self.parser, self.struct)
 
+        self.parser.processed_types.add(self.class_name)
+
     def get_class_call(self):
         # set backup
         inheritance = f"({self.class_basename})" if self.class_basename else ""

--- a/codegen/Basics.py
+++ b/codegen/Basics.py
@@ -24,7 +24,11 @@ class Basics:
     def read(self, xml_struct):
         basic_name = xml_struct.attrib["name"]
         if hasattr(self.base_module, basic_name):
+
+            self.parser.processed_types.add(basic_name)
+
             self.basic_map[basic_name] = getattr(self.base_module, basic_name)
+
             if xml_struct.attrib.get("boolean", "False") == "True":
                 self.booleans.add(basic_name)
         else:

--- a/codegen/Bitfield.py
+++ b/codegen/Bitfield.py
@@ -52,7 +52,7 @@ class Bitfield(BaseClass):
             self.get_mask()
             for field in self.struct:
                 field_name = field.attrib["name"]
-                _, field_type = self.parser.map_type(field.attrib.get("type", "int"))
+                field_type = self.parser.map_type(field.attrib.get("type", "int"))
                 # print(field_name, field_type)
                 if field_type not in self.parser.builtin_literals:
                     field_type = f'{field_type}.from_value'

--- a/codegen/Compound.py
+++ b/codegen/Compound.py
@@ -60,15 +60,15 @@ class Compound(BaseClass):
                 self.write_line(f, 3, "self.set_defaults()")
 
             # write attribute list
-            method_str = "_attribute_list = "
-            if "_attribute_list = " not in self.src_code:
+            method_str = "def _get_attribute_list(cls):"
+            if method_str not in self.src_code:
                 self.write_line(f)
+                self.write_line(f, 1, "@classmethod")
                 self.write_line(f, 1, method_str)
                 if self.class_basename:
-                    f.write(f"{self.class_basename}._attribute_list + [\n\t\t")
+                    self.write_line(f, 2, "yield from super()._get_attribute_list()")
                 for union in self.field_unions:
                     union.write_attributes(f)
-                f.write("]")
 
             # write the _get_filtered_attribute_list method
             method_str = "def _get_filtered_attribute_list(cls, instance, include_abstract=True):"
@@ -83,4 +83,7 @@ class Compound(BaseClass):
                     condition = union.write_filtered_attributes(f, condition, target_variable="instance")
 
             self.write_src_body(f)
+            self.write_line(f)
+            self.write_line(f)
+            self.write_line(f, 0, f"{self.class_name}.init_attributes()")
             self.write_line(f)

--- a/codegen/Imports.py
+++ b/codegen/Imports.py
@@ -22,13 +22,6 @@ class Imports:
         for field in xml_struct:
             if field.tag in ("add", "field", "member"):
                 field_type = field.attrib["type"]
-                template = field.attrib.get("template")
-                if template:
-                    # template can be either a type or a reference to a local field
-                    # only import if a type
-                    template_class = convention.name_class(template)
-                    if template_class in self.path_dict:
-                        self.add_indirect_import(template_class)
                 arr1 = field.attrib.get("arr1")
                 if arr1 is None:
                     arr1 = field.attrib.get("length")
@@ -41,12 +34,23 @@ class Imports:
                     self.add_mapped_type(field_type)
                     if xml_struct.tag in parser.struct_types:
                         self.add(field_type)
+
+                template = field.attrib.get("template")
+                if template:
+                    # template can be either a type or a reference to a local field
+                    # only import if a type
+                    template_class = convention.name_class(template)
+                    if template_class in self.path_dict:
+                        self.add_indirect_import(template_class)
+
                 onlyT = field.attrib.get("onlyT")
                 if onlyT:
                     self.add_indirect_import(onlyT)
+
                 excludeT = field.attrib.get("excludeT")
                 if excludeT:
                     self.add_indirect_import(excludeT)
+
                 for default in field:
                     if default.tag in ("default",):
                         if default.attrib.get("versions"):

--- a/codegen/Imports.py
+++ b/codegen/Imports.py
@@ -22,17 +22,19 @@ class Imports:
         for field in xml_struct:
             if field.tag in ("add", "field", "member"):
                 field_type = field.attrib["type"]
+                is_recursive = self.is_recursive_field(field)
                 arr1 = field.attrib.get("arr1")
                 if arr1 is None:
                     arr1 = field.attrib.get("length")
                 if arr1:
-                    self.add_mapped_type(field_type, array=True)
+                    self.add_mapped_type(field_type, array=True, exclude_cls=is_recursive)
                     if xml_struct.tag in parser.struct_types:
-                        self.add(field_type)
+                        if not is_recursive:
+                            self.add(field_type)
                         self.add("Array")
                 else:
-                    self.add_mapped_type(field_type)
-                    if xml_struct.tag in parser.struct_types:
+                    self.add_mapped_type(field_type, exclude_cls=is_recursive)
+                    if xml_struct.tag in parser.struct_types and not is_recursive:
                         self.add(field_type)
 
                 template = field.attrib.get("template")
@@ -62,7 +64,7 @@ class Imports:
                         if excludeT:
                             self.add_indirect_import(excludeT)
 
-    def add_mapped_type(self, cls_to_import, array=False):
+    def add_mapped_type(self, cls_to_import, array=False, exclude_cls=False):
         if cls_to_import:
             import_type = self.parent.map_type(cls_to_import, array)
             if not array:
@@ -71,11 +73,16 @@ class Imports:
                     return
                 else:
                     import_type = (import_type, )
+            if exclude_cls:
+                import_type = (cls for cls in import_type if cls != cls_to_import)
             [self.add(import_class) for import_class in import_type]
 
     def add(self, cls_to_import):
         if cls_to_import and cls_to_import != self.xml_struct.attrib["name"]:
             self.imports.append(cls_to_import.split('.')[0])
+
+    def is_recursive_field(self, field):
+        return field.attrib.get('recursive', 'False') == 'True'
 
     def add_indirect_import(self, cls_to_import):
         # import the class directly, but only if it's not a struct (because those could lead to circular imports)

--- a/codegen/Imports.py
+++ b/codegen/Imports.py
@@ -64,9 +64,9 @@ class Imports:
 
     def add_mapped_type(self, cls_to_import, array=False):
         if cls_to_import:
-            has_stream_functions, import_type = self.parent.map_type(cls_to_import, array)
+            import_type = self.parent.map_type(cls_to_import, array)
             if not array:
-                if has_stream_functions and import_type in self.parent.builtin_literals:
+                if import_type in self.parent.builtin_literals:
                     # import not necessary (read/write on stream, and init can happen from literal)
                     return
                 else:

--- a/codegen/Union.py
+++ b/codegen/Union.py
@@ -205,7 +205,10 @@ class Union:
         # we init each field with its basic default string so that the field exists regardless of any condition
         field_default = self.get_default_string(field.attrib.get('default'), f'self.{CONTEXT_SUFFIX}', arg, template,
                                                 arr1, field_type)
-        f.write(f'\n{base_indent}self.{field_name} = {field_default}')
+
+        # do not init types used before their position in the xml - they are assumed to be circular
+        if field_type in self.compounds.parser.processed_types:
+            f.write(f'\n{base_indent}self.{field_name} = {field_default}')
 
     def write_attributes(self, f):
         for field in self.members:

--- a/codegen/Union.py
+++ b/codegen/Union.py
@@ -249,7 +249,7 @@ class Union:
                 shape = f"({', '.join(resolved_shape_parts)},)"
                 arguments = f"({arg}, {template}, {shape}, {field_type_access})"
                 field_type_access = "Array"
-            f.write(f"({repr(field_name)}, {field_type_access}, {arguments}, ({optional}, {default}), {True if conditionals else None}),\n\t\t")
+            f.write(f"\n\t\tyield ({repr(field_name)}, {field_type_access}, {arguments}, ({optional}, {default}), {True if conditionals else None})")
 
     def write_filtered_attributes(self, f, condition, target_variable="self"):
         base_indent = "\n\t\t"

--- a/codegen/Union.py
+++ b/codegen/Union.py
@@ -167,7 +167,7 @@ class Union:
         # get the default (or the best guess of it)
         field_type_lower = field_type.lower()
         tag_of_field_type = self.compounds.parser.tag_dict.get(field_type_lower)
-        _, return_type = self.compounds.parser.map_type(field_type, arr1)
+        return_type = self.compounds.parser.map_type(field_type, arr1)
         default_string = self.default_to_value(default_string, field_type)
 
         if arr1:
@@ -207,8 +207,9 @@ class Union:
                                                 arr1, field_type)
 
         # do not init types used before their position in the xml - they are assumed to be circular
-        if field_type in self.compounds.parser.processed_types:
-            f.write(f'\n{base_indent}self.{field_name} = {field_default}')
+        # other option: use it with conditions
+        # if field_type in self.compounds.parser.processed_types:
+        f.write(f'\n{base_indent}self.{field_name} = {field_default}')
 
     def write_attributes(self, f):
         for field in self.members:

--- a/generated/base_struct.py
+++ b/generated/base_struct.py
@@ -166,7 +166,7 @@ class BaseStruct(metaclass=StructMetaClass):
 
     _import_map = ImportMap()
     _import_key = "base_struct"
-    _attribute_list = ()
+    _attribute_list = []
     allow_np = False
 
     def __init__(self, context, arg=0, template=None, set_default=True):

--- a/generated/base_struct.py
+++ b/generated/base_struct.py
@@ -25,86 +25,6 @@ class StructMetaClass(type):
             cls._import_map[dict['_import_key']] = cls
         super().__init__(name, bases, dict, **kwds)
 
-        def free_function(function_name):
-            """Checks if the function is defined"""
-            if function_name in dict:
-                return False
-            else:
-                # not defined in class body allows automatic filling, as long as any parents are also compatible
-                return callable(getattr(cls, function_name, lambda: True))
-
-        # if attribute list is not defined and we have the function to generate it, create it
-        if "_attribute_list" not in dict and not free_function("_get_attribute_list"):
-            cls._attribute_list = tuple(cls._get_attribute_list())
-
-        # check if the class has a non-empty _attribute_list
-        if getattr(cls, "_attribute_list", ()):
-            attribute_list = cls._attribute_list
-            # for convenience, sort the attribute list into continuous lists
-            attr_names, attr_types, _, _, attr_conds = zip(*attribute_list)
-            if all(cond is None for cond in attr_conds) and all(attr_type is not None for attr_type in attr_types):
-                # all fields are static
-                if len(set(attr_types)) == 1:
-                    # every field is the same type, iteration makes sense
-                    if free_function("__len__"):
-                        cls.__len__ = lambda self: len(attribute_list)
-                    if free_function("__iter__"):
-                        def __iter__(self):
-                            yield from (getattr(self, attr_name) for attr_name in attr_names)
-                        cls.__iter__ = __iter__
-                    if free_function("__getitem__"):
-                        def __getitem__(self, key):
-                            if 0 <= key < len(attribute_list):
-                                return getattr(self, attr_names[key])
-                            else:
-                                raise IndexError(f'Index {key} not in {type(self)}')
-                        cls.__getitem__ = __getitem__
-                    if free_function("__setitem__"):
-                        def __setitem__(self, key, value):
-                            if 0 <= key < len(attribute_list):
-                                return setattr(self, attr_names[key], value)
-                            else:
-                                raise IndexError(f'Index {key} not in {type(self)}')
-                        cls.__setitem__ = __setitem__
-                # check if all of the class's attributes have a from_value function
-                if all(callable(getattr(attr_type, "from_value", None)) for attr_type in attr_types):
-                    # since all fields are static and have a from_value function defined, this struct can also have
-                    # from_value defined
-                    if free_function("from_value"):
-                        def from_value(value):
-                            # from_value implies context-independence so pass None as context
-                            instance = cls(None)
-                            for f_name, f_type, value_element in zip(attr_names, attr_types, value):
-                                setattr(instance, f_name, f_type.from_value(value_element))
-                            return instance
-                        cls.from_value = from_value
-            # check if all of the class's attributes have a from_value function
-            if getattr(cls, "allow_np", False) and all(
-                    # check for a struct with get_np_dtype and flag set to True
-                    callable(getattr(attr_type, "get_np_dtype", None)) or
-                    # or a basic numeric type
-                    getattr(attr_type, "np_dtype", None)
-                    for attr_type in attr_types):
-                if free_function("create_array"):
-                    def create_array(shape, default=None, context=None, arg=0, template=None):
-                        np_dtype = cls.get_np_dtype(context, arg, template)
-                        return np.zeros(shape, dtype=np_dtype)
-                    cls.create_array = create_array
-                if free_function("read_array"):
-                    def read_array(stream, shape, context=None, arg=0, template=None):
-                        np_dtype = cls.get_np_dtype(context, arg, template)
-                        array = np.empty(shape, dtype=np_dtype)
-                        stream.readinto(array)
-                        return array
-                    cls.read_array = read_array
-                if free_function("write_array"):
-                    def write_array(instance, stream):
-                        # todo - do type conversion, cf. basic.py
-                        assert isinstance(instance, np.ndarray)
-                        # np_dtype = cls.get_np_dtype(context, arg, template)
-                        stream.write(instance.tobytes())
-                    cls.write_array = write_array
-
 
 def indent(e, level=0):
     i = "\n" + level * "	"
@@ -349,6 +269,89 @@ class BaseStruct(metaclass=StructMetaClass):
             except:
                 logging.error(f"validation failed on field {f_name} on type {cls}")
                 raise
+
+    @classmethod
+    def init_attributes(cls):
+
+        def free_function(function_name):
+            """Checks if the function is defined"""
+            if function_name in cls.__dict__:
+                return False
+            else:
+                # not defined in class body allows automatic filling, as long as any parents are also compatible
+                return callable(getattr(cls, function_name, lambda: True))
+
+        # if attribute list is not defined and we have the function to generate it, create it
+        if "_attribute_list" not in cls.__dict__ and not free_function("_get_attribute_list"):
+            cls._attribute_list = tuple(cls._get_attribute_list())
+
+        # check if the class has a non-empty _attribute_list
+        if getattr(cls, "_attribute_list", ()):
+            attribute_list = cls._attribute_list
+            # for convenience, sort the attribute list into continuous lists
+            attr_names, attr_types, _, _, attr_conds = zip(*attribute_list)
+            if all(cond is None for cond in attr_conds) and all(attr_type is not None for attr_type in attr_types):
+                # all fields are static
+                if len(set(attr_types)) == 1:
+                    # every field is the same type, iteration makes sense
+                    if free_function("__len__"):
+                        cls.__len__ = lambda self: len(attribute_list)
+                    if free_function("__iter__"):
+                        def __iter__(self):
+                            yield from (getattr(self, attr_name) for attr_name in attr_names)
+                        cls.__iter__ = __iter__
+                    if free_function("__getitem__"):
+                        def __getitem__(self, key):
+                            if 0 <= key < len(attribute_list):
+                                return getattr(self, attr_names[key])
+                            else:
+                                raise IndexError(f'Index {key} not in {type(self)}')
+                        cls.__getitem__ = __getitem__
+                    if free_function("__setitem__"):
+                        def __setitem__(self, key, value):
+                            if 0 <= key < len(attribute_list):
+                                return setattr(self, attr_names[key], value)
+                            else:
+                                raise IndexError(f'Index {key} not in {type(self)}')
+                        cls.__setitem__ = __setitem__
+                # check if all of the class's attributes have a from_value function
+                if all(callable(getattr(attr_type, "from_value", None)) for attr_type in attr_types):
+                    # since all fields are static and have a from_value function defined, this struct can also have
+                    # from_value defined
+                    if free_function("from_value"):
+                        def from_value(value):
+                            # from_value implies context-independence so pass None as context
+                            instance = cls(None)
+                            for f_name, f_type, value_element in zip(attr_names, attr_types, value):
+                                setattr(instance, f_name, f_type.from_value(value_element))
+                            return instance
+                        cls.from_value = from_value
+            # check if all of the class's attributes have a from_value function
+            if getattr(cls, "allow_np", False) and all(
+                    # check for a struct with get_np_dtype and flag set to True
+                    callable(getattr(attr_type, "get_np_dtype", None)) or
+                    # or a basic numeric type
+                    getattr(attr_type, "np_dtype", None)
+                    for attr_type in attr_types):
+                if free_function("create_array"):
+                    def create_array(shape, default=None, context=None, arg=0, template=None):
+                        np_dtype = cls.get_np_dtype(context, arg, template)
+                        return np.zeros(shape, dtype=np_dtype)
+                    cls.create_array = create_array
+                if free_function("read_array"):
+                    def read_array(stream, shape, context=None, arg=0, template=None):
+                        np_dtype = cls.get_np_dtype(context, arg, template)
+                        array = np.empty(shape, dtype=np_dtype)
+                        stream.readinto(array)
+                        return array
+                    cls.read_array = read_array
+                if free_function("write_array"):
+                    def write_array(instance, stream):
+                        # todo - do type conversion, cf. basic.py
+                        assert isinstance(instance, np.ndarray)
+                        # np_dtype = cls.get_np_dtype(context, arg, template)
+                        stream.write(instance.tobytes())
+                    cls.write_array = write_array
 
     @classmethod
     def _get_attribute_list(cls):

--- a/generated/base_struct.py
+++ b/generated/base_struct.py
@@ -33,6 +33,10 @@ class StructMetaClass(type):
                 # not defined in class body allows automatic filling, as long as any parents are also compatible
                 return callable(getattr(cls, function_name, lambda: True))
 
+        # if attribute list is not defined and we have the function to generate it, create it
+        if "_attribute_list" not in dict and not free_function("_get_attribute_list"):
+            cls._attribute_list = tuple(cls._get_attribute_list())
+
         # check if the class has a non-empty _attribute_list
         if getattr(cls, "_attribute_list", ()):
             attribute_list = cls._attribute_list
@@ -162,7 +166,7 @@ class BaseStruct(metaclass=StructMetaClass):
 
     _import_map = ImportMap()
     _import_key = "base_struct"
-    _attribute_list = []
+    _attribute_list = ()
     allow_np = False
 
     def __init__(self, context, arg=0, template=None, set_default=True):
@@ -345,6 +349,10 @@ class BaseStruct(metaclass=StructMetaClass):
             except:
                 logging.error(f"validation failed on field {f_name} on type {cls}")
                 raise
+
+    @classmethod
+    def _get_attribute_list(cls):
+        yield from ()
 
     @classmethod
     def _get_filtered_attribute_list(cls, instance, include_abstract=True):

--- a/generated/formats/animalresearch/compounds/PtrList.py
+++ b/generated/formats/animalresearch/compounds/PtrList.py
@@ -16,11 +16,15 @@ class PtrList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, ZString, (instance.arg,), Pointer), (False, None)
+
+
+PtrList.init_attributes()

--- a/generated/formats/animalresearch/compounds/ResearchLevel.py
+++ b/generated/formats/animalresearch/compounds/ResearchLevel.py
@@ -20,13 +20,14 @@ class ResearchLevel(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('level_name', Pointer, (0, ZString), (False, None), None),
-		('next_levels', Pointer, (None, None), (False, None), None),
-		('next_level_count', Uint64, (0, None), (False, None), None),
-		('children', Pointer, (None, None), (False, None), None),
-		('children_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('level_name', Pointer, (0, ZString), (False, None), None)
+		yield ('next_levels', Pointer, (None, None), (False, None), None)
+		yield ('next_level_count', Uint64, (0, None), (False, None), None)
+		yield ('children', Pointer, (None, None), (False, None), None)
+		yield ('children_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class ResearchLevel(MemStruct):
 		yield 'next_level_count', Uint64, (0, None), (False, None)
 		yield 'children', Pointer, (instance.children_count, ResearchLevel._import_map["animalresearch.compounds.PtrList"]), (False, None)
 		yield 'children_count', Uint64, (0, None), (False, None)
+
+
+ResearchLevel.init_attributes()

--- a/generated/formats/animalresearch/compounds/ResearchRoot.py
+++ b/generated/formats/animalresearch/compounds/ResearchRoot.py
@@ -16,13 +16,17 @@ class ResearchRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('levels', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('levels', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'levels', ArrayPointer, (instance.count, ResearchRoot._import_map["animalresearch.compounds.ResearchLevel"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
+
+
+ResearchRoot.init_attributes()

--- a/generated/formats/animalresearch/compounds/ResearchStartRoot.py
+++ b/generated/formats/animalresearch/compounds/ResearchStartRoot.py
@@ -16,13 +16,17 @@ class ResearchStartRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('states', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('states', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'states', ArrayPointer, (instance.count, ResearchStartRoot._import_map["animalresearch.compounds.UnlockState"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
+
+
+ResearchStartRoot.init_attributes()

--- a/generated/formats/animalresearch/compounds/UnlockState.py
+++ b/generated/formats/animalresearch/compounds/UnlockState.py
@@ -16,13 +16,17 @@ class UnlockState(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('entity_name', Pointer, (0, ZString), (False, None), None),
-		('level_name', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('entity_name', Pointer, (0, ZString), (False, None), None)
+		yield ('level_name', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'entity_name', Pointer, (0, ZString), (False, None)
 		yield 'level_name', Pointer, (0, ZString), (False, None)
+
+
+UnlockState.init_attributes()

--- a/generated/formats/assetpkg/compounds/AssetpkgRoot.py
+++ b/generated/formats/assetpkg/compounds/AssetpkgRoot.py
@@ -17,13 +17,17 @@ class AssetpkgRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('asset_path', Pointer, (0, ZString), (False, None), None),
-		('_zero', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('asset_path', Pointer, (0, ZString), (False, None), None)
+		yield ('_zero', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'asset_path', Pointer, (0, ZString), (False, None)
 		yield '_zero', Uint64, (0, None), (False, None)
+
+
+AssetpkgRoot.init_attributes()

--- a/generated/formats/bani/compounds/BaniInfoHeader.py
+++ b/generated/formats/bani/compounds/BaniInfoHeader.py
@@ -29,11 +29,12 @@ class BaniInfoHeader(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('magic', Array, (0, None, (4,), Byte), (False, None), None),
-		('banis_name', ZString, (0, None), (False, None), None),
-		('data', BaniRoot, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('magic', Array, (0, None, (4,), Byte), (False, None), None)
+		yield ('banis_name', ZString, (0, None), (False, None), None)
+		yield ('data', BaniRoot, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class BaniInfoHeader(BaseStruct):
 		yield 'magic', Array, (0, None, (4,), Byte), (False, None)
 		yield 'banis_name', ZString, (0, None), (False, None)
 		yield 'data', BaniRoot, (0, None), (False, None)
+
+
+BaniInfoHeader.init_attributes()

--- a/generated/formats/bani/compounds/BaniRoot.py
+++ b/generated/formats/bani/compounds/BaniRoot.py
@@ -34,13 +34,14 @@ class BaniRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('banis', Pointer, (0, None), (False, None), None),
-		('read_start_frame', Uint, (0, None), (False, None), None),
-		('num_frames', Uint, (0, None), (False, None), None),
-		('animation_length', Float, (0, None), (False, None), None),
-		('loop_flag', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('banis', Pointer, (0, None), (False, None), None)
+		yield ('read_start_frame', Uint, (0, None), (False, None), None)
+		yield ('num_frames', Uint, (0, None), (False, None), None)
+		yield ('animation_length', Float, (0, None), (False, None), None)
+		yield ('loop_flag', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -50,3 +51,6 @@ class BaniRoot(MemStruct):
 		yield 'num_frames', Uint, (0, None), (False, None)
 		yield 'animation_length', Float, (0, None), (False, None)
 		yield 'loop_flag', Uint, (0, None), (False, None)
+
+
+BaniRoot.init_attributes()

--- a/generated/formats/bani/compounds/BanisRoot.py
+++ b/generated/formats/bani/compounds/BanisRoot.py
@@ -40,15 +40,16 @@ class BanisRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('zeros', Array, (0, None, (2,), Uint64), (False, None), None),
-		('bytes_per_frame', Uint, (0, None), (False, None), None),
-		('bytes_per_bone', Uint, (0, None), (False, None), None),
-		('num_frames', Uint, (0, None), (False, None), None),
-		('num_bones', Uint, (0, None), (False, None), None),
-		('loc_scale', Float, (0, None), (False, None), None),
-		('loc_offset', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('zeros', Array, (0, None, (2,), Uint64), (False, None), None)
+		yield ('bytes_per_frame', Uint, (0, None), (False, None), None)
+		yield ('bytes_per_bone', Uint, (0, None), (False, None), None)
+		yield ('num_frames', Uint, (0, None), (False, None), None)
+		yield ('num_bones', Uint, (0, None), (False, None), None)
+		yield ('loc_scale', Float, (0, None), (False, None), None)
+		yield ('loc_offset', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -60,3 +61,6 @@ class BanisRoot(MemStruct):
 		yield 'num_bones', Uint, (0, None), (False, None)
 		yield 'loc_scale', Float, (0, None), (False, None)
 		yield 'loc_offset', Float, (0, None), (False, None)
+
+
+BanisRoot.init_attributes()

--- a/generated/formats/bani/compounds/Key.py
+++ b/generated/formats/bani/compounds/Key.py
@@ -16,13 +16,17 @@ class Key(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('euler', Vector3Short, (0, None), (False, None), None),
-		('translation', Vector3Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('euler', Vector3Short, (0, None), (False, None), None)
+		yield ('translation', Vector3Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'euler', Vector3Short, (0, None), (False, None)
 		yield 'translation', Vector3Ushort, (0, None), (False, None)
+
+
+Key.init_attributes()

--- a/generated/formats/bani/compounds/Vector3.py
+++ b/generated/formats/bani/compounds/Vector3.py
@@ -26,11 +26,12 @@ class Vector3(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class Vector3(BaseStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+Vector3.init_attributes()

--- a/generated/formats/bani/compounds/Vector3Short.py
+++ b/generated/formats/bani/compounds/Vector3Short.py
@@ -26,11 +26,12 @@ class Vector3Short(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('x', Short, (0, None), (False, None), None),
-		('y', Short, (0, None), (False, None), None),
-		('z', Short, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Short, (0, None), (False, None), None)
+		yield ('y', Short, (0, None), (False, None), None)
+		yield ('z', Short, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class Vector3Short(BaseStruct):
 		yield 'x', Short, (0, None), (False, None)
 		yield 'y', Short, (0, None), (False, None)
 		yield 'z', Short, (0, None), (False, None)
+
+
+Vector3Short.init_attributes()

--- a/generated/formats/bani/compounds/Vector3Ushort.py
+++ b/generated/formats/bani/compounds/Vector3Ushort.py
@@ -26,11 +26,12 @@ class Vector3Ushort(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('x', Ushort, (0, None), (False, None), None),
-		('y', Ushort, (0, None), (False, None), None),
-		('z', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Ushort, (0, None), (False, None), None)
+		yield ('y', Ushort, (0, None), (False, None), None)
+		yield ('z', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class Vector3Ushort(BaseStruct):
 		yield 'x', Ushort, (0, None), (False, None)
 		yield 'y', Ushort, (0, None), (False, None)
 		yield 'z', Ushort, (0, None), (False, None)
+
+
+Vector3Ushort.init_attributes()

--- a/generated/formats/bani/compounds/Vector4.py
+++ b/generated/formats/bani/compounds/Vector4.py
@@ -29,12 +29,13 @@ class Vector4(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('w', Float, (0, None), (False, None), None),
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('w', Float, (0, None), (False, None), None)
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -43,3 +44,6 @@ class Vector4(BaseStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+Vector4.init_attributes()

--- a/generated/formats/base/compounds/FixedString.py
+++ b/generated/formats/base/compounds/FixedString.py
@@ -11,8 +11,9 @@ class FixedString(BaseStruct):
 
 	_import_key = 'base.compounds.FixedString'
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class FixedString(BaseStruct):
 	@staticmethod
 	def get_size(instance, context, arg=0, template=None):
 		return len(instance.data)
+
+
+FixedString.init_attributes()

--- a/generated/formats/base/compounds/PadAlign.py
+++ b/generated/formats/base/compounds/PadAlign.py
@@ -29,8 +29,9 @@ class PadAlign(BaseStruct):
 
 	_import_key = 'base.compounds.PadAlign'
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -62,3 +63,6 @@ class PadAlign(BaseStruct):
 		# position: instance.io_start
 		return get_padding_size(instance.io_start - instance.template.io_start, alignment=instance.arg)
 
+
+
+PadAlign.init_attributes()

--- a/generated/formats/base/compounds/ZStringBuffer.py
+++ b/generated/formats/base/compounds/ZStringBuffer.py
@@ -20,8 +20,9 @@ class ZStringBuffer(BaseStruct):
 
 	_import_key = 'base.compounds.ZStringBuffer'
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -93,3 +94,6 @@ class ZStringBuffer(BaseStruct):
 	def get_size(cls, instance, context, arg=0, template=None):
 		return len(instance.data)
 
+
+
+ZStringBuffer.init_attributes()

--- a/generated/formats/bnk/compounds/AkBankSourceData.py
+++ b/generated/formats/bnk/compounds/AkBankSourceData.py
@@ -18,11 +18,12 @@ class AkBankSourceData(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('ul_plugin_i_d', Uint, (0, None), (False, None), None),
-		('stream_type', Ubyte, (0, None), (False, None), None),
-		('ak_media_information', AkMediaInformation, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ul_plugin_i_d', Uint, (0, None), (False, None), None)
+		yield ('stream_type', Ubyte, (0, None), (False, None), None)
+		yield ('ak_media_information', AkMediaInformation, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -30,3 +31,6 @@ class AkBankSourceData(BaseStruct):
 		yield 'ul_plugin_i_d', Uint, (0, None), (False, None)
 		yield 'stream_type', Ubyte, (0, None), (False, None)
 		yield 'ak_media_information', AkMediaInformation, (0, None), (False, None)
+
+
+AkBankSourceData.init_attributes()

--- a/generated/formats/bnk/compounds/AkMediaInformation.py
+++ b/generated/formats/bnk/compounds/AkMediaInformation.py
@@ -17,11 +17,12 @@ class AkMediaInformation(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('source_i_d', Uint, (0, None), (False, None), None),
-		('u_in_memory_media_size', Uint, (0, None), (False, None), None),
-		('u_source_bits', Ubyte, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('source_i_d', Uint, (0, None), (False, None), None)
+		yield ('u_in_memory_media_size', Uint, (0, None), (False, None), None)
+		yield ('u_source_bits', Ubyte, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -29,3 +30,6 @@ class AkMediaInformation(BaseStruct):
 		yield 'source_i_d', Uint, (0, None), (False, None)
 		yield 'u_in_memory_media_size', Uint, (0, None), (False, None)
 		yield 'u_source_bits', Ubyte, (0, None), (False, None)
+
+
+AkMediaInformation.init_attributes()

--- a/generated/formats/bnk/compounds/AkTrackSrcInfo.py
+++ b/generated/formats/bnk/compounds/AkTrackSrcInfo.py
@@ -21,15 +21,16 @@ class AkTrackSrcInfo(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('track_i_d', Uint, (0, None), (False, None), None),
-		('source_i_d', Uint, (0, None), (False, None), None),
-		('event_i_d', Uint, (0, None), (False, None), None),
-		('f_play_at', Double, (0, None), (False, None), None),
-		('f_begin_trim_offset', Double, (0, None), (False, None), None),
-		('f_end_trim_offset', Double, (0, None), (False, None), None),
-		('f_src_duration', Double, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('track_i_d', Uint, (0, None), (False, None), None)
+		yield ('source_i_d', Uint, (0, None), (False, None), None)
+		yield ('event_i_d', Uint, (0, None), (False, None), None)
+		yield ('f_play_at', Double, (0, None), (False, None), None)
+		yield ('f_begin_trim_offset', Double, (0, None), (False, None), None)
+		yield ('f_end_trim_offset', Double, (0, None), (False, None), None)
+		yield ('f_src_duration', Double, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class AkTrackSrcInfo(BaseStruct):
 		yield 'f_begin_trim_offset', Double, (0, None), (False, None)
 		yield 'f_end_trim_offset', Double, (0, None), (False, None)
 		yield 'f_src_duration', Double, (0, None), (False, None)
+
+
+AkTrackSrcInfo.init_attributes()

--- a/generated/formats/bnk/compounds/BKHDSection.py
+++ b/generated/formats/bnk/compounds/BKHDSection.py
@@ -32,16 +32,17 @@ class BKHDSection(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('length', Uint, (0, None), (False, None), None),
-		('version', Uint, (0, None), (False, None), None),
-		('id_a', Uint, (0, None), (False, None), None),
-		('id_b', Uint, (0, None), (False, None), None),
-		('constant_a', Uint, (0, None), (False, None), None),
-		('constant_b', Uint, (0, None), (False, None), None),
-		('unk', Uint, (0, None), (False, None), None),
-		('zeroes', Array, (0, None, (None,), Ubyte), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('length', Uint, (0, None), (False, None), None)
+		yield ('version', Uint, (0, None), (False, None), None)
+		yield ('id_a', Uint, (0, None), (False, None), None)
+		yield ('id_b', Uint, (0, None), (False, None), None)
+		yield ('constant_a', Uint, (0, None), (False, None), None)
+		yield ('constant_b', Uint, (0, None), (False, None), None)
+		yield ('unk', Uint, (0, None), (False, None), None)
+		yield ('zeroes', Array, (0, None, (None,), Ubyte), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -54,3 +55,6 @@ class BKHDSection(BaseStruct):
 		yield 'constant_b', Uint, (0, None), (False, None)
 		yield 'unk', Uint, (0, None), (False, None)
 		yield 'zeroes', Array, (0, None, (instance.length - 24,), Ubyte), (False, None)
+
+
+BKHDSection.init_attributes()

--- a/generated/formats/bnk/compounds/BnkBufferData.py
+++ b/generated/formats/bnk/compounds/BnkBufferData.py
@@ -52,18 +52,19 @@ class BnkBufferData(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('size_b', Uint64, (0, None), (False, None), None),
-		('external_aux_b_count', Uint, (0, None), (False, None), None),
-		('total_aux_count', Uint, (0, None), (False, None), None),
-		('streams_count', Uint, (0, None), (False, None), None),
-		('zeros', Array, (0, None, (7,), Uint), (False, None), None),
-		('zeros_per_buffer', Array, (0, None, (None, 2,), Uint64), (False, None), None),
-		('streams', Array, (0, None, (None,), StreamInfo), (False, None), None),
-		('name', ZString, (0, None), (False, None), None),
-		('external_b_suffix', ZString, (0, None), (False, None), True),
-		('external_s_suffix', ZString, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('size_b', Uint64, (0, None), (False, None), None)
+		yield ('external_aux_b_count', Uint, (0, None), (False, None), None)
+		yield ('total_aux_count', Uint, (0, None), (False, None), None)
+		yield ('streams_count', Uint, (0, None), (False, None), None)
+		yield ('zeros', Array, (0, None, (7,), Uint), (False, None), None)
+		yield ('zeros_per_buffer', Array, (0, None, (None, 2,), Uint64), (False, None), None)
+		yield ('streams', Array, (0, None, (None,), StreamInfo), (False, None), None)
+		yield ('name', ZString, (0, None), (False, None), None)
+		yield ('external_b_suffix', ZString, (0, None), (False, None), True)
+		yield ('external_s_suffix', ZString, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -80,3 +81,6 @@ class BnkBufferData(BaseStruct):
 			yield 'external_b_suffix', ZString, (0, None), (False, None)
 		if instance.streams_count:
 			yield 'external_s_suffix', ZString, (0, None), (False, None)
+
+
+BnkBufferData.init_attributes()

--- a/generated/formats/bnk/compounds/BnkFileContainer.py
+++ b/generated/formats/bnk/compounds/BnkFileContainer.py
@@ -18,11 +18,15 @@ class BnkFileContainer(GenericHeader):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = GenericHeader._attribute_list + [
-		('bnk_header', BnkBufferData, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('bnk_header', BnkBufferData, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'bnk_header', BnkBufferData, (0, None), (False, None)
+
+
+BnkFileContainer.init_attributes()

--- a/generated/formats/bnk/compounds/DATASection.py
+++ b/generated/formats/bnk/compounds/DATASection.py
@@ -24,13 +24,17 @@ class DATASection(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('length', Uint, (0, None), (False, None), None),
-		('wem_datas', Array, (0, None, (None,), Byte), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('length', Uint, (0, None), (False, None), None)
+		yield ('wem_datas', Array, (0, None, (None,), Byte), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'length', Uint, (0, None), (False, None)
 		yield 'wem_datas', Array, (0, None, (instance.length,), Byte), (False, None)
+
+
+DATASection.init_attributes()

--- a/generated/formats/bnk/compounds/DIDXSection.py
+++ b/generated/formats/bnk/compounds/DIDXSection.py
@@ -23,13 +23,17 @@ class DIDXSection(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('length', Uint, (0, None), (False, None), None),
-		('data_pointers', Array, (0, None, (None,), DataPointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('length', Uint, (0, None), (False, None), None)
+		yield ('data_pointers', Array, (0, None, (None,), DataPointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'length', Uint, (0, None), (False, None)
 		yield 'data_pointers', Array, (0, None, (int(instance.length / 12),), DataPointer), (False, None)
+
+
+DIDXSection.init_attributes()

--- a/generated/formats/bnk/compounds/DataPointer.py
+++ b/generated/formats/bnk/compounds/DataPointer.py
@@ -24,11 +24,12 @@ class DataPointer(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('wem_id', Uint, (0, None), (False, None), None),
-		('data_section_offset', Uint, (0, None), (False, None), None),
-		('wem_filesize', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('wem_id', Uint, (0, None), (False, None), None)
+		yield ('data_section_offset', Uint, (0, None), (False, None), None)
+		yield ('wem_filesize', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class DataPointer(BaseStruct):
 		yield 'wem_id', Uint, (0, None), (False, None)
 		yield 'data_section_offset', Uint, (0, None), (False, None)
 		yield 'wem_filesize', Uint, (0, None), (False, None)
+
+
+DataPointer.init_attributes()

--- a/generated/formats/bnk/compounds/HIRCSection.py
+++ b/generated/formats/bnk/compounds/HIRCSection.py
@@ -24,11 +24,12 @@ class HIRCSection(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('length', Uint, (0, None), (False, None), None),
-		('count', Uint, (0, None), (False, None), None),
-		('hirc_pointers', Array, (0, None, (None,), HircPointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('length', Uint, (0, None), (False, None), None)
+		yield ('count', Uint, (0, None), (False, None), None)
+		yield ('hirc_pointers', Array, (0, None, (None,), HircPointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class HIRCSection(BaseStruct):
 		yield 'length', Uint, (0, None), (False, None)
 		yield 'count', Uint, (0, None), (False, None)
 		yield 'hirc_pointers', Array, (0, None, (instance.count,), HircPointer), (False, None)
+
+
+HIRCSection.init_attributes()

--- a/generated/formats/bnk/compounds/HircPointer.py
+++ b/generated/formats/bnk/compounds/HircPointer.py
@@ -18,12 +18,13 @@ class HircPointer(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('id', HircType, (0, None), (False, None), None),
-		('data', SoundSfxVoice, (0, None), (False, None), True),
-		('data', MusicTrack, (0, None), (False, None), True),
-		('data', TypeOther, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('id', HircType, (0, None), (False, None), None)
+		yield ('data', SoundSfxVoice, (0, None), (False, None), True)
+		yield ('data', MusicTrack, (0, None), (False, None), True)
+		yield ('data', TypeOther, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -35,3 +36,6 @@ class HircPointer(BaseStruct):
 			yield 'data', MusicTrack, (0, None), (False, None)
 		if (instance.id != 2) and (instance.id != 11):
 			yield 'data', TypeOther, (0, None), (False, None)
+
+
+HircPointer.init_attributes()

--- a/generated/formats/bnk/compounds/MusicTrack.py
+++ b/generated/formats/bnk/compounds/MusicTrack.py
@@ -19,11 +19,12 @@ class MusicTrack(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('length', Uint, (0, None), (False, None), None),
-		('id', Uint, (0, None), (False, None), None),
-		('data', MusicTrackInitialValues, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('length', Uint, (0, None), (False, None), None)
+		yield ('id', Uint, (0, None), (False, None), None)
+		yield ('data', MusicTrackInitialValues, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -31,3 +32,6 @@ class MusicTrack(BaseStruct):
 		yield 'length', Uint, (0, None), (False, None)
 		yield 'id', Uint, (0, None), (False, None)
 		yield 'data', MusicTrackInitialValues, (0, None), (False, None)
+
+
+MusicTrack.init_attributes()

--- a/generated/formats/bnk/compounds/MusicTrackInitialValues.py
+++ b/generated/formats/bnk/compounds/MusicTrackInitialValues.py
@@ -31,19 +31,20 @@ class MusicTrackInitialValues(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('u_flags', Ubyte, (0, None), (False, None), None),
-		('num_sources', Uint, (0, None), (False, None), None),
-		('p_source', Array, (0, None, (None,), AkBankSourceData), (False, None), None),
-		('num_playlist_item', Uint, (0, None), (False, None), None),
-		('p_playlist', Array, (0, None, (None,), AkTrackSrcInfo), (False, None), None),
-		('num_sub_track', Uint, (0, None), (False, None), None),
-		('num_clip_automation_item', Uint, (0, None), (False, None), None),
-		('p_items', Array, (0, None, (None,), Uint), (False, None), None),
-		('node_base_params', NodeBaseParams, (0, None), (False, None), None),
-		('e_track_type', Ubyte, (0, None), (False, None), None),
-		('i_look_ahead_time', Int, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('u_flags', Ubyte, (0, None), (False, None), None)
+		yield ('num_sources', Uint, (0, None), (False, None), None)
+		yield ('p_source', Array, (0, None, (None,), AkBankSourceData), (False, None), None)
+		yield ('num_playlist_item', Uint, (0, None), (False, None), None)
+		yield ('p_playlist', Array, (0, None, (None,), AkTrackSrcInfo), (False, None), None)
+		yield ('num_sub_track', Uint, (0, None), (False, None), None)
+		yield ('num_clip_automation_item', Uint, (0, None), (False, None), None)
+		yield ('p_items', Array, (0, None, (None,), Uint), (False, None), None)
+		yield ('node_base_params', NodeBaseParams, (0, None), (False, None), None)
+		yield ('e_track_type', Ubyte, (0, None), (False, None), None)
+		yield ('i_look_ahead_time', Int, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -59,3 +60,6 @@ class MusicTrackInitialValues(BaseStruct):
 		yield 'node_base_params', NodeBaseParams, (0, None), (False, None)
 		yield 'e_track_type', Ubyte, (0, None), (False, None)
 		yield 'i_look_ahead_time', Int, (0, None), (False, None)
+
+
+MusicTrackInitialValues.init_attributes()

--- a/generated/formats/bnk/compounds/NodeBaseParams.py
+++ b/generated/formats/bnk/compounds/NodeBaseParams.py
@@ -16,11 +16,15 @@ class NodeBaseParams(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('raw', Array, (0, None, (30,), Byte), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('raw', Array, (0, None, (30,), Byte), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'raw', Array, (0, None, (30,), Byte), (False, None)
+
+
+NodeBaseParams.init_attributes()

--- a/generated/formats/bnk/compounds/SoundSfxVoice.py
+++ b/generated/formats/bnk/compounds/SoundSfxVoice.py
@@ -37,15 +37,16 @@ class SoundSfxVoice(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('length', Uint, (0, None), (False, None), None),
-		('id', Uint, (0, None), (False, None), None),
-		('const_a', Uint, (0, None), (False, None), None),
-		('const_b', Byte, (0, None), (False, None), None),
-		('didx_id', Uint, (0, None), (False, None), None),
-		('wem_length', Uint, (0, None), (False, None), None),
-		('extra', Array, (0, None, (None,), Byte), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('length', Uint, (0, None), (False, None), None)
+		yield ('id', Uint, (0, None), (False, None), None)
+		yield ('const_a', Uint, (0, None), (False, None), None)
+		yield ('const_b', Byte, (0, None), (False, None), None)
+		yield ('didx_id', Uint, (0, None), (False, None), None)
+		yield ('wem_length', Uint, (0, None), (False, None), None)
+		yield ('extra', Array, (0, None, (None,), Byte), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -57,3 +58,6 @@ class SoundSfxVoice(BaseStruct):
 		yield 'didx_id', Uint, (0, None), (False, None)
 		yield 'wem_length', Uint, (0, None), (False, None)
 		yield 'extra', Array, (0, None, (instance.length - 17,), Byte), (False, None)
+
+
+SoundSfxVoice.init_attributes()

--- a/generated/formats/bnk/compounds/StreamInfo.py
+++ b/generated/formats/bnk/compounds/StreamInfo.py
@@ -24,12 +24,13 @@ class StreamInfo(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('offset', Uint64, (0, None), (False, None), None),
-		('size', Uint64, (0, None), (False, None), None),
-		('event_id', Uint, (0, None), (False, None), None),
-		('zero', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('offset', Uint64, (0, None), (False, None), None)
+		yield ('size', Uint64, (0, None), (False, None), None)
+		yield ('event_id', Uint, (0, None), (False, None), None)
+		yield ('zero', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class StreamInfo(BaseStruct):
 		yield 'size', Uint64, (0, None), (False, None)
 		yield 'event_id', Uint, (0, None), (False, None)
 		yield 'zero', Uint, (0, None), (False, None)
+
+
+StreamInfo.init_attributes()

--- a/generated/formats/bnk/compounds/TypeOther.py
+++ b/generated/formats/bnk/compounds/TypeOther.py
@@ -26,13 +26,17 @@ class TypeOther(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('length', Uint, (0, None), (False, None), None),
-		('raw', Array, (0, None, (None,), Byte), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('length', Uint, (0, None), (False, None), None)
+		yield ('raw', Array, (0, None, (None,), Byte), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'length', Uint, (0, None), (False, None)
 		yield 'raw', Array, (0, None, (instance.length,), Byte), (False, None)
+
+
+TypeOther.init_attributes()

--- a/generated/formats/brush/compounds/BrushRoot.py
+++ b/generated/formats/brush/compounds/BrushRoot.py
@@ -22,12 +22,13 @@ class BrushRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('_zero', Uint64, (0, None), (False, None), None),
-		('num_pixels', Uint64, (0, None), (False, None), None),
-		('x', Uint, (0, None), (False, None), None),
-		('y', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('_zero', Uint64, (0, None), (False, None), None)
+		yield ('num_pixels', Uint64, (0, None), (False, None), None)
+		yield ('x', Uint, (0, None), (False, None), None)
+		yield ('y', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class BrushRoot(MemStruct):
 		yield 'num_pixels', Uint64, (0, None), (False, None)
 		yield 'x', Uint, (0, None), (False, None)
 		yield 'y', Uint, (0, None), (False, None)
+
+
+BrushRoot.init_attributes()

--- a/generated/formats/buildingset/compounds/BuildingSetRoot.py
+++ b/generated/formats/buildingset/compounds/BuildingSetRoot.py
@@ -19,12 +19,13 @@ class BuildingSetRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('set_id_name', Pointer, (0, ZStringObfuscated), (False, None), None),
-		('set_count_or_type', Uint64, (0, None), (False, None), None),
-		('unk_1_found_as_0', Uint64, (0, None), (False, None), None),
-		('unk_2_found_as_0', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('set_id_name', Pointer, (0, ZStringObfuscated), (False, None), None)
+		yield ('set_count_or_type', Uint64, (0, None), (False, None), None)
+		yield ('unk_1_found_as_0', Uint64, (0, None), (False, None), None)
+		yield ('unk_2_found_as_0', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -33,3 +34,6 @@ class BuildingSetRoot(MemStruct):
 		yield 'set_count_or_type', Uint64, (0, None), (False, None)
 		yield 'unk_1_found_as_0', Uint64, (0, None), (False, None)
 		yield 'unk_2_found_as_0', Uint64, (0, None), (False, None)
+
+
+BuildingSetRoot.init_attributes()

--- a/generated/formats/cinematic/compounds/CinematicData.py
+++ b/generated/formats/cinematic/compounds/CinematicData.py
@@ -19,11 +19,12 @@ class CinematicData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('default_name', Pointer, (0, ZString), (False, None), None),
-		('next_levels', ArrayPointer, (None, None), (False, None), None),
-		('next_level_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('default_name', Pointer, (0, ZString), (False, None), None)
+		yield ('next_levels', ArrayPointer, (None, None), (False, None), None)
+		yield ('next_level_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -31,3 +32,6 @@ class CinematicData(MemStruct):
 		yield 'default_name', Pointer, (0, ZString), (False, None)
 		yield 'next_levels', ArrayPointer, (instance.next_level_count, CinematicData._import_map["cinematic.compounds.State"]), (False, None)
 		yield 'next_level_count', Uint64, (0, None), (False, None)
+
+
+CinematicData.init_attributes()

--- a/generated/formats/cinematic/compounds/CinematicRoot.py
+++ b/generated/formats/cinematic/compounds/CinematicRoot.py
@@ -17,11 +17,12 @@ class CinematicRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('u_0', Uint64, (0, None), (False, None), None),
-		('u_1', Uint64, (0, None), (False, None), None),
-		('data', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('u_0', Uint64, (0, None), (False, None), None)
+		yield ('u_1', Uint64, (0, None), (False, None), None)
+		yield ('data', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -29,3 +30,6 @@ class CinematicRoot(MemStruct):
 		yield 'u_0', Uint64, (0, None), (False, None)
 		yield 'u_1', Uint64, (0, None), (False, None)
 		yield 'data', Pointer, (0, CinematicRoot._import_map["cinematic.compounds.CinematicData"]), (False, None)
+
+
+CinematicRoot.init_attributes()

--- a/generated/formats/cinematic/compounds/Event.py
+++ b/generated/formats/cinematic/compounds/Event.py
@@ -25,14 +25,15 @@ class Event(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('start_time', Float, (0, None), (False, None), None),
-		('b', Float, (0, None), (False, None), None),
-		('module_name', Pointer, (0, ZString), (False, None), None),
-		('attributes', Pointer, (0, None), (False, None), None),
-		('duration', Float, (0, None), (False, None), None),
-		('d', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('start_time', Float, (0, None), (False, None), None)
+		yield ('b', Float, (0, None), (False, None), None)
+		yield ('module_name', Pointer, (0, ZString), (False, None), None)
+		yield ('attributes', Pointer, (0, None), (False, None), None)
+		yield ('duration', Float, (0, None), (False, None), None)
+		yield ('d', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -43,3 +44,6 @@ class Event(MemStruct):
 		yield 'attributes', Pointer, (0, Event._import_map["cinematic.compounds.EventAttributes"]), (False, None)
 		yield 'duration', Float, (0, None), (False, None)
 		yield 'd', Float, (0, None), (False, None)
+
+
+Event.init_attributes()

--- a/generated/formats/cinematic/compounds/EventAttributes.py
+++ b/generated/formats/cinematic/compounds/EventAttributes.py
@@ -21,11 +21,12 @@ class EventAttributes(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('anim_name', Pointer, (0, ZString), (False, None), None),
-		('event_name', Pointer, (0, ZString), (False, None), None),
-		('empty_string', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('anim_name', Pointer, (0, ZString), (False, None), None)
+		yield ('event_name', Pointer, (0, ZString), (False, None), None)
+		yield ('empty_string', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -33,3 +34,6 @@ class EventAttributes(MemStruct):
 		yield 'anim_name', Pointer, (0, ZString), (False, None)
 		yield 'event_name', Pointer, (0, ZString), (False, None)
 		yield 'empty_string', Pointer, (0, ZString), (False, None)
+
+
+EventAttributes.init_attributes()

--- a/generated/formats/cinematic/compounds/EventsList.py
+++ b/generated/formats/cinematic/compounds/EventsList.py
@@ -16,13 +16,17 @@ class EventsList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('events', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('events', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'events', ArrayPointer, (instance.count, EventsList._import_map["cinematic.compounds.Event"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
+
+
+EventsList.init_attributes()

--- a/generated/formats/cinematic/compounds/State.py
+++ b/generated/formats/cinematic/compounds/State.py
@@ -27,16 +27,17 @@ class State(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('abstract_name', Pointer, (0, ZString), (False, None), None),
-		('concrete_name', Pointer, (0, ZString), (False, None), None),
-		('prefab_name', Pointer, (0, ZString), (False, None), None),
-		('a', Uint64, (0, None), (False, None), None),
-		('b', Uint64, (0, None), (False, None), None),
-		('c', Uint64, (0, None), (False, None), None),
-		('events_list', Pointer, (0, None), (False, None), None),
-		('d', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('abstract_name', Pointer, (0, ZString), (False, None), None)
+		yield ('concrete_name', Pointer, (0, ZString), (False, None), None)
+		yield ('prefab_name', Pointer, (0, ZString), (False, None), None)
+		yield ('a', Uint64, (0, None), (False, None), None)
+		yield ('b', Uint64, (0, None), (False, None), None)
+		yield ('c', Uint64, (0, None), (False, None), None)
+		yield ('events_list', Pointer, (0, None), (False, None), None)
+		yield ('d', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -49,3 +50,6 @@ class State(MemStruct):
 		yield 'c', Uint64, (0, None), (False, None)
 		yield 'events_list', Pointer, (0, State._import_map["cinematic.compounds.EventsList"]), (False, None)
 		yield 'd', Uint64, (0, None), (False, None)
+
+
+State.init_attributes()

--- a/generated/formats/curve/compounds/CurveRoot.py
+++ b/generated/formats/curve/compounds/CurveRoot.py
@@ -16,13 +16,17 @@ class CurveRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('keys', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('keys', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'keys', ArrayPointer, (instance.count, CurveRoot._import_map["curve.compounds.Key"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
+
+
+CurveRoot.init_attributes()

--- a/generated/formats/curve/compounds/Key.py
+++ b/generated/formats/curve/compounds/Key.py
@@ -15,13 +15,17 @@ class Key(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('time', Float, (0, None), (False, None), None),
-		('value', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('time', Float, (0, None), (False, None), None)
+		yield ('value', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'time', Float, (0, None), (False, None)
 		yield 'value', Float, (0, None), (False, None)
+
+
+Key.init_attributes()

--- a/generated/formats/dds/structs/Dxt10Header.py
+++ b/generated/formats/dds/structs/Dxt10Header.py
@@ -20,13 +20,14 @@ class Dxt10Header(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('dxgi_format', DxgiFormat, (0, None), (False, None), None),
-		('resource_dimension', D3D10ResourceDimension, (0, None), (False, None), None),
-		('misc_flag', Uint, (0, None), (False, None), None),
-		('num_tiles', Uint, (0, None), (False, 1), None),
-		('misc_flag_2', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('dxgi_format', DxgiFormat, (0, None), (False, None), None)
+		yield ('resource_dimension', D3D10ResourceDimension, (0, None), (False, None), None)
+		yield ('misc_flag', Uint, (0, None), (False, None), None)
+		yield ('num_tiles', Uint, (0, None), (False, 1), None)
+		yield ('misc_flag_2', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class Dxt10Header(BaseStruct):
 		yield 'misc_flag', Uint, (0, None), (False, None)
 		yield 'num_tiles', Uint, (0, None), (False, 1)
 		yield 'misc_flag_2', Uint, (0, None), (False, None)
+
+
+Dxt10Header.init_attributes()

--- a/generated/formats/dds/structs/Header.py
+++ b/generated/formats/dds/structs/Header.py
@@ -45,24 +45,25 @@ class Header(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('header_string', FixedString, (4, None), (False, None), None),
-		('size', Uint, (0, None), (False, 124), None),
-		('flags', HeaderFlags, (0, None), (False, None), None),
-		('height', Uint, (0, None), (False, None), None),
-		('width', Uint, (0, None), (False, None), None),
-		('linear_size', Uint, (0, None), (False, None), None),
-		('depth', Uint, (0, None), (False, 1), None),
-		('mipmap_count', Uint, (0, None), (False, None), None),
-		('reserved_1', Array, (0, None, (11,), Uint), (False, None), None),
-		('pixel_format', PixelFormat, (0, None), (False, None), None),
-		('caps_1', Caps1, (0, None), (False, None), None),
-		('caps_2', Caps2, (0, None), (False, None), None),
-		('caps_3', Uint, (0, None), (False, None), None),
-		('caps_4', Uint, (0, None), (False, None), None),
-		('unused', Uint, (0, None), (False, None), None),
-		('dx_10', Dxt10Header, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('header_string', FixedString, (4, None), (False, None), None)
+		yield ('size', Uint, (0, None), (False, 124), None)
+		yield ('flags', HeaderFlags, (0, None), (False, None), None)
+		yield ('height', Uint, (0, None), (False, None), None)
+		yield ('width', Uint, (0, None), (False, None), None)
+		yield ('linear_size', Uint, (0, None), (False, None), None)
+		yield ('depth', Uint, (0, None), (False, 1), None)
+		yield ('mipmap_count', Uint, (0, None), (False, None), None)
+		yield ('reserved_1', Array, (0, None, (11,), Uint), (False, None), None)
+		yield ('pixel_format', PixelFormat, (0, None), (False, None), None)
+		yield ('caps_1', Caps1, (0, None), (False, None), None)
+		yield ('caps_2', Caps2, (0, None), (False, None), None)
+		yield ('caps_3', Uint, (0, None), (False, None), None)
+		yield ('caps_4', Uint, (0, None), (False, None), None)
+		yield ('unused', Uint, (0, None), (False, None), None)
+		yield ('dx_10', Dxt10Header, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -84,3 +85,6 @@ class Header(BaseStruct):
 		yield 'unused', Uint, (0, None), (False, None)
 		if instance.pixel_format.four_c_c == 808540228:
 			yield 'dx_10', Dxt10Header, (0, None), (False, None)
+
+
+Header.init_attributes()

--- a/generated/formats/dds/structs/PixelFormat.py
+++ b/generated/formats/dds/structs/PixelFormat.py
@@ -42,16 +42,17 @@ class PixelFormat(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('size', Uint, (0, None), (False, 32), None),
-		('flags', PixelFormatFlags, (0, None), (False, None), None),
-		('four_c_c', FourCC, (0, None), (False, None), None),
-		('bit_count', Uint, (0, None), (False, None), None),
-		('r_mask', Uint, (0, None), (False, None), None),
-		('g_mask', Uint, (0, None), (False, None), None),
-		('b_mask', Uint, (0, None), (False, None), None),
-		('a_mask', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('size', Uint, (0, None), (False, 32), None)
+		yield ('flags', PixelFormatFlags, (0, None), (False, None), None)
+		yield ('four_c_c', FourCC, (0, None), (False, None), None)
+		yield ('bit_count', Uint, (0, None), (False, None), None)
+		yield ('r_mask', Uint, (0, None), (False, None), None)
+		yield ('g_mask', Uint, (0, None), (False, None), None)
+		yield ('b_mask', Uint, (0, None), (False, None), None)
+		yield ('a_mask', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -64,3 +65,6 @@ class PixelFormat(BaseStruct):
 		yield 'g_mask', Uint, (0, None), (False, None)
 		yield 'b_mask', Uint, (0, None), (False, None)
 		yield 'a_mask', Uint, (0, None), (False, None)
+
+
+PixelFormat.init_attributes()

--- a/generated/formats/decalsettings/compounds/DecalSettingItem.py
+++ b/generated/formats/decalsettings/compounds/DecalSettingItem.py
@@ -15,11 +15,15 @@ class DecalSettingItem(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('layer_name', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('layer_name', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'layer_name', Pointer, (0, ZString), (False, None)
+
+
+DecalSettingItem.init_attributes()

--- a/generated/formats/decalsettings/compounds/DecalSettingsRoot.py
+++ b/generated/formats/decalsettings/compounds/DecalSettingsRoot.py
@@ -20,12 +20,13 @@ class DecalSettingsRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('atlas_name', Pointer, (0, ZString), (False, None), None),
-		('layer_list', ArrayPointer, (None, None), (False, None), None),
-		('layer_count', Uint64, (0, None), (False, None), None),
-		('unknown', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('atlas_name', Pointer, (0, ZString), (False, None), None)
+		yield ('layer_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('layer_count', Uint64, (0, None), (False, None), None)
+		yield ('unknown', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -34,3 +35,6 @@ class DecalSettingsRoot(MemStruct):
 		yield 'layer_list', ArrayPointer, (instance.layer_count, DecalSettingsRoot._import_map["decalsettings.compounds.DecalSettingItem"]), (False, None)
 		yield 'layer_count', Uint64, (0, None), (False, None)
 		yield 'unknown', Uint64, (0, None), (False, None)
+
+
+DecalSettingsRoot.init_attributes()

--- a/generated/formats/dinosaurmaterialvariants/compounds/DinoEffectsHeader.py
+++ b/generated/formats/dinosaurmaterialvariants/compounds/DinoEffectsHeader.py
@@ -41,30 +41,31 @@ class DinoEffectsHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('fgm_name', Pointer, (0, ZStringObfuscated), (False, None), None),
-		('vec_0', Vector3F, (0, None), (False, None), None),
-		('vec_1', Vector3F, (0, None), (False, None), None),
-		('a', Uint, (0, None), (False, None), None),
-		('b', Uint, (0, None), (False, None), None),
-		('vec_2', Vector3F, (0, None), (False, None), None),
-		('vec_3', Vector3F, (0, None), (False, None), None),
-		('vec_4', Vector3F, (0, None), (False, None), None),
-		('vec_5', Vector3F, (0, None), (False, None), None),
-		('c', Uint, (0, None), (False, None), None),
-		('d', Uint, (0, None), (False, None), None),
-		('floats_1', Array, (0, None, (2,), Float), (False, None), None),
-		('e', Uint, (0, None), (False, None), None),
-		('floats_2', Array, (0, None, (2,), Float), (False, None), None),
-		('f', Uint, (0, None), (False, None), None),
-		('floats_3', Array, (0, None, (8,), Float), (False, None), None),
-		('g', Uint, (0, None), (False, None), None),
-		('floats_4', Array, (0, None, (6,), Float), (False, None), None),
-		('h', Uint, (0, None), (False, None), None),
-		('floats_5', Array, (0, None, (20,), Float), (False, None), None),
-		('i', Uint, (0, None), (False, None), None),
-		('float', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('fgm_name', Pointer, (0, ZStringObfuscated), (False, None), None)
+		yield ('vec_0', Vector3F, (0, None), (False, None), None)
+		yield ('vec_1', Vector3F, (0, None), (False, None), None)
+		yield ('a', Uint, (0, None), (False, None), None)
+		yield ('b', Uint, (0, None), (False, None), None)
+		yield ('vec_2', Vector3F, (0, None), (False, None), None)
+		yield ('vec_3', Vector3F, (0, None), (False, None), None)
+		yield ('vec_4', Vector3F, (0, None), (False, None), None)
+		yield ('vec_5', Vector3F, (0, None), (False, None), None)
+		yield ('c', Uint, (0, None), (False, None), None)
+		yield ('d', Uint, (0, None), (False, None), None)
+		yield ('floats_1', Array, (0, None, (2,), Float), (False, None), None)
+		yield ('e', Uint, (0, None), (False, None), None)
+		yield ('floats_2', Array, (0, None, (2,), Float), (False, None), None)
+		yield ('f', Uint, (0, None), (False, None), None)
+		yield ('floats_3', Array, (0, None, (8,), Float), (False, None), None)
+		yield ('g', Uint, (0, None), (False, None), None)
+		yield ('floats_4', Array, (0, None, (6,), Float), (False, None), None)
+		yield ('h', Uint, (0, None), (False, None), None)
+		yield ('floats_5', Array, (0, None, (20,), Float), (False, None), None)
+		yield ('i', Uint, (0, None), (False, None), None)
+		yield ('float', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -91,3 +92,6 @@ class DinoEffectsHeader(MemStruct):
 		yield 'floats_5', Array, (0, None, (20,), Float), (False, None)
 		yield 'i', Uint, (0, None), (False, None)
 		yield 'float', Float, (0, None), (False, None)
+
+
+DinoEffectsHeader.init_attributes()

--- a/generated/formats/dinosaurmaterialvariants/compounds/DinoLayersHeader.py
+++ b/generated/formats/dinosaurmaterialvariants/compounds/DinoLayersHeader.py
@@ -20,12 +20,13 @@ class DinoLayersHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('fgm_name', Pointer, (0, ZStringObfuscated), (False, None), None),
-		('layers', ArrayPointer, (None, None), (False, None), None),
-		('layer_count', Uint64, (0, None), (False, None), None),
-		('zero', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('fgm_name', Pointer, (0, ZStringObfuscated), (False, None), None)
+		yield ('layers', ArrayPointer, (None, None), (False, None), None)
+		yield ('layer_count', Uint64, (0, None), (False, None), None)
+		yield ('zero', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -34,3 +35,6 @@ class DinoLayersHeader(MemStruct):
 		yield 'layers', ArrayPointer, (instance.layer_count, DinoLayersHeader._import_map["dinosaurmaterialvariants.compounds.Layer"]), (False, None)
 		yield 'layer_count', Uint64, (0, None), (False, None)
 		yield 'zero', Uint64, (0, None), (False, None)
+
+
+DinoLayersHeader.init_attributes()

--- a/generated/formats/dinosaurmaterialvariants/compounds/DinoPatternsHeader.py
+++ b/generated/formats/dinosaurmaterialvariants/compounds/DinoPatternsHeader.py
@@ -22,14 +22,15 @@ class DinoPatternsHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('fgm_name', Pointer, (0, ZStringObfuscated), (False, None), None),
-		('set_count', Uint64, (0, None), (False, None), None),
-		('set_name', Pointer, (0, ZString), (False, None), None),
-		('patterns', Pointer, (None, None), (False, None), None),
-		('pattern_count', Uint64, (0, None), (False, None), None),
-		('zero', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('fgm_name', Pointer, (0, ZStringObfuscated), (False, None), None)
+		yield ('set_count', Uint64, (0, None), (False, None), None)
+		yield ('set_name', Pointer, (0, ZString), (False, None), None)
+		yield ('patterns', Pointer, (None, None), (False, None), None)
+		yield ('pattern_count', Uint64, (0, None), (False, None), None)
+		yield ('zero', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -40,3 +41,6 @@ class DinoPatternsHeader(MemStruct):
 		yield 'patterns', Pointer, (instance.pattern_count, DinoPatternsHeader._import_map["dinosaurmaterialvariants.compounds.PatternArray"]), (False, None)
 		yield 'pattern_count', Uint64, (0, None), (False, None)
 		yield 'zero', Uint64, (0, None), (False, None)
+
+
+DinoPatternsHeader.init_attributes()

--- a/generated/formats/dinosaurmaterialvariants/compounds/DinoVariantsHeader.py
+++ b/generated/formats/dinosaurmaterialvariants/compounds/DinoVariantsHeader.py
@@ -27,14 +27,15 @@ class DinoVariantsHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('fgm_name', Pointer, (0, ZStringObfuscated), (False, None), None),
-		('has_sets', Uint64, (0, None), (False, None), None),
-		('set_name', Pointer, (0, ZString), (False, None), None),
-		('variants', Pointer, (None, None), (False, None), None),
-		('variant_count', Uint64, (0, None), (False, None), None),
-		('zero', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('fgm_name', Pointer, (0, ZStringObfuscated), (False, None), None)
+		yield ('has_sets', Uint64, (0, None), (False, None), None)
+		yield ('set_name', Pointer, (0, ZString), (False, None), None)
+		yield ('variants', Pointer, (None, None), (False, None), None)
+		yield ('variant_count', Uint64, (0, None), (False, None), None)
+		yield ('zero', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -45,3 +46,6 @@ class DinoVariantsHeader(MemStruct):
 		yield 'variants', Pointer, (instance.variant_count, DinoVariantsHeader._import_map["dinosaurmaterialvariants.compounds.VariantArray"]), (False, None)
 		yield 'variant_count', Uint64, (0, None), (False, None)
 		yield 'zero', Uint64, (0, None), (False, None)
+
+
+DinoVariantsHeader.init_attributes()

--- a/generated/formats/dinosaurmaterialvariants/compounds/Layer.py
+++ b/generated/formats/dinosaurmaterialvariants/compounds/Layer.py
@@ -22,11 +22,12 @@ class Layer(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('has_ptr', Uint64, (0, None), (False, None), None),
-		('texture_fgm_name', Pointer, (0, ZString), (False, None), None),
-		('transform_fgm_name', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('has_ptr', Uint64, (0, None), (False, None), None)
+		yield ('texture_fgm_name', Pointer, (0, ZString), (False, None), None)
+		yield ('transform_fgm_name', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -34,3 +35,6 @@ class Layer(MemStruct):
 		yield 'has_ptr', Uint64, (0, None), (False, None)
 		yield 'texture_fgm_name', Pointer, (0, ZString), (False, None)
 		yield 'transform_fgm_name', Pointer, (0, ZString), (False, None)
+
+
+Layer.init_attributes()

--- a/generated/formats/dinosaurmaterialvariants/compounds/LayerArray.py
+++ b/generated/formats/dinosaurmaterialvariants/compounds/LayerArray.py
@@ -15,11 +15,15 @@ class LayerArray(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('layers', Array, (0, None, (None,), Layer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('layers', Array, (0, None, (None,), Layer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'layers', Array, (0, None, (instance.arg,), Layer), (False, None)
+
+
+LayerArray.init_attributes()

--- a/generated/formats/dinosaurmaterialvariants/compounds/Pattern.py
+++ b/generated/formats/dinosaurmaterialvariants/compounds/Pattern.py
@@ -17,13 +17,17 @@ class Pattern(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('has_ptr', Uint64, (0, None), (False, None), None),
-		('pattern_name', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('has_ptr', Uint64, (0, None), (False, None), None)
+		yield ('pattern_name', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'has_ptr', Uint64, (0, None), (False, None)
 		yield 'pattern_name', Pointer, (0, ZString), (False, None)
+
+
+Pattern.init_attributes()

--- a/generated/formats/dinosaurmaterialvariants/compounds/PatternArray.py
+++ b/generated/formats/dinosaurmaterialvariants/compounds/PatternArray.py
@@ -15,11 +15,15 @@ class PatternArray(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('patterns', Array, (0, None, (None,), Pattern), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('patterns', Array, (0, None, (None,), Pattern), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'patterns', Array, (0, None, (instance.arg,), Pattern), (False, None)
+
+
+PatternArray.init_attributes()

--- a/generated/formats/dinosaurmaterialvariants/compounds/Variant.py
+++ b/generated/formats/dinosaurmaterialvariants/compounds/Variant.py
@@ -17,13 +17,17 @@ class Variant(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('has_ptr', Uint64, (0, None), (False, None), None),
-		('variant_name', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('has_ptr', Uint64, (0, None), (False, None), None)
+		yield ('variant_name', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'has_ptr', Uint64, (0, None), (False, None)
 		yield 'variant_name', Pointer, (0, ZString), (False, None)
+
+
+Variant.init_attributes()

--- a/generated/formats/dinosaurmaterialvariants/compounds/VariantArray.py
+++ b/generated/formats/dinosaurmaterialvariants/compounds/VariantArray.py
@@ -15,11 +15,15 @@ class VariantArray(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('variants', Array, (0, None, (None,), Variant), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('variants', Array, (0, None, (None,), Variant), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'variants', Array, (0, None, (instance.arg,), Variant), (False, None)
+
+
+VariantArray.init_attributes()

--- a/generated/formats/dinosaurmaterialvariants/compounds/Vector3F.py
+++ b/generated/formats/dinosaurmaterialvariants/compounds/Vector3F.py
@@ -16,11 +16,12 @@ class Vector3F(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -28,3 +29,6 @@ class Vector3F(MemStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+Vector3F.init_attributes()

--- a/generated/formats/enumnamer/compounds/EnumnamerRoot.py
+++ b/generated/formats/enumnamer/compounds/EnumnamerRoot.py
@@ -16,13 +16,17 @@ class EnumnamerRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('count', Uint64, (0, None), (False, None), None),
-		('strings', Pointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('count', Uint64, (0, None), (False, None), None)
+		yield ('strings', Pointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'count', Uint64, (0, None), (False, None)
 		yield 'strings', Pointer, (instance.count, EnumnamerRoot._import_map["enumnamer.compounds.PtrList"]), (False, None)
+
+
+EnumnamerRoot.init_attributes()

--- a/generated/formats/enumnamer/compounds/PtrList.py
+++ b/generated/formats/enumnamer/compounds/PtrList.py
@@ -16,11 +16,15 @@ class PtrList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, ZString, (instance.arg,), Pointer), (False, None)
+
+
+PtrList.init_attributes()

--- a/generated/formats/fct/compounds/FctRoot.py
+++ b/generated/formats/fct/compounds/FctRoot.py
@@ -33,19 +33,20 @@ class FctRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('u_0', Short, (0, None), (False, None), None),
-		('u_1', Short, (0, None), (False, None), None),
-		('a', Float, (0, None), (False, None), None),
-		('b', Float, (0, None), (False, None), None),
-		('c', Float, (0, None), (False, None), None),
-		('minus_1', Short, (0, None), (False, None), None),
-		('z_0', Short, (0, None), (False, None), None),
-		('z_1', Int, (0, None), (False, None), None),
-		('z_2', Uint64, (0, None), (False, None), None),
-		('offset', Uint64, (0, None), (False, None), None),
-		('fonts', Array, (0, None, (4,), Font), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('u_0', Short, (0, None), (False, None), None)
+		yield ('u_1', Short, (0, None), (False, None), None)
+		yield ('a', Float, (0, None), (False, None), None)
+		yield ('b', Float, (0, None), (False, None), None)
+		yield ('c', Float, (0, None), (False, None), None)
+		yield ('minus_1', Short, (0, None), (False, None), None)
+		yield ('z_0', Short, (0, None), (False, None), None)
+		yield ('z_1', Int, (0, None), (False, None), None)
+		yield ('z_2', Uint64, (0, None), (False, None), None)
+		yield ('offset', Uint64, (0, None), (False, None), None)
+		yield ('fonts', Array, (0, None, (4,), Font), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -61,3 +62,6 @@ class FctRoot(MemStruct):
 		yield 'z_2', Uint64, (0, None), (False, None)
 		yield 'offset', Uint64, (0, None), (False, None)
 		yield 'fonts', Array, (0, None, (4,), Font), (False, None)
+
+
+FctRoot.init_attributes()

--- a/generated/formats/fct/compounds/Font.py
+++ b/generated/formats/fct/compounds/Font.py
@@ -19,13 +19,17 @@ class Font(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('data_size', Uint64, (0, None), (False, None), None),
-		('zero', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('data_size', Uint64, (0, None), (False, None), None)
+		yield ('zero', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'data_size', Uint64, (0, None), (False, None)
 		yield 'zero', Uint64, (0, None), (False, None)
+
+
+Font.init_attributes()

--- a/generated/formats/fgm/compounds/AttribData.py
+++ b/generated/formats/fgm/compounds/AttribData.py
@@ -17,14 +17,15 @@ class AttribData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('value', Array, (0, None, (1,), Float), (False, None), True),
-		('value', Array, (0, None, (2,), Float), (False, None), True),
-		('value', Array, (0, None, (3,), Float), (False, None), True),
-		('value', Array, (0, None, (4,), Float), (False, None), True),
-		('value', Array, (0, None, (1,), Int), (False, None), True),
-		('value', Array, (0, None, (1,), Int), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('value', Array, (0, None, (1,), Float), (False, None), True)
+		yield ('value', Array, (0, None, (2,), Float), (False, None), True)
+		yield ('value', Array, (0, None, (3,), Float), (False, None), True)
+		yield ('value', Array, (0, None, (4,), Float), (False, None), True)
+		yield ('value', Array, (0, None, (1,), Int), (False, None), True)
+		yield ('value', Array, (0, None, (1,), Int), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class AttribData(MemStruct):
 			yield 'value', Array, (0, None, (1,), Int), (False, None)
 		if instance.arg.dtype == 6:
 			yield 'value', Array, (0, None, (1,), Int), (False, None)
+
+
+AttribData.init_attributes()

--- a/generated/formats/fgm/compounds/AttribInfo.py
+++ b/generated/formats/fgm/compounds/AttribInfo.py
@@ -20,11 +20,15 @@ class AttribInfo(GenericInfo):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = GenericInfo._attribute_list + [
-		('_value_offset', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('_value_offset', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield '_value_offset', Uint64, (0, None), (False, None)
+
+
+AttribInfo.init_attributes()

--- a/generated/formats/fgm/compounds/Color.py
+++ b/generated/formats/fgm/compounds/Color.py
@@ -21,12 +21,13 @@ class Color(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('r', Ubyte, (0, None), (False, None), None),
-		('g', Ubyte, (0, None), (False, None), None),
-		('b', Ubyte, (0, None), (False, None), None),
-		('a', Ubyte, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('r', Ubyte, (0, None), (False, None), None)
+		yield ('g', Ubyte, (0, None), (False, None), None)
+		yield ('b', Ubyte, (0, None), (False, None), None)
+		yield ('a', Ubyte, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -35,3 +36,6 @@ class Color(MemStruct):
 		yield 'g', Ubyte, (0, None), (False, None)
 		yield 'b', Ubyte, (0, None), (False, None)
 		yield 'a', Ubyte, (0, None), (False, None)
+
+
+Color.init_attributes()

--- a/generated/formats/fgm/compounds/FgmHeader.py
+++ b/generated/formats/fgm/compounds/FgmHeader.py
@@ -32,20 +32,21 @@ class FgmHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('_texture_count', Uint, (0, None), (False, None), True),
-		('_texture_count', Uint64, (0, None), (False, None), True),
-		('_attribute_count', Uint, (0, None), (False, None), True),
-		('_attribute_count', Uint64, (0, None), (False, None), True),
-		('textures', ArrayPointer, (None, None), (False, None), None),
-		('attributes', ArrayPointer, (None, None), (False, None), None),
-		('name_foreach_textures', ForEachPointer, (None, None), (False, None), None),
-		('value_foreach_attributes', ForEachPointer, (None, None), (False, None), None),
-		('_unk_0', Uint64, (0, None), (False, None), None),
-		('_unk_1', Uint64, (0, None), (False, None), None),
-		('_unk_2', Uint64, (0, None), (False, None), True),
-		('_unk_3', Uint64, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('_texture_count', Uint, (0, None), (False, None), True)
+		yield ('_texture_count', Uint64, (0, None), (False, None), True)
+		yield ('_attribute_count', Uint, (0, None), (False, None), True)
+		yield ('_attribute_count', Uint64, (0, None), (False, None), True)
+		yield ('textures', ArrayPointer, (None, None), (False, None), None)
+		yield ('attributes', ArrayPointer, (None, None), (False, None), None)
+		yield ('name_foreach_textures', ForEachPointer, (None, None), (False, None), None)
+		yield ('value_foreach_attributes', ForEachPointer, (None, None), (False, None), None)
+		yield ('_unk_0', Uint64, (0, None), (False, None), None)
+		yield ('_unk_1', Uint64, (0, None), (False, None), None)
+		yield ('_unk_2', Uint64, (0, None), (False, None), True)
+		yield ('_unk_3', Uint64, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -67,3 +68,6 @@ class FgmHeader(MemStruct):
 		if instance.context.user_version.use_djb and (instance.context.version == 20):
 			yield '_unk_2', Uint64, (0, None), (False, None)
 			yield '_unk_3', Uint64, (0, None), (False, None)
+
+
+FgmHeader.init_attributes()

--- a/generated/formats/fgm/compounds/GenericInfo.py
+++ b/generated/formats/fgm/compounds/GenericInfo.py
@@ -18,13 +18,17 @@ class GenericInfo(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('_name_offset', Uint, (0, None), (False, None), None),
-		('dtype', FgmDtype, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('_name_offset', Uint, (0, None), (False, None), None)
+		yield ('dtype', FgmDtype, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield '_name_offset', Uint, (0, None), (False, None)
 		yield 'dtype', FgmDtype, (0, None), (False, None)
+
+
+GenericInfo.init_attributes()

--- a/generated/formats/fgm/compounds/TexIndex.py
+++ b/generated/formats/fgm/compounds/TexIndex.py
@@ -21,10 +21,11 @@ class TexIndex(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('_tex_index', Uint, (0, None), (False, None), None),
-		('array_index', Uint, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('_tex_index', Uint, (0, None), (False, None), None)
+		yield ('array_index', Uint, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -32,3 +33,6 @@ class TexIndex(MemStruct):
 		yield '_tex_index', Uint, (0, None), (False, None)
 		if instance.context.version >= 18:
 			yield 'array_index', Uint, (0, None), (False, None)
+
+
+TexIndex.init_attributes()

--- a/generated/formats/fgm/compounds/TextureData.py
+++ b/generated/formats/fgm/compounds/TextureData.py
@@ -16,12 +16,16 @@ class TextureData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('dependency_name', Pointer, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('dependency_name', Pointer, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		if instance.arg.dtype == 8:
 			yield 'dependency_name', Pointer, (0, None), (False, None)
+
+
+TextureData.init_attributes()

--- a/generated/formats/fgm/compounds/TextureInfo.py
+++ b/generated/formats/fgm/compounds/TextureInfo.py
@@ -27,13 +27,14 @@ class TextureInfo(GenericInfo):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = GenericInfo._attribute_list + [
-		('value', Array, (0, None, (1,), TexIndex), (False, None), True),
-		('value', Array, (0, None, (2,), Color), (False, None), True),
-		('value', Array, (0, None, (1,), Color), (False, None), True),
-		('some_index_0', Uint, (0, None), (True, 0), True),
-		('some_index_1', Uint, (0, None), (True, 0), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('value', Array, (0, None, (1,), TexIndex), (False, None), True)
+		yield ('value', Array, (0, None, (2,), Color), (False, None), True)
+		yield ('value', Array, (0, None, (1,), Color), (False, None), True)
+		yield ('some_index_0', Uint, (0, None), (True, 0), True)
+		yield ('some_index_1', Uint, (0, None), (True, 0), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -47,3 +48,6 @@ class TextureInfo(GenericInfo):
 		if instance.context.version >= 18:
 			yield 'some_index_0', Uint, (0, None), (True, 0)
 			yield 'some_index_1', Uint, (0, None), (True, 0)
+
+
+TextureInfo.init_attributes()

--- a/generated/formats/frendercontextset/compounds/ContextSet1Item.py
+++ b/generated/formats/frendercontextset/compounds/ContextSet1Item.py
@@ -27,20 +27,21 @@ class ContextSet1Item(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('stuff_1_name', Pointer, (0, ZString), (False, None), None),
-		('stuff_11_sub', ArrayPointer, (None, None), (False, None), None),
-		('stuff_11_sub_count', Uint64, (0, None), (False, None), None),
-		('stuff_12_sub', ArrayPointer, (None, None), (False, None), None),
-		('stuff_12_sub_count', Uint64, (0, None), (False, None), None),
-		('stuff_13_sub', ArrayPointer, (None, None), (False, None), None),
-		('stuff_13_sub_count', Uint64, (0, None), (False, None), None),
-		('stuff_14_sub_name', Pointer, (0, ZString), (False, None), None),
-		('stuff_14_sub_name', Pointer, (0, ZString), (False, None), None),
-		('stuff_15_sub_name', Pointer, (0, ZString), (False, None), None),
-		('stuff_1_unknown_1', Uint64, (0, None), (False, None), None),
-		('stuff_1_unknown_2', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('stuff_1_name', Pointer, (0, ZString), (False, None), None)
+		yield ('stuff_11_sub', ArrayPointer, (None, None), (False, None), None)
+		yield ('stuff_11_sub_count', Uint64, (0, None), (False, None), None)
+		yield ('stuff_12_sub', ArrayPointer, (None, None), (False, None), None)
+		yield ('stuff_12_sub_count', Uint64, (0, None), (False, None), None)
+		yield ('stuff_13_sub', ArrayPointer, (None, None), (False, None), None)
+		yield ('stuff_13_sub_count', Uint64, (0, None), (False, None), None)
+		yield ('stuff_14_sub_name', Pointer, (0, ZString), (False, None), None)
+		yield ('stuff_14_sub_name', Pointer, (0, ZString), (False, None), None)
+		yield ('stuff_15_sub_name', Pointer, (0, ZString), (False, None), None)
+		yield ('stuff_1_unknown_1', Uint64, (0, None), (False, None), None)
+		yield ('stuff_1_unknown_2', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -57,3 +58,6 @@ class ContextSet1Item(MemStruct):
 		yield 'stuff_15_sub_name', Pointer, (0, ZString), (False, None)
 		yield 'stuff_1_unknown_1', Uint64, (0, None), (False, None)
 		yield 'stuff_1_unknown_2', Uint64, (0, None), (False, None)
+
+
+ContextSet1Item.init_attributes()

--- a/generated/formats/frendercontextset/compounds/ContextSet1SubItem.py
+++ b/generated/formats/frendercontextset/compounds/ContextSet1SubItem.py
@@ -17,13 +17,17 @@ class ContextSet1SubItem(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('stuff_1_sub_name', Pointer, (0, ZString), (False, None), None),
-		('stuff_1_sub_order_or_flags', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('stuff_1_sub_name', Pointer, (0, ZString), (False, None), None)
+		yield ('stuff_1_sub_order_or_flags', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'stuff_1_sub_name', Pointer, (0, ZString), (False, None)
 		yield 'stuff_1_sub_order_or_flags', Uint64, (0, None), (False, None)
+
+
+ContextSet1SubItem.init_attributes()

--- a/generated/formats/frendercontextset/compounds/ContextSet2Item.py
+++ b/generated/formats/frendercontextset/compounds/ContextSet2Item.py
@@ -17,13 +17,17 @@ class ContextSet2Item(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('stuff_2_name', Pointer, (0, ZString), (False, None), None),
-		('stuff_2_id', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('stuff_2_name', Pointer, (0, ZString), (False, None), None)
+		yield ('stuff_2_id', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'stuff_2_name', Pointer, (0, ZString), (False, None)
 		yield 'stuff_2_id', Uint64, (0, None), (False, None)
+
+
+ContextSet2Item.init_attributes()

--- a/generated/formats/frendercontextset/compounds/ContextSet3Item.py
+++ b/generated/formats/frendercontextset/compounds/ContextSet3Item.py
@@ -18,11 +18,12 @@ class ContextSet3Item(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('stuff_3_name_1', Pointer, (0, ZString), (False, None), None),
-		('stuff_3_sub', Pointer, (0, None), (False, None), None),
-		('stuff_3_id_allways_1', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('stuff_3_name_1', Pointer, (0, ZString), (False, None), None)
+		yield ('stuff_3_sub', Pointer, (0, None), (False, None), None)
+		yield ('stuff_3_id_allways_1', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -30,3 +31,6 @@ class ContextSet3Item(MemStruct):
 		yield 'stuff_3_name_1', Pointer, (0, ZString), (False, None)
 		yield 'stuff_3_sub', Pointer, (0, ContextSet3Item._import_map["frendercontextset.compounds.ContextSet3SubItem"]), (False, None)
 		yield 'stuff_3_id_allways_1', Uint64, (0, None), (False, None)
+
+
+ContextSet3Item.init_attributes()

--- a/generated/formats/frendercontextset/compounds/ContextSet3SubItem.py
+++ b/generated/formats/frendercontextset/compounds/ContextSet3SubItem.py
@@ -19,12 +19,13 @@ class ContextSet3SubItem(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('stuff_31_name_1', Pointer, (0, ZString), (False, None), None),
-		('stuff_31_name_2', Pointer, (0, ZString), (False, None), None),
-		('stuff_31_name_3', Pointer, (0, ZString), (False, None), None),
-		('stuff_31_id_allways_0', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('stuff_31_name_1', Pointer, (0, ZString), (False, None), None)
+		yield ('stuff_31_name_2', Pointer, (0, ZString), (False, None), None)
+		yield ('stuff_31_name_3', Pointer, (0, ZString), (False, None), None)
+		yield ('stuff_31_id_allways_0', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -33,3 +34,6 @@ class ContextSet3SubItem(MemStruct):
 		yield 'stuff_31_name_2', Pointer, (0, ZString), (False, None)
 		yield 'stuff_31_name_3', Pointer, (0, ZString), (False, None)
 		yield 'stuff_31_id_allways_0', Uint64, (0, None), (False, None)
+
+
+ContextSet3SubItem.init_attributes()

--- a/generated/formats/frendercontextset/compounds/FRenderContextSetRoot.py
+++ b/generated/formats/frendercontextset/compounds/FRenderContextSetRoot.py
@@ -20,14 +20,15 @@ class FRenderContextSetRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptr_1_list', ArrayPointer, (None, None), (False, None), None),
-		('ptr_1_count', Uint64, (0, None), (False, None), None),
-		('ptr_2_list', ArrayPointer, (None, None), (False, None), None),
-		('ptr_2_count', Uint64, (0, None), (False, None), None),
-		('ptr_3_list', ArrayPointer, (None, None), (False, None), None),
-		('ptr_3_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptr_1_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('ptr_1_count', Uint64, (0, None), (False, None), None)
+		yield ('ptr_2_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('ptr_2_count', Uint64, (0, None), (False, None), None)
+		yield ('ptr_3_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('ptr_3_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class FRenderContextSetRoot(MemStruct):
 		yield 'ptr_2_count', Uint64, (0, None), (False, None)
 		yield 'ptr_3_list', ArrayPointer, (instance.ptr_3_count, FRenderContextSetRoot._import_map["frendercontextset.compounds.ContextSet3Item"]), (False, None)
 		yield 'ptr_3_count', Uint64, (0, None), (False, None)
+
+
+FRenderContextSetRoot.init_attributes()

--- a/generated/formats/frenderfeatureset/compounds/FRenderFeatureSetRoot.py
+++ b/generated/formats/frenderfeatureset/compounds/FRenderFeatureSetRoot.py
@@ -17,11 +17,12 @@ class FRenderFeatureSetRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('featureset_list', ArrayPointer, (None, None), (False, None), None),
-		('featureset_count', Uint, (0, None), (False, None), None),
-		('unknown_always_1', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('featureset_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('featureset_count', Uint, (0, None), (False, None), None)
+		yield ('unknown_always_1', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -29,3 +30,6 @@ class FRenderFeatureSetRoot(MemStruct):
 		yield 'featureset_list', ArrayPointer, (instance.featureset_count, FRenderFeatureSetRoot._import_map["frenderfeatureset.compounds.FeatureSetItem"]), (False, None)
 		yield 'featureset_count', Uint, (0, None), (False, None)
 		yield 'unknown_always_1', Uint, (0, None), (False, None)
+
+
+FRenderFeatureSetRoot.init_attributes()

--- a/generated/formats/frenderfeatureset/compounds/FeatureSetItem.py
+++ b/generated/formats/frenderfeatureset/compounds/FeatureSetItem.py
@@ -15,11 +15,15 @@ class FeatureSetItem(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('feature_name', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('feature_name', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'feature_name', Pointer, (0, ZString), (False, None)
+
+
+FeatureSetItem.init_attributes()

--- a/generated/formats/frenderlodspec/compounds/FRenderLodSpecRoot.py
+++ b/generated/formats/frenderlodspec/compounds/FRenderLodSpecRoot.py
@@ -17,11 +17,12 @@ class FRenderLodSpecRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('spec_list', ArrayPointer, (None, None), (False, None), None),
-		('spec_count', Uint64, (0, None), (False, None), None),
-		('unknown', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('spec_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('spec_count', Uint64, (0, None), (False, None), None)
+		yield ('unknown', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -29,3 +30,6 @@ class FRenderLodSpecRoot(MemStruct):
 		yield 'spec_list', ArrayPointer, (instance.spec_count, FRenderLodSpecRoot._import_map["frenderlodspec.compounds.LodSpecItem"]), (False, None)
 		yield 'spec_count', Uint64, (0, None), (False, None)
 		yield 'unknown', Uint64, (0, None), (False, None)
+
+
+FRenderLodSpecRoot.init_attributes()

--- a/generated/formats/frenderlodspec/compounds/LodSpecItem.py
+++ b/generated/formats/frenderlodspec/compounds/LodSpecItem.py
@@ -31,22 +31,23 @@ class LodSpecItem(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('group_name', Pointer, (0, ZString), (False, None), None),
-		('unknown_1', Uint, (0, None), (False, None), None),
-		('max_model_bounding_sphere_radius', Float, (0, None), (False, None), None),
-		('flags_1', Ushort, (0, None), (False, None), None),
-		('flags_2', Ushort, (0, None), (False, None), None),
-		('lod_point_0', Float, (0, None), (False, None), None),
-		('lod_point_1', Float, (0, None), (False, None), None),
-		('lod_point_2', Float, (0, None), (False, None), None),
-		('lod_point_3', Float, (0, None), (False, None), None),
-		('lod_point_4', Float, (0, None), (False, None), None),
-		('pixel_size_off', Float, (0, None), (False, None), None),
-		('unknown_2', Uint, (0, None), (False, None), None),
-		('unknown_3', Uint, (0, None), (False, None), None),
-		('unknown_4', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('group_name', Pointer, (0, ZString), (False, None), None)
+		yield ('unknown_1', Uint, (0, None), (False, None), None)
+		yield ('max_model_bounding_sphere_radius', Float, (0, None), (False, None), None)
+		yield ('flags_1', Ushort, (0, None), (False, None), None)
+		yield ('flags_2', Ushort, (0, None), (False, None), None)
+		yield ('lod_point_0', Float, (0, None), (False, None), None)
+		yield ('lod_point_1', Float, (0, None), (False, None), None)
+		yield ('lod_point_2', Float, (0, None), (False, None), None)
+		yield ('lod_point_3', Float, (0, None), (False, None), None)
+		yield ('lod_point_4', Float, (0, None), (False, None), None)
+		yield ('pixel_size_off', Float, (0, None), (False, None), None)
+		yield ('unknown_2', Uint, (0, None), (False, None), None)
+		yield ('unknown_3', Uint, (0, None), (False, None), None)
+		yield ('unknown_4', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -65,3 +66,6 @@ class LodSpecItem(MemStruct):
 		yield 'unknown_2', Uint, (0, None), (False, None)
 		yield 'unknown_3', Uint, (0, None), (False, None)
 		yield 'unknown_4', Uint, (0, None), (False, None)
+
+
+LodSpecItem.init_attributes()

--- a/generated/formats/guesteconomy/compounds/GuestEconomyRoot.py
+++ b/generated/formats/guesteconomy/compounds/GuestEconomyRoot.py
@@ -81,40 +81,41 @@ class GuestEconomyRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('target_profit', Uint, (0, None), (False, None), None),
-		('u_00', Float, (0, None), (False, None), None),
-		('target_dinosaur_prestige', Uint, (0, None), (False, None), None),
-		('dinosaur_prestige_power', Float, (0, None), (False, None), None),
-		('u_01', Uint, (0, None), (False, None), None),
-		('u_02', Float, (0, None), (False, None), None),
-		('u_03', Float, (0, None), (False, None), None),
-		('u_04', Float, (0, None), (False, None), None),
-		('visitor_arrival_rate', Float, (0, None), (False, None), None),
-		('visitor_departure_rate', Float, (0, None), (False, None), None),
-		('u_05', Float, (0, None), (False, None), None),
-		('u_06', Float, (0, None), (False, None), None),
-		('u_07', Float, (0, None), (False, None), None),
-		('u_08', Float, (0, None), (False, None), None),
-		('u_09', Float, (0, None), (False, None), None),
-		('u_10', Float, (0, None), (False, None), None),
-		('u_11', Float, (0, None), (False, None), None),
-		('ticket_price_visitor_proportion_power', Float, (0, None), (False, None), None),
-		('ticket_price_full_visitor_proportion', Float, (0, None), (False, None), None),
-		('ticket_price_minimum_price_fraction', Float, (0, None), (False, None), None),
-		('visitor_deaths_decay_rate', Float, (0, None), (False, None), None),
-		('visitor_deaths_limit', Float, (0, None), (False, None), None),
-		('danger_exposure_safe_decay_rate', Float, (0, None), (False, None), None),
-		('danger_exposure_unnecessary_shelter_punishment', Float, (0, None), (False, None), None),
-		('danger_exposure_storm_exposure_punishment', Float, (0, None), (False, None), None),
-		('danger_exposure_dinosaur_exposure_punishment', Float, (0, None), (False, None), None),
-		('danger_exposure_dinosaur_danger_radius', Float, (0, None), (False, None), None),
-		('danger_exposure_limit', Float, (0, None), (False, None), None),
-		('transport_rating_disabled', Uint, (0, None), (False, None), None),
-		('u_12', Uint, (0, None), (False, None), None),
-		('u_13', Uint, (0, None), (False, None), None),
-		('u_14', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('target_profit', Uint, (0, None), (False, None), None)
+		yield ('u_00', Float, (0, None), (False, None), None)
+		yield ('target_dinosaur_prestige', Uint, (0, None), (False, None), None)
+		yield ('dinosaur_prestige_power', Float, (0, None), (False, None), None)
+		yield ('u_01', Uint, (0, None), (False, None), None)
+		yield ('u_02', Float, (0, None), (False, None), None)
+		yield ('u_03', Float, (0, None), (False, None), None)
+		yield ('u_04', Float, (0, None), (False, None), None)
+		yield ('visitor_arrival_rate', Float, (0, None), (False, None), None)
+		yield ('visitor_departure_rate', Float, (0, None), (False, None), None)
+		yield ('u_05', Float, (0, None), (False, None), None)
+		yield ('u_06', Float, (0, None), (False, None), None)
+		yield ('u_07', Float, (0, None), (False, None), None)
+		yield ('u_08', Float, (0, None), (False, None), None)
+		yield ('u_09', Float, (0, None), (False, None), None)
+		yield ('u_10', Float, (0, None), (False, None), None)
+		yield ('u_11', Float, (0, None), (False, None), None)
+		yield ('ticket_price_visitor_proportion_power', Float, (0, None), (False, None), None)
+		yield ('ticket_price_full_visitor_proportion', Float, (0, None), (False, None), None)
+		yield ('ticket_price_minimum_price_fraction', Float, (0, None), (False, None), None)
+		yield ('visitor_deaths_decay_rate', Float, (0, None), (False, None), None)
+		yield ('visitor_deaths_limit', Float, (0, None), (False, None), None)
+		yield ('danger_exposure_safe_decay_rate', Float, (0, None), (False, None), None)
+		yield ('danger_exposure_unnecessary_shelter_punishment', Float, (0, None), (False, None), None)
+		yield ('danger_exposure_storm_exposure_punishment', Float, (0, None), (False, None), None)
+		yield ('danger_exposure_dinosaur_exposure_punishment', Float, (0, None), (False, None), None)
+		yield ('danger_exposure_dinosaur_danger_radius', Float, (0, None), (False, None), None)
+		yield ('danger_exposure_limit', Float, (0, None), (False, None), None)
+		yield ('transport_rating_disabled', Uint, (0, None), (False, None), None)
+		yield ('u_12', Uint, (0, None), (False, None), None)
+		yield ('u_13', Uint, (0, None), (False, None), None)
+		yield ('u_14', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -151,3 +152,6 @@ class GuestEconomyRoot(MemStruct):
 		yield 'u_12', Uint, (0, None), (False, None)
 		yield 'u_13', Uint, (0, None), (False, None)
 		yield 'u_14', Uint, (0, None), (False, None)
+
+
+GuestEconomyRoot.init_attributes()

--- a/generated/formats/habitatboundary/structs/ClimbproofDataRoot.py
+++ b/generated/formats/habitatboundary/structs/ClimbproofDataRoot.py
@@ -29,15 +29,16 @@ class ClimbproofDataRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('climb_proof', Pointer, (0, ZString), (False, None), None),
-		('climb_proof_cap_start', Pointer, (0, ZString), (False, None), None),
-		('climb_proof_cap_end', Pointer, (0, ZString), (False, None), None),
-		('climb_proof_bracket', Pointer, (0, ZString), (False, None), None),
-		('post_gap', Float, (0, None), (False, None), None),
-		('u_1', Float, (0, None), (False, 2.0), None),
-		('zero', Uint64, (0, None), (True, 0), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('climb_proof', Pointer, (0, ZString), (False, None), None)
+		yield ('climb_proof_cap_start', Pointer, (0, ZString), (False, None), None)
+		yield ('climb_proof_cap_end', Pointer, (0, ZString), (False, None), None)
+		yield ('climb_proof_bracket', Pointer, (0, ZString), (False, None), None)
+		yield ('post_gap', Float, (0, None), (False, None), None)
+		yield ('u_1', Float, (0, None), (False, 2.0), None)
+		yield ('zero', Uint64, (0, None), (True, 0), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -49,3 +50,6 @@ class ClimbproofDataRoot(MemStruct):
 		yield 'post_gap', Float, (0, None), (False, None)
 		yield 'u_1', Float, (0, None), (False, 2.0)
 		yield 'zero', Uint64, (0, None), (True, 0)
+
+
+ClimbproofDataRoot.init_attributes()

--- a/generated/formats/habitatboundary/structs/HabitatBoundaryDataRoot.py
+++ b/generated/formats/habitatboundary/structs/HabitatBoundaryDataRoot.py
@@ -63,39 +63,40 @@ class HabitatBoundaryDataRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('prefab', Pointer, (0, ZString), (False, None), None),
-		('walls_extrusion', Pointer, (0, ZString), (False, None), None),
-		('walls_extrusion_end', Pointer, (0, ZString), (False, None), None),
-		('walls_extrusion_top', Pointer, (0, ZString), (False, None), None),
-		('walls_extrusion_cap_top', Pointer, (0, ZString), (False, None), None),
-		('walls_extrusion_bottom', Pointer, (0, ZString), (False, None), None),
-		('walls_unk_2', Pointer, (0, ZString), (False, None), None),
-		('walls_unk_3', Pointer, (0, ZString), (False, None), None),
-		('walls_unk_4', Pointer, (0, ZString), (False, None), None),
-		('walls_extrusion_door_cap_side', Pointer, (0, ZString), (False, None), None),
-		('walls_extrusion_door_cap_end', Pointer, (0, ZString), (False, None), None),
-		('walls_extrusion_door_cap_underside', Pointer, (0, ZString), (False, None), None),
-		('climb_proof_data', Pointer, (0, ZString), (False, None), None),
-		('broken_post', Pointer, (0, ZString), (False, None), None),
-		('broken_extrusion', Pointer, (0, ZString), (False, None), None),
-		('broken_extrusion_pile', Pointer, (0, ZString), (False, None), None),
-		('broken_ground', Pointer, (0, ZString), (False, None), None),
-		('broken_1_m', Pointer, (0, ZString), (False, None), None),
-		('broken_10_m', Pointer, (0, ZString), (False, None), None),
-		('post', Pointer, (0, ZString), (False, None), None),
-		('post_cap', Pointer, (0, ZString), (False, None), None),
-		('u_1', Uint, (0, None), (False, 3), None),
-		('u_2', Float, (0, None), (False, None), None),
-		('u_3', Ushort, (0, None), (False, 0), None),
-		('ui_options', HbUiOptions, (0, None), (False, None), None),
-		('u_4', Float, (0, None), (False, 1.5), None),
-		('u_5', Float, (0, None), (False, 2.5), None),
-		('offsets', HbOffsets, (0, None), (False, None), None),
-		('wall_replace_level', Byte, (0, None), (False, None), None),
-		('type', Byte, (0, None), (False, None), None),
-		('padding', Ushort, (0, None), (True, 0), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('prefab', Pointer, (0, ZString), (False, None), None)
+		yield ('walls_extrusion', Pointer, (0, ZString), (False, None), None)
+		yield ('walls_extrusion_end', Pointer, (0, ZString), (False, None), None)
+		yield ('walls_extrusion_top', Pointer, (0, ZString), (False, None), None)
+		yield ('walls_extrusion_cap_top', Pointer, (0, ZString), (False, None), None)
+		yield ('walls_extrusion_bottom', Pointer, (0, ZString), (False, None), None)
+		yield ('walls_unk_2', Pointer, (0, ZString), (False, None), None)
+		yield ('walls_unk_3', Pointer, (0, ZString), (False, None), None)
+		yield ('walls_unk_4', Pointer, (0, ZString), (False, None), None)
+		yield ('walls_extrusion_door_cap_side', Pointer, (0, ZString), (False, None), None)
+		yield ('walls_extrusion_door_cap_end', Pointer, (0, ZString), (False, None), None)
+		yield ('walls_extrusion_door_cap_underside', Pointer, (0, ZString), (False, None), None)
+		yield ('climb_proof_data', Pointer, (0, ZString), (False, None), None)
+		yield ('broken_post', Pointer, (0, ZString), (False, None), None)
+		yield ('broken_extrusion', Pointer, (0, ZString), (False, None), None)
+		yield ('broken_extrusion_pile', Pointer, (0, ZString), (False, None), None)
+		yield ('broken_ground', Pointer, (0, ZString), (False, None), None)
+		yield ('broken_1_m', Pointer, (0, ZString), (False, None), None)
+		yield ('broken_10_m', Pointer, (0, ZString), (False, None), None)
+		yield ('post', Pointer, (0, ZString), (False, None), None)
+		yield ('post_cap', Pointer, (0, ZString), (False, None), None)
+		yield ('u_1', Uint, (0, None), (False, 3), None)
+		yield ('u_2', Float, (0, None), (False, None), None)
+		yield ('u_3', Ushort, (0, None), (False, 0), None)
+		yield ('ui_options', HbUiOptions, (0, None), (False, None), None)
+		yield ('u_4', Float, (0, None), (False, 1.5), None)
+		yield ('u_5', Float, (0, None), (False, 2.5), None)
+		yield ('offsets', HbOffsets, (0, None), (False, None), None)
+		yield ('wall_replace_level', Byte, (0, None), (False, None), None)
+		yield ('type', Byte, (0, None), (False, None), None)
+		yield ('padding', Ushort, (0, None), (True, 0), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -131,3 +132,6 @@ class HabitatBoundaryDataRoot(MemStruct):
 		yield 'wall_replace_level', Byte, (0, None), (False, None)
 		yield 'type', Byte, (0, None), (False, None)
 		yield 'padding', Ushort, (0, None), (True, 0)
+
+
+HabitatBoundaryDataRoot.init_attributes()

--- a/generated/formats/habitatboundary/structs/HabitatBoundaryPropRoot.py
+++ b/generated/formats/habitatboundary/structs/HabitatBoundaryPropRoot.py
@@ -40,22 +40,23 @@ class HabitatBoundaryPropRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('type', Uint64, (0, None), (False, None), None),
-		('prefab', Pointer, (0, ZString), (False, None), None),
-		('u_1', Uint64, (0, None), (False, None), None),
-		('post', Pointer, (0, ZString), (False, None), None),
-		('wall', Pointer, (0, ZString), (False, None), None),
-		('is_guest', Uint, (0, None), (False, None), None),
-		('post_position', HbPostPos, (0, None), (False, None), None),
-		('u_2', Float, (0, None), (False, None), None),
-		('door_physics', HbPropPhysics, (0, None), (False, None), None),
-		('path_physics', HbPropPhysics, (0, None), (False, None), None),
-		('path_join_part', Pointer, (0, ZString), (False, None), None),
-		('door_cutout', HbDoorCutout, (0, None), (False, None), None),
-		('small', Uint, (0, None), (False, None), None),
-		('height', Float, (0, None), (False, 2.0), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('type', Uint64, (0, None), (False, None), None)
+		yield ('prefab', Pointer, (0, ZString), (False, None), None)
+		yield ('u_1', Uint64, (0, None), (False, None), None)
+		yield ('post', Pointer, (0, ZString), (False, None), None)
+		yield ('wall', Pointer, (0, ZString), (False, None), None)
+		yield ('is_guest', Uint, (0, None), (False, None), None)
+		yield ('post_position', HbPostPos, (0, None), (False, None), None)
+		yield ('u_2', Float, (0, None), (False, None), None)
+		yield ('door_physics', HbPropPhysics, (0, None), (False, None), None)
+		yield ('path_physics', HbPropPhysics, (0, None), (False, None), None)
+		yield ('path_join_part', Pointer, (0, ZString), (False, None), None)
+		yield ('door_cutout', HbDoorCutout, (0, None), (False, None), None)
+		yield ('small', Uint, (0, None), (False, None), None)
+		yield ('height', Float, (0, None), (False, 2.0), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -74,3 +75,6 @@ class HabitatBoundaryPropRoot(MemStruct):
 		yield 'door_cutout', HbDoorCutout, (0, None), (False, None)
 		yield 'small', Uint, (0, None), (False, None)
 		yield 'height', Float, (0, None), (False, 2.0)
+
+
+HabitatBoundaryPropRoot.init_attributes()

--- a/generated/formats/habitatboundary/structs/HbDoorCutout.py
+++ b/generated/formats/habitatboundary/structs/HbDoorCutout.py
@@ -26,11 +26,12 @@ class HbDoorCutout(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('height', Float, (0, None), (False, None), None),
-		('right', Float, (0, None), (False, None), None),
-		('left', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('height', Float, (0, None), (False, None), None)
+		yield ('right', Float, (0, None), (False, None), None)
+		yield ('left', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class HbDoorCutout(MemStruct):
 		yield 'height', Float, (0, None), (False, None)
 		yield 'right', Float, (0, None), (False, None)
 		yield 'left', Float, (0, None), (False, None)
+
+
+HbDoorCutout.init_attributes()

--- a/generated/formats/habitatboundary/structs/HbOffsets.py
+++ b/generated/formats/habitatboundary/structs/HbOffsets.py
@@ -21,11 +21,12 @@ class HbOffsets(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('physics', HbPhysicsOffsets, (0, None), (False, None), None),
-		('post_height_offset', Float, (0, None), (False, None), None),
-		('wall_height', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('physics', HbPhysicsOffsets, (0, None), (False, None), None)
+		yield ('post_height_offset', Float, (0, None), (False, None), None)
+		yield ('wall_height', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -33,3 +34,6 @@ class HbOffsets(MemStruct):
 		yield 'physics', HbPhysicsOffsets, (0, None), (False, None)
 		yield 'post_height_offset', Float, (0, None), (False, None)
 		yield 'wall_height', Float, (0, None), (False, None)
+
+
+HbOffsets.init_attributes()

--- a/generated/formats/habitatboundary/structs/HbPhysicsOffsets.py
+++ b/generated/formats/habitatboundary/structs/HbPhysicsOffsets.py
@@ -28,12 +28,13 @@ class HbPhysicsOffsets(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('thickness', Float, (0, None), (False, None), None),
-		('post_size', HbPostSize, (0, None), (False, None), None),
-		('wall_pad_top', Float, (0, None), (False, None), None),
-		('wall_post_gap', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('thickness', Float, (0, None), (False, None), None)
+		yield ('post_size', HbPostSize, (0, None), (False, None), None)
+		yield ('wall_pad_top', Float, (0, None), (False, None), None)
+		yield ('wall_post_gap', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -42,3 +43,6 @@ class HbPhysicsOffsets(MemStruct):
 		yield 'post_size', HbPostSize, (0, None), (False, None)
 		yield 'wall_pad_top', Float, (0, None), (False, None)
 		yield 'wall_post_gap', Float, (0, None), (False, None)
+
+
+HbPhysicsOffsets.init_attributes()

--- a/generated/formats/habitatboundary/structs/HbPostPos.py
+++ b/generated/formats/habitatboundary/structs/HbPostPos.py
@@ -19,13 +19,17 @@ class HbPostPos(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('right', Float, (0, None), (False, None), None),
-		('left', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('right', Float, (0, None), (False, None), None)
+		yield ('left', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'right', Float, (0, None), (False, None)
 		yield 'left', Float, (0, None), (False, None)
+
+
+HbPostPos.init_attributes()

--- a/generated/formats/habitatboundary/structs/HbPostSize.py
+++ b/generated/formats/habitatboundary/structs/HbPostSize.py
@@ -22,11 +22,12 @@ class HbPostSize(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('front_back', Float, (0, None), (False, None), None),
-		('left_right', Float, (0, None), (False, None), None),
-		('top', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('front_back', Float, (0, None), (False, None), None)
+		yield ('left_right', Float, (0, None), (False, None), None)
+		yield ('top', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -34,3 +35,6 @@ class HbPostSize(MemStruct):
 		yield 'front_back', Float, (0, None), (False, None)
 		yield 'left_right', Float, (0, None), (False, None)
 		yield 'top', Float, (0, None), (False, None)
+
+
+HbPostSize.init_attributes()

--- a/generated/formats/habitatboundary/structs/HbPropPhysics.py
+++ b/generated/formats/habitatboundary/structs/HbPropPhysics.py
@@ -31,14 +31,15 @@ class HbPropPhysics(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('pad_top', Float, (0, None), (False, None), None),
-		('z_pos', Float, (0, None), (False, None), None),
-		('half_width', Float, (0, None), (False, None), None),
-		('pad_bottom', Float, (0, None), (False, None), None),
-		('half_depth', Float, (0, None), (False, None), None),
-		('u_6', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('pad_top', Float, (0, None), (False, None), None)
+		yield ('z_pos', Float, (0, None), (False, None), None)
+		yield ('half_width', Float, (0, None), (False, None), None)
+		yield ('pad_bottom', Float, (0, None), (False, None), None)
+		yield ('half_depth', Float, (0, None), (False, None), None)
+		yield ('u_6', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -49,3 +50,6 @@ class HbPropPhysics(MemStruct):
 		yield 'pad_bottom', Float, (0, None), (False, None)
 		yield 'half_depth', Float, (0, None), (False, None)
 		yield 'u_6', Float, (0, None), (False, None)
+
+
+HbPropPhysics.init_attributes()

--- a/generated/formats/habitatboundary/structs/HbUiOptions.py
+++ b/generated/formats/habitatboundary/structs/HbUiOptions.py
@@ -19,13 +19,17 @@ class HbUiOptions(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('straight_curve', Bool, (0, None), (False, None), None),
-		('windows', Bool, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('straight_curve', Bool, (0, None), (False, None), None)
+		yield ('windows', Bool, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'straight_curve', Bool, (0, None), (False, None)
 		yield 'windows', Bool, (0, None), (False, None)
+
+
+HbUiOptions.init_attributes()

--- a/generated/formats/island/compounds/IslandRoot.py
+++ b/generated/formats/island/compounds/IslandRoot.py
@@ -25,13 +25,14 @@ class IslandRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('path_name', Pointer, (0, ZString), (False, None), None),
-		('a', Float, (0, None), (False, None), None),
-		('b', Float, (0, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		('zero', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('path_name', Pointer, (0, ZString), (False, None), None)
+		yield ('a', Float, (0, None), (False, None), None)
+		yield ('b', Float, (0, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
+		yield ('zero', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class IslandRoot(MemStruct):
 		yield 'b', Float, (0, None), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
 		yield 'zero', Uint64, (0, None), (False, None)
+
+
+IslandRoot.init_attributes()

--- a/generated/formats/janitorsettings/compounds/JanitorSettingsRoot.py
+++ b/generated/formats/janitorsettings/compounds/JanitorSettingsRoot.py
@@ -88,76 +88,77 @@ class JanitorSettingsRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('array_0', ArrayPointer, (None, None), (False, None), None),
-		('array_1', ArrayPointer, (None, None), (False, None), None),
-		('array_2', ArrayPointer, (None, None), (False, None), None),
-		('array_3', ArrayPointer, (None, None), (False, None), None),
-		('array_4', ArrayPointer, (None, None), (False, None), None),
-		('array_5', ArrayPointer, (None, None), (False, None), None),
-		('array_6', ArrayPointer, (None, Uint), (False, None), None),
-		('array_7', ArrayPointer, (None, Uint), (False, None), None),
-		('array_8', ArrayPointer, (None, Uint), (False, None), None),
-		('array_9', ArrayPointer, (None, Float), (False, None), None),
-		('array_10', ArrayPointer, (None, Float), (False, None), None),
-		('array_11', ArrayPointer, (None, Float), (False, None), None),
-		('array_12', ArrayPointer, (None, Float), (False, None), None),
-		('array_13', ArrayPointer, (None, Float), (False, None), None),
-		('array_14', ArrayPointer, (None, Float), (False, None), None),
-		('unk_0', Float, (0, None), (False, None), None),
-		('unk_1', Float, (0, None), (False, None), None),
-		('unk_2', Float, (0, None), (False, None), None),
-		('unk_3', Float, (0, None), (False, None), None),
-		('unk_4', Float, (0, None), (False, None), None),
-		('unk_5', Float, (0, None), (False, None), None),
-		('unk_6', Float, (0, None), (False, None), None),
-		('unk_7', Float, (0, None), (False, None), None),
-		('unk_8', Uint, (0, None), (False, None), None),
-		('unk_9', Float, (0, None), (False, None), None),
-		('unk_10', Float, (0, None), (False, None), None),
-		('count_0', Ubyte, (0, None), (False, None), None),
-		('count_1', Ubyte, (0, None), (False, None), None),
-		('count_2', Ubyte, (0, None), (False, None), None),
-		('count_3', Ubyte, (0, None), (False, None), None),
-		('count_4', Ubyte, (0, None), (False, None), None),
-		('count_5', Ubyte, (0, None), (False, None), None),
-		('count_6', Ubyte, (0, None), (False, None), None),
-		('count_7', Ubyte, (0, None), (False, None), None),
-		('count_8', Ubyte, (0, None), (False, None), None),
-		('count_9', Ubyte, (0, None), (False, None), None),
-		('count_10', Ubyte, (0, None), (False, None), None),
-		('count_11', Ubyte, (0, None), (False, None), None),
-		('count_12', Ubyte, (0, None), (False, None), None),
-		('count_13', Ubyte, (0, None), (False, None), None),
-		('count_14', Ubyte, (0, None), (False, None), None),
-		('possibly_unused_count_0', Ubyte, (0, None), (False, None), None),
-		('possibly_unused_count_1', Ubyte, (0, None), (False, None), None),
-		('possibly_unused_count_2', Ubyte, (0, None), (False, None), None),
-		('possibly_unused_count_3', Ubyte, (0, None), (False, None), None),
-		('possibly_unused_count_4', Ubyte, (0, None), (False, None), None),
-		('unk_11', Float, (0, None), (False, None), None),
-		('unk_12', Float, (0, None), (False, None), None),
-		('unk_13', Float, (0, None), (False, None), None),
-		('unk_14', Float, (0, None), (False, None), None),
-		('unk_15', Float, (0, None), (False, None), None),
-		('unk_16', Float, (0, None), (False, None), None),
-		('unk_17', Float, (0, None), (False, None), None),
-		('unk_18', Float, (0, None), (False, None), None),
-		('unk_19', Float, (0, None), (False, None), None),
-		('unk_20', Float, (0, None), (False, None), None),
-		('unk_21', Float, (0, None), (False, None), None),
-		('unk_22', Float, (0, None), (False, None), None),
-		('unk_23', Float, (0, None), (False, None), None),
-		('unk_24', Float, (0, None), (False, None), None),
-		('unk_25', Float, (0, None), (False, None), None),
-		('unk_26', Float, (0, None), (False, None), None),
-		('unk_27', Float, (0, None), (False, None), None),
-		('unk_28', Float, (0, None), (False, None), None),
-		('unk_29', Float, (0, None), (False, None), None),
-		('unk_30', Float, (0, None), (False, None), None),
-		('unk_31', Float, (0, None), (False, None), None),
-		('unk_32', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('array_0', ArrayPointer, (None, None), (False, None), None)
+		yield ('array_1', ArrayPointer, (None, None), (False, None), None)
+		yield ('array_2', ArrayPointer, (None, None), (False, None), None)
+		yield ('array_3', ArrayPointer, (None, None), (False, None), None)
+		yield ('array_4', ArrayPointer, (None, None), (False, None), None)
+		yield ('array_5', ArrayPointer, (None, None), (False, None), None)
+		yield ('array_6', ArrayPointer, (None, Uint), (False, None), None)
+		yield ('array_7', ArrayPointer, (None, Uint), (False, None), None)
+		yield ('array_8', ArrayPointer, (None, Uint), (False, None), None)
+		yield ('array_9', ArrayPointer, (None, Float), (False, None), None)
+		yield ('array_10', ArrayPointer, (None, Float), (False, None), None)
+		yield ('array_11', ArrayPointer, (None, Float), (False, None), None)
+		yield ('array_12', ArrayPointer, (None, Float), (False, None), None)
+		yield ('array_13', ArrayPointer, (None, Float), (False, None), None)
+		yield ('array_14', ArrayPointer, (None, Float), (False, None), None)
+		yield ('unk_0', Float, (0, None), (False, None), None)
+		yield ('unk_1', Float, (0, None), (False, None), None)
+		yield ('unk_2', Float, (0, None), (False, None), None)
+		yield ('unk_3', Float, (0, None), (False, None), None)
+		yield ('unk_4', Float, (0, None), (False, None), None)
+		yield ('unk_5', Float, (0, None), (False, None), None)
+		yield ('unk_6', Float, (0, None), (False, None), None)
+		yield ('unk_7', Float, (0, None), (False, None), None)
+		yield ('unk_8', Uint, (0, None), (False, None), None)
+		yield ('unk_9', Float, (0, None), (False, None), None)
+		yield ('unk_10', Float, (0, None), (False, None), None)
+		yield ('count_0', Ubyte, (0, None), (False, None), None)
+		yield ('count_1', Ubyte, (0, None), (False, None), None)
+		yield ('count_2', Ubyte, (0, None), (False, None), None)
+		yield ('count_3', Ubyte, (0, None), (False, None), None)
+		yield ('count_4', Ubyte, (0, None), (False, None), None)
+		yield ('count_5', Ubyte, (0, None), (False, None), None)
+		yield ('count_6', Ubyte, (0, None), (False, None), None)
+		yield ('count_7', Ubyte, (0, None), (False, None), None)
+		yield ('count_8', Ubyte, (0, None), (False, None), None)
+		yield ('count_9', Ubyte, (0, None), (False, None), None)
+		yield ('count_10', Ubyte, (0, None), (False, None), None)
+		yield ('count_11', Ubyte, (0, None), (False, None), None)
+		yield ('count_12', Ubyte, (0, None), (False, None), None)
+		yield ('count_13', Ubyte, (0, None), (False, None), None)
+		yield ('count_14', Ubyte, (0, None), (False, None), None)
+		yield ('possibly_unused_count_0', Ubyte, (0, None), (False, None), None)
+		yield ('possibly_unused_count_1', Ubyte, (0, None), (False, None), None)
+		yield ('possibly_unused_count_2', Ubyte, (0, None), (False, None), None)
+		yield ('possibly_unused_count_3', Ubyte, (0, None), (False, None), None)
+		yield ('possibly_unused_count_4', Ubyte, (0, None), (False, None), None)
+		yield ('unk_11', Float, (0, None), (False, None), None)
+		yield ('unk_12', Float, (0, None), (False, None), None)
+		yield ('unk_13', Float, (0, None), (False, None), None)
+		yield ('unk_14', Float, (0, None), (False, None), None)
+		yield ('unk_15', Float, (0, None), (False, None), None)
+		yield ('unk_16', Float, (0, None), (False, None), None)
+		yield ('unk_17', Float, (0, None), (False, None), None)
+		yield ('unk_18', Float, (0, None), (False, None), None)
+		yield ('unk_19', Float, (0, None), (False, None), None)
+		yield ('unk_20', Float, (0, None), (False, None), None)
+		yield ('unk_21', Float, (0, None), (False, None), None)
+		yield ('unk_22', Float, (0, None), (False, None), None)
+		yield ('unk_23', Float, (0, None), (False, None), None)
+		yield ('unk_24', Float, (0, None), (False, None), None)
+		yield ('unk_25', Float, (0, None), (False, None), None)
+		yield ('unk_26', Float, (0, None), (False, None), None)
+		yield ('unk_27', Float, (0, None), (False, None), None)
+		yield ('unk_28', Float, (0, None), (False, None), None)
+		yield ('unk_29', Float, (0, None), (False, None), None)
+		yield ('unk_30', Float, (0, None), (False, None), None)
+		yield ('unk_31', Float, (0, None), (False, None), None)
+		yield ('unk_32', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -230,3 +231,6 @@ class JanitorSettingsRoot(MemStruct):
 		yield 'unk_30', Float, (0, None), (False, None)
 		yield 'unk_31', Float, (0, None), (False, None)
 		yield 'unk_32', Float, (0, None), (False, None)
+
+
+JanitorSettingsRoot.init_attributes()

--- a/generated/formats/janitorsettings/compounds/UIntPair.py
+++ b/generated/formats/janitorsettings/compounds/UIntPair.py
@@ -15,13 +15,17 @@ class UIntPair(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('value_0', Uint, (0, None), (False, None), None),
-		('value_1', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('value_0', Uint, (0, None), (False, None), None)
+		yield ('value_1', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'value_0', Uint, (0, None), (False, None)
 		yield 'value_1', Uint, (0, None), (False, None)
+
+
+UIntPair.init_attributes()

--- a/generated/formats/logicalcontrols/compounds/AxisButton.py
+++ b/generated/formats/logicalcontrols/compounds/AxisButton.py
@@ -21,11 +21,12 @@ class AxisButton(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('button_name', Pointer, (0, ZString), (False, None), None),
-		('axis_name_x', Pointer, (0, ZString), (False, None), None),
-		('axis_name_y', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('button_name', Pointer, (0, ZString), (False, None), None)
+		yield ('axis_name_x', Pointer, (0, ZString), (False, None), None)
+		yield ('axis_name_y', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -33,3 +34,6 @@ class AxisButton(MemStruct):
 		yield 'button_name', Pointer, (0, ZString), (False, None)
 		yield 'axis_name_x', Pointer, (0, ZString), (False, None)
 		yield 'axis_name_y', Pointer, (0, ZString), (False, None)
+
+
+AxisButton.init_attributes()

--- a/generated/formats/logicalcontrols/compounds/AxisValue.py
+++ b/generated/formats/logicalcontrols/compounds/AxisValue.py
@@ -22,15 +22,16 @@ class AxisValue(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('axis_name', Pointer, (0, ZString), (False, None), None),
-		('u_0', Uint64, (0, None), (False, None), None),
-		('u_1', Uint64, (0, None), (False, None), None),
-		('u_2', Uint64, (0, None), (False, None), None),
-		('value_name', Pointer, (0, ZString), (False, None), None),
-		('u_3', Uint64, (0, None), (False, None), None),
-		('u_4', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('axis_name', Pointer, (0, ZString), (False, None), None)
+		yield ('u_0', Uint64, (0, None), (False, None), None)
+		yield ('u_1', Uint64, (0, None), (False, None), None)
+		yield ('u_2', Uint64, (0, None), (False, None), None)
+		yield ('value_name', Pointer, (0, ZString), (False, None), None)
+		yield ('u_3', Uint64, (0, None), (False, None), None)
+		yield ('u_4', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -42,3 +43,6 @@ class AxisValue(MemStruct):
 		yield 'value_name', Pointer, (0, ZString), (False, None)
 		yield 'u_3', Uint64, (0, None), (False, None)
 		yield 'u_4', Uint64, (0, None), (False, None)
+
+
+AxisValue.init_attributes()

--- a/generated/formats/logicalcontrols/compounds/Button.py
+++ b/generated/formats/logicalcontrols/compounds/Button.py
@@ -20,12 +20,13 @@ class Button(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('button_name', Pointer, (0, ZString), (False, None), None),
-		('datas', ArrayPointer, (None, None), (False, None), None),
-		('datas_count', Uint, (0, None), (False, None), None),
-		('flags', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('button_name', Pointer, (0, ZString), (False, None), None)
+		yield ('datas', ArrayPointer, (None, None), (False, None), None)
+		yield ('datas_count', Uint, (0, None), (False, None), None)
+		yield ('flags', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -34,3 +35,6 @@ class Button(MemStruct):
 		yield 'datas', ArrayPointer, (instance.datas_count, Button._import_map["logicalcontrols.compounds.ButtonData"]), (False, None)
 		yield 'datas_count', Uint, (0, None), (False, None)
 		yield 'flags', Uint, (0, None), (False, None)
+
+
+Button.init_attributes()

--- a/generated/formats/logicalcontrols/compounds/ButtonData.py
+++ b/generated/formats/logicalcontrols/compounds/ButtonData.py
@@ -25,13 +25,14 @@ class ButtonData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('k_1_a', Ushort, (0, None), (False, None), None),
-		('k_1_b', Ushort, (0, None), (False, None), None),
-		('k_2', Uint, (0, None), (False, None), None),
-		('k_3', Uint, (0, None), (False, None), None),
-		('k_4', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('k_1_a', Ushort, (0, None), (False, None), None)
+		yield ('k_1_b', Ushort, (0, None), (False, None), None)
+		yield ('k_2', Uint, (0, None), (False, None), None)
+		yield ('k_3', Uint, (0, None), (False, None), None)
+		yield ('k_4', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class ButtonData(MemStruct):
 		yield 'k_2', Uint, (0, None), (False, None)
 		yield 'k_3', Uint, (0, None), (False, None)
 		yield 'k_4', Uint, (0, None), (False, None)
+
+
+ButtonData.init_attributes()

--- a/generated/formats/logicalcontrols/compounds/LogicalControls.py
+++ b/generated/formats/logicalcontrols/compounds/LogicalControls.py
@@ -27,18 +27,19 @@ class LogicalControls(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('buttons', ArrayPointer, (None, None), (False, None), None),
-		('axes', ArrayPointer, (None, None), (False, None), None),
-		('axis_buttons', ArrayPointer, (None, None), (False, None), None),
-		('d', ArrayPointer, (None, None), (False, None), None),
-		('button_count', Ubyte, (0, None), (False, None), None),
-		('axis_count', Ubyte, (0, None), (False, None), None),
-		('count_3', Ubyte, (0, None), (False, None), None),
-		('count_4', Ubyte, (0, None), (False, None), None),
-		('flags', Uint, (0, None), (False, None), None),
-		('unsure', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('buttons', ArrayPointer, (None, None), (False, None), None)
+		yield ('axes', ArrayPointer, (None, None), (False, None), None)
+		yield ('axis_buttons', ArrayPointer, (None, None), (False, None), None)
+		yield ('d', ArrayPointer, (None, None), (False, None), None)
+		yield ('button_count', Ubyte, (0, None), (False, None), None)
+		yield ('axis_count', Ubyte, (0, None), (False, None), None)
+		yield ('count_3', Ubyte, (0, None), (False, None), None)
+		yield ('count_4', Ubyte, (0, None), (False, None), None)
+		yield ('flags', Uint, (0, None), (False, None), None)
+		yield ('unsure', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -53,3 +54,6 @@ class LogicalControls(MemStruct):
 		yield 'count_4', Ubyte, (0, None), (False, None)
 		yield 'flags', Uint, (0, None), (False, None)
 		yield 'unsure', Pointer, (0, ZString), (False, None)
+
+
+LogicalControls.init_attributes()

--- a/generated/formats/logicalcontrols/compounds/PtrList.py
+++ b/generated/formats/logicalcontrols/compounds/PtrList.py
@@ -16,11 +16,15 @@ class PtrList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, ZString, (instance.arg,), Pointer), (False, None)
+
+
+PtrList.init_attributes()

--- a/generated/formats/logicalcontrols/compounds/Some.py
+++ b/generated/formats/logicalcontrols/compounds/Some.py
@@ -23,11 +23,12 @@ class Some(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('some_name', Pointer, (0, ZString), (False, None), None),
-		('some_data', ArrayPointer, (None, None), (False, None), None),
-		('some_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('some_name', Pointer, (0, ZString), (False, None), None)
+		yield ('some_data', ArrayPointer, (None, None), (False, None), None)
+		yield ('some_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -35,3 +36,6 @@ class Some(MemStruct):
 		yield 'some_name', Pointer, (0, ZString), (False, None)
 		yield 'some_data', ArrayPointer, (instance.some_count, Some._import_map["logicalcontrols.compounds.SomeData"]), (False, None)
 		yield 'some_count', Uint64, (0, None), (False, None)
+
+
+Some.init_attributes()

--- a/generated/formats/logicalcontrols/compounds/SomeData.py
+++ b/generated/formats/logicalcontrols/compounds/SomeData.py
@@ -22,12 +22,13 @@ class SomeData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('key', Uint, (0, None), (False, None), None),
-		('extra', Uint, (0, None), (False, None), None),
-		('a', Float, (0, None), (False, None), None),
-		('b', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('key', Uint, (0, None), (False, None), None)
+		yield ('extra', Uint, (0, None), (False, None), None)
+		yield ('a', Float, (0, None), (False, None), None)
+		yield ('b', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class SomeData(MemStruct):
 		yield 'extra', Uint, (0, None), (False, None)
 		yield 'a', Float, (0, None), (False, None)
 		yield 'b', Float, (0, None), (False, None)
+
+
+SomeData.init_attributes()

--- a/generated/formats/lua/compounds/LuaRoot.py
+++ b/generated/formats/lua/compounds/LuaRoot.py
@@ -30,16 +30,17 @@ class LuaRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('lua_size', Uint, (0, None), (False, None), None),
-		('sixteenk', Uint, (0, None), (False, None), None),
-		('hash', Uint, (0, None), (False, None), None),
-		('zero_0', Uint, (0, None), (False, None), None),
-		('source_path', Pointer, (0, ZString), (False, None), True),
-		('likely_alignment', Pointer, (0, ZString), (False, None), True),
-		('zero_1', Uint64, (0, None), (False, None), None),
-		('zero_2', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('lua_size', Uint, (0, None), (False, None), None)
+		yield ('sixteenk', Uint, (0, None), (False, None), None)
+		yield ('hash', Uint, (0, None), (False, None), None)
+		yield ('zero_0', Uint, (0, None), (False, None), None)
+		yield ('source_path', Pointer, (0, ZString), (False, None), True)
+		yield ('likely_alignment', Pointer, (0, ZString), (False, None), True)
+		yield ('zero_1', Uint64, (0, None), (False, None), None)
+		yield ('zero_2', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -53,3 +54,6 @@ class LuaRoot(MemStruct):
 			yield 'likely_alignment', Pointer, (0, ZString), (False, None)
 		yield 'zero_1', Uint64, (0, None), (False, None)
 		yield 'zero_2', Uint64, (0, None), (False, None)
+
+
+LuaRoot.init_attributes()

--- a/generated/formats/lut/compounds/LutHeader.py
+++ b/generated/formats/lut/compounds/LutHeader.py
@@ -25,14 +25,15 @@ class LutHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('colors', ArrayPointer, (None, None), (False, None), None),
-		('colors_count', Ushort, (0, None), (False, None), None),
-		('unk_0', Ushort, (0, None), (False, None), None),
-		('unk_1', Uint, (0, None), (False, None), None),
-		('colors_in_column_count', Uint, (0, None), (False, None), None),
-		('unk_2', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('colors', ArrayPointer, (None, None), (False, None), None)
+		yield ('colors_count', Ushort, (0, None), (False, None), None)
+		yield ('unk_0', Ushort, (0, None), (False, None), None)
+		yield ('unk_1', Uint, (0, None), (False, None), None)
+		yield ('colors_in_column_count', Uint, (0, None), (False, None), None)
+		yield ('unk_2', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -43,3 +44,6 @@ class LutHeader(MemStruct):
 		yield 'unk_1', Uint, (0, None), (False, None)
 		yield 'colors_in_column_count', Uint, (0, None), (False, None)
 		yield 'unk_2', Uint, (0, None), (False, None)
+
+
+LutHeader.init_attributes()

--- a/generated/formats/lut/compounds/Vector3.py
+++ b/generated/formats/lut/compounds/Vector3.py
@@ -26,11 +26,12 @@ class Vector3(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class Vector3(MemStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+Vector3.init_attributes()

--- a/generated/formats/manis/compounds/Buffer1.py
+++ b/generated/formats/manis/compounds/Buffer1.py
@@ -20,11 +20,12 @@ class Buffer1(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('bone_hashes', Array, (0, None, (None,), Uint), (False, None), None),
-		('bone_names', Array, (0, None, (None,), ZString), (False, None), None),
-		('bone_pad', PadAlign, (4, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('bone_hashes', Array, (0, None, (None,), Uint), (False, None), None)
+		yield ('bone_names', Array, (0, None, (None,), ZString), (False, None), None)
+		yield ('bone_pad', PadAlign, (4, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -32,3 +33,6 @@ class Buffer1(BaseStruct):
 		yield 'bone_hashes', Array, (0, None, (instance.arg,), Uint), (False, None)
 		yield 'bone_names', Array, (0, None, (instance.arg,), ZString), (False, None)
 		yield 'bone_pad', PadAlign, (4, instance.bone_names), (False, None)
+
+
+Buffer1.init_attributes()

--- a/generated/formats/manis/compounds/ChunkSizes.py
+++ b/generated/formats/manis/compounds/ChunkSizes.py
@@ -17,11 +17,12 @@ class ChunkSizes(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('zeros_0', Uint64, (0, None), (False, None), None),
-		('bone', Uint, (0, None), (False, None), None),
-		('counta', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('zeros_0', Uint64, (0, None), (False, None), None)
+		yield ('bone', Uint, (0, None), (False, None), None)
+		yield ('counta', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -29,3 +30,6 @@ class ChunkSizes(BaseStruct):
 		yield 'zeros_0', Uint64, (0, None), (False, None)
 		yield 'bone', Uint, (0, None), (False, None)
 		yield 'counta', Uint, (0, None), (False, None)
+
+
+ChunkSizes.init_attributes()

--- a/generated/formats/manis/compounds/CompressedManiData.py
+++ b/generated/formats/manis/compounds/CompressedManiData.py
@@ -60,30 +60,31 @@ class CompressedManiData(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('ref', Empty, (0, None), (False, None), None),
-		('floatsa', Array, (0, None, (None, None,), Float), (False, None), None),
-		('pad_2', SmartPadding, (0, None), (False, None), None),
-		('frame_count', Uint, (0, None), (False, None), None),
-		('ori_bone_count', Uint, (0, None), (False, None), None),
-		('pos_bone_count', Uint, (0, None), (False, None), None),
-		('scl_bone_count', Uint, (0, None), (False, None), None),
-		('zeros_18', Array, (0, None, (18,), Uint), (False, None), None),
-		('count', Ushort, (0, None), (False, None), None),
-		('quantisation_level', Ushort, (0, None), (False, None), None),
-		('ref_2', Empty, (0, None), (False, None), None),
-		('some_indices', Array, (0, None, (None,), Ubyte), (False, None), None),
-		('flag_0', Ubyte, (0, None), (False, None), None),
-		('flag_1', Ubyte, (0, None), (False, None), None),
-		('flag_2', Ubyte, (0, None), (False, None), None),
-		('flag_3', Ubyte, (0, None), (False, None), None),
-		('anoth_pad', PadAlign, (4, None), (False, None), None),
-		('floatsb', FloatsGrabber, (0, None), (False, None), None),
-		('extra_pc_zero', Uint64, (0, None), (False, None), True),
-		('anoth_pad_2', PadAlign, (16, None), (False, None), None),
-		('ref_3', Empty, (0, None), (False, None), None),
-		('repeats', Array, (0, None, (None,), Repeat), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ref', Empty, (0, None), (False, None), None)
+		yield ('floatsa', Array, (0, None, (None, None,), Float), (False, None), None)
+		yield ('pad_2', SmartPadding, (0, None), (False, None), None)
+		yield ('frame_count', Uint, (0, None), (False, None), None)
+		yield ('ori_bone_count', Uint, (0, None), (False, None), None)
+		yield ('pos_bone_count', Uint, (0, None), (False, None), None)
+		yield ('scl_bone_count', Uint, (0, None), (False, None), None)
+		yield ('zeros_18', Array, (0, None, (18,), Uint), (False, None), None)
+		yield ('count', Ushort, (0, None), (False, None), None)
+		yield ('quantisation_level', Ushort, (0, None), (False, None), None)
+		yield ('ref_2', Empty, (0, None), (False, None), None)
+		yield ('some_indices', Array, (0, None, (None,), Ubyte), (False, None), None)
+		yield ('flag_0', Ubyte, (0, None), (False, None), None)
+		yield ('flag_1', Ubyte, (0, None), (False, None), None)
+		yield ('flag_2', Ubyte, (0, None), (False, None), None)
+		yield ('flag_3', Ubyte, (0, None), (False, None), None)
+		yield ('anoth_pad', PadAlign, (4, None), (False, None), None)
+		yield ('floatsb', FloatsGrabber, (0, None), (False, None), None)
+		yield ('extra_pc_zero', Uint64, (0, None), (False, None), True)
+		yield ('anoth_pad_2', PadAlign, (16, None), (False, None), None)
+		yield ('ref_3', Empty, (0, None), (False, None), None)
+		yield ('repeats', Array, (0, None, (None,), Repeat), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -111,3 +112,6 @@ class CompressedManiData(BaseStruct):
 		yield 'anoth_pad_2', PadAlign, (16, instance.ref), (False, None)
 		yield 'ref_3', Empty, (0, None), (False, None)
 		yield 'repeats', Array, (0, None, (instance.count,), Repeat), (False, None)
+
+
+CompressedManiData.init_attributes()

--- a/generated/formats/manis/compounds/FloatsGrabber.py
+++ b/generated/formats/manis/compounds/FloatsGrabber.py
@@ -13,8 +13,9 @@ class FloatsGrabber(BaseStruct):
 
 	_import_key = 'manis.compounds.FloatsGrabber'
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -47,3 +48,6 @@ class FloatsGrabber(BaseStruct):
 	@classmethod
 	def write_fields(cls, stream, instance):
 		stream.write(instance.data)
+
+
+FloatsGrabber.init_attributes()

--- a/generated/formats/manis/compounds/InfoHeader.py
+++ b/generated/formats/manis/compounds/InfoHeader.py
@@ -30,15 +30,16 @@ class InfoHeader(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('version', Uint, (0, None), (False, None), None),
-		('mani_count', Uint, (0, None), (False, None), None),
-		('names', Array, (0, None, (None,), ZString), (False, None), None),
-		('header', ManisRoot, (0, None), (False, None), None),
-		('mani_infos', Array, (0, None, (None,), ManiInfo), (False, None), None),
-		('name_buffer', Buffer1, (None, None), (False, None), None),
-		('keys_buffer', KeysReader, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('version', Uint, (0, None), (False, None), None)
+		yield ('mani_count', Uint, (0, None), (False, None), None)
+		yield ('names', Array, (0, None, (None,), ZString), (False, None), None)
+		yield ('header', ManisRoot, (0, None), (False, None), None)
+		yield ('mani_infos', Array, (0, None, (None,), ManiInfo), (False, None), None)
+		yield ('name_buffer', Buffer1, (None, None), (False, None), None)
+		yield ('keys_buffer', KeysReader, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -50,3 +51,6 @@ class InfoHeader(BaseStruct):
 		yield 'mani_infos', Array, (0, None, (instance.mani_count,), ManiInfo), (False, None)
 		yield 'name_buffer', Buffer1, (int(instance.header.hash_block_size / 4), None), (False, None)
 		yield 'keys_buffer', KeysReader, (instance.mani_infos, None), (False, None)
+
+
+InfoHeader.init_attributes()

--- a/generated/formats/manis/compounds/KeysReader.py
+++ b/generated/formats/manis/compounds/KeysReader.py
@@ -17,8 +17,9 @@ class KeysReader(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -72,3 +73,6 @@ class KeysReader(BaseStruct):
 		return s
 
 
+
+
+KeysReader.init_attributes()

--- a/generated/formats/manis/compounds/ManiBlock.py
+++ b/generated/formats/manis/compounds/ManiBlock.py
@@ -33,22 +33,23 @@ class ManiBlock(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('ref', Empty, (0, None), (False, None), None),
-		('pos_bones', Array, (0, None, (None,), Channelname), (False, None), None),
-		('ori_bones', Array, (0, None, (None,), Channelname), (False, None), None),
-		('scl_bones', Array, (0, None, (None,), Channelname), (False, None), None),
-		('floats', Array, (0, None, (None,), Channelname), (False, None), None),
-		('pos_bones_p', Array, (0, None, (None,), Ubyte), (False, None), None),
-		('ori_bones_p', Array, (0, None, (None,), Ubyte), (False, None), None),
-		('scl_bones_p', Array, (0, None, (None,), Ubyte), (False, None), None),
-		('pos_bones_delta', Array, (0, None, (None,), Ubyte), (False, None), True),
-		('ori_bones_delta', Array, (0, None, (None,), Ubyte), (False, None), True),
-		('scl_bones_delta', Array, (0, None, (None,), Ubyte), (False, None), True),
-		('pad', PadAlign, (4, None), (False, None), None),
-		('key_data', UncompressedManiData, (None, None), (False, None), True),
-		('key_data', CompressedManiData, (None, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ref', Empty, (0, None), (False, None), None)
+		yield ('pos_bones', Array, (0, None, (None,), Channelname), (False, None), None)
+		yield ('ori_bones', Array, (0, None, (None,), Channelname), (False, None), None)
+		yield ('scl_bones', Array, (0, None, (None,), Channelname), (False, None), None)
+		yield ('floats', Array, (0, None, (None,), Channelname), (False, None), None)
+		yield ('pos_bones_p', Array, (0, None, (None,), Ubyte), (False, None), None)
+		yield ('ori_bones_p', Array, (0, None, (None,), Ubyte), (False, None), None)
+		yield ('scl_bones_p', Array, (0, None, (None,), Ubyte), (False, None), None)
+		yield ('pos_bones_delta', Array, (0, None, (None,), Ubyte), (False, None), True)
+		yield ('ori_bones_delta', Array, (0, None, (None,), Ubyte), (False, None), True)
+		yield ('scl_bones_delta', Array, (0, None, (None,), Ubyte), (False, None), True)
+		yield ('pad', PadAlign, (4, None), (False, None), None)
+		yield ('key_data', UncompressedManiData, (None, None), (False, None), True)
+		yield ('key_data', CompressedManiData, (None, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -72,3 +73,6 @@ class ManiBlock(BaseStruct):
 			yield 'key_data', UncompressedManiData, (instance.arg, None), (False, None)
 		if instance.arg.b > 0:
 			yield 'key_data', CompressedManiData, (instance.arg, None), (False, None)
+
+
+ManiBlock.init_attributes()

--- a/generated/formats/manis/compounds/ManiInfo.py
+++ b/generated/formats/manis/compounds/ManiInfo.py
@@ -84,43 +84,44 @@ class ManiInfo(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('duration', Float, (0, None), (False, None), None),
-		('frame_count', Uint, (0, None), (False, None), None),
-		('b', Uint, (0, None), (False, None), None),
-		('zeros_0', Array, (0, None, (6,), Ushort), (False, None), None),
-		('extra_pc_1', Ushort, (0, None), (False, None), True),
-		('pos_bone_count', Ushort, (0, None), (False, None), None),
-		('ori_bone_count', Ushort, (0, None), (False, None), None),
-		('scl_bone_count', Ushort, (0, None), (False, None), None),
-		('extra_pc', Uint64, (0, None), (False, None), True),
-		('pos_bone_count_repeat', Ushort, (0, None), (False, None), True),
-		('ori_bone_count_repeat', Ushort, (0, None), (False, None), True),
-		('scl_bone_count_repeat', Ushort, (0, None), (False, None), True),
-		('zeros_1', Ushort, (0, None), (False, None), None),
-		('zeros_1_new', Uint, (0, None), (False, None), True),
-		('float_count', Ushort, (0, None), (False, None), None),
-		('count_a', Ubyte, (0, None), (False, None), None),
-		('count_b', Ubyte, (0, None), (False, None), None),
-		('target_bone_count', Ushort, (0, None), (False, None), None),
-		('g', Ushort, (0, None), (False, None), None),
-		('zeros_2', Array, (0, None, (57,), Uint), (False, None), None),
-		('extra_zeros_pc', Array, (0, None, (6,), Ushort), (False, None), True),
-		('pos_bone_min', Ubyte, (0, None), (False, None), None),
-		('pos_bone_max', Ubyte, (0, None), (False, None), None),
-		('ori_bone_min', Ubyte, (0, None), (False, None), None),
-		('ori_bone_max', Ubyte, (0, None), (False, None), None),
-		('scl_bone_min', Byte, (0, None), (False, None), None),
-		('scl_bone_max', Byte, (0, None), (False, None), None),
-		('pos_bone_count_related', Ubyte, (0, None), (False, None), True),
-		('pos_bone_count_repeat', Ubyte, (0, None), (False, None), True),
-		('ori_bone_count_related', Ubyte, (0, None), (False, None), True),
-		('ori_bone_count_repeat', Ubyte, (0, None), (False, None), True),
-		('scl_bone_count_related', Byte, (0, None), (False, None), True),
-		('scl_bone_count_repeat', Byte, (0, None), (False, None), True),
-		('zeros_end', Ushort, (0, None), (False, None), True),
-		('zero_2_end', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('duration', Float, (0, None), (False, None), None)
+		yield ('frame_count', Uint, (0, None), (False, None), None)
+		yield ('b', Uint, (0, None), (False, None), None)
+		yield ('zeros_0', Array, (0, None, (6,), Ushort), (False, None), None)
+		yield ('extra_pc_1', Ushort, (0, None), (False, None), True)
+		yield ('pos_bone_count', Ushort, (0, None), (False, None), None)
+		yield ('ori_bone_count', Ushort, (0, None), (False, None), None)
+		yield ('scl_bone_count', Ushort, (0, None), (False, None), None)
+		yield ('extra_pc', Uint64, (0, None), (False, None), True)
+		yield ('pos_bone_count_repeat', Ushort, (0, None), (False, None), True)
+		yield ('ori_bone_count_repeat', Ushort, (0, None), (False, None), True)
+		yield ('scl_bone_count_repeat', Ushort, (0, None), (False, None), True)
+		yield ('zeros_1', Ushort, (0, None), (False, None), None)
+		yield ('zeros_1_new', Uint, (0, None), (False, None), True)
+		yield ('float_count', Ushort, (0, None), (False, None), None)
+		yield ('count_a', Ubyte, (0, None), (False, None), None)
+		yield ('count_b', Ubyte, (0, None), (False, None), None)
+		yield ('target_bone_count', Ushort, (0, None), (False, None), None)
+		yield ('g', Ushort, (0, None), (False, None), None)
+		yield ('zeros_2', Array, (0, None, (57,), Uint), (False, None), None)
+		yield ('extra_zeros_pc', Array, (0, None, (6,), Ushort), (False, None), True)
+		yield ('pos_bone_min', Ubyte, (0, None), (False, None), None)
+		yield ('pos_bone_max', Ubyte, (0, None), (False, None), None)
+		yield ('ori_bone_min', Ubyte, (0, None), (False, None), None)
+		yield ('ori_bone_max', Ubyte, (0, None), (False, None), None)
+		yield ('scl_bone_min', Byte, (0, None), (False, None), None)
+		yield ('scl_bone_max', Byte, (0, None), (False, None), None)
+		yield ('pos_bone_count_related', Ubyte, (0, None), (False, None), True)
+		yield ('pos_bone_count_repeat', Ubyte, (0, None), (False, None), True)
+		yield ('ori_bone_count_related', Ubyte, (0, None), (False, None), True)
+		yield ('ori_bone_count_repeat', Ubyte, (0, None), (False, None), True)
+		yield ('scl_bone_count_related', Byte, (0, None), (False, None), True)
+		yield ('scl_bone_count_repeat', Byte, (0, None), (False, None), True)
+		yield ('zeros_end', Ushort, (0, None), (False, None), True)
+		yield ('zero_2_end', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -165,3 +166,6 @@ class ManiInfo(BaseStruct):
 			yield 'scl_bone_count_repeat', Byte, (0, None), (False, None)
 			yield 'zeros_end', Ushort, (0, None), (False, None)
 		yield 'zero_2_end', Ushort, (0, None), (False, None)
+
+
+ManiInfo.init_attributes()

--- a/generated/formats/manis/compounds/ManisRoot.py
+++ b/generated/formats/manis/compounds/ManisRoot.py
@@ -28,14 +28,15 @@ class ManisRoot(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('names_size', Ushort, (0, None), (False, None), None),
-		('hash_block_size', Ushort, (0, None), (False, None), None),
-		('zero_0', Uint, (0, None), (False, None), None),
-		('zero_1', Uint64, (0, None), (False, None), None),
-		('zero_2', Uint64, (0, None), (False, None), None),
-		('zero_3', Uint64, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('names_size', Ushort, (0, None), (False, None), None)
+		yield ('hash_block_size', Ushort, (0, None), (False, None), None)
+		yield ('zero_0', Uint, (0, None), (False, None), None)
+		yield ('zero_1', Uint64, (0, None), (False, None), None)
+		yield ('zero_2', Uint64, (0, None), (False, None), None)
+		yield ('zero_3', Uint64, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -47,3 +48,6 @@ class ManisRoot(BaseStruct):
 		yield 'zero_2', Uint64, (0, None), (False, None)
 		if instance.context.version >= 260:
 			yield 'zero_3', Uint64, (0, None), (False, None)
+
+
+ManisRoot.init_attributes()

--- a/generated/formats/manis/compounds/Repeat.py
+++ b/generated/formats/manis/compounds/Repeat.py
@@ -20,11 +20,12 @@ class Repeat(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('zeros_0', Array, (0, None, (7,), Uint64), (False, None), None),
-		('byte_size', Uint64, (0, None), (False, None), None),
-		('zeros_1', Array, (0, None, (2,), Uint64), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('zeros_0', Array, (0, None, (7,), Uint64), (False, None), None)
+		yield ('byte_size', Uint64, (0, None), (False, None), None)
+		yield ('zeros_1', Array, (0, None, (2,), Uint64), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -32,3 +33,6 @@ class Repeat(BaseStruct):
 		yield 'zeros_0', Array, (0, None, (7,), Uint64), (False, None)
 		yield 'byte_size', Uint64, (0, None), (False, None)
 		yield 'zeros_1', Array, (0, None, (2,), Uint64), (False, None)
+
+
+Repeat.init_attributes()

--- a/generated/formats/manis/compounds/SubChunk.py
+++ b/generated/formats/manis/compounds/SubChunk.py
@@ -25,13 +25,17 @@ class SubChunk(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('weird_list_one', Array, (0, None, (None,), WeirdElementOne), (False, None), None),
-		('weird_list_two', WeirdElementTwoReader, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('weird_list_one', Array, (0, None, (None,), WeirdElementOne), (False, None), None)
+		yield ('weird_list_two', WeirdElementTwoReader, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'weird_list_one', Array, (0, None, (instance.arg.counta,), WeirdElementOne), (False, None)
 		yield 'weird_list_two', WeirdElementTwoReader, (instance.weird_list_one, None), (False, None)
+
+
+SubChunk.init_attributes()

--- a/generated/formats/manis/compounds/SubChunkReader.py
+++ b/generated/formats/manis/compounds/SubChunkReader.py
@@ -17,8 +17,9 @@ class SubChunkReader(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -54,3 +55,6 @@ class SubChunkReader(BaseStruct):
 		return s
 
 
+
+
+SubChunkReader.init_attributes()

--- a/generated/formats/manis/compounds/UncompressedManiData.py
+++ b/generated/formats/manis/compounds/UncompressedManiData.py
@@ -20,11 +20,12 @@ class UncompressedManiData(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('pos_bones', Array, (0, None, (None, None,), Vector3), (False, None), None),
-		('ori_bones', Array, (0, None, (None, None,), Vector4H), (False, None), None),
-		('floats', Array, (0, None, (None, None,), Float), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('pos_bones', Array, (0, None, (None, None,), Vector3), (False, None), None)
+		yield ('ori_bones', Array, (0, None, (None, None,), Vector4H), (False, None), None)
+		yield ('floats', Array, (0, None, (None, None,), Float), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -32,3 +33,6 @@ class UncompressedManiData(BaseStruct):
 		yield 'pos_bones', Array, (0, None, (instance.arg.pos_bone_count, instance.arg.frame_count,), Vector3), (False, None)
 		yield 'ori_bones', Array, (0, None, (instance.arg.ori_bone_count, instance.arg.frame_count,), Vector4H), (False, None)
 		yield 'floats', Array, (0, None, (instance.arg.float_count, instance.arg.frame_count,), Float), (False, None)
+
+
+UncompressedManiData.init_attributes()

--- a/generated/formats/manis/compounds/UnkChunkList.py
+++ b/generated/formats/manis/compounds/UnkChunkList.py
@@ -30,16 +30,17 @@ class UnkChunkList(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('ref', Empty, (0, None), (False, None), None),
-		('zero_0', SmartPadding, (0, None), (False, None), None),
-		('subchunk_count', Ushort, (0, None), (False, None), None),
-		('flag', Ushort, (0, None), (False, None), None),
-		('zero_1', Uint, (0, None), (False, None), None),
-		('chunksize_list', Array, (0, None, (None,), ChunkSizes), (False, None), None),
-		('subchunk_list', SubChunkReader, (None, None), (False, None), None),
-		('pad', PadAlign, (16, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ref', Empty, (0, None), (False, None), None)
+		yield ('zero_0', SmartPadding, (0, None), (False, None), None)
+		yield ('subchunk_count', Ushort, (0, None), (False, None), None)
+		yield ('flag', Ushort, (0, None), (False, None), None)
+		yield ('zero_1', Uint, (0, None), (False, None), None)
+		yield ('chunksize_list', Array, (0, None, (None,), ChunkSizes), (False, None), None)
+		yield ('subchunk_list', SubChunkReader, (None, None), (False, None), None)
+		yield ('pad', PadAlign, (16, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -52,3 +53,6 @@ class UnkChunkList(BaseStruct):
 		yield 'chunksize_list', Array, (0, None, (instance.subchunk_count,), ChunkSizes), (False, None)
 		yield 'subchunk_list', SubChunkReader, (instance.chunksize_list, None), (False, None)
 		yield 'pad', PadAlign, (16, instance.ref), (False, None)
+
+
+UnkChunkList.init_attributes()

--- a/generated/formats/manis/compounds/Vector3.py
+++ b/generated/formats/manis/compounds/Vector3.py
@@ -26,11 +26,12 @@ class Vector3(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class Vector3(BaseStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+Vector3.init_attributes()

--- a/generated/formats/manis/compounds/Vector4H.py
+++ b/generated/formats/manis/compounds/Vector4H.py
@@ -17,12 +17,13 @@ class Vector4H(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('w', Normshort, (0, None), (False, None), None),
-		('x', Normshort, (0, None), (False, None), None),
-		('y', Normshort, (0, None), (False, None), None),
-		('z', Normshort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('w', Normshort, (0, None), (False, None), None)
+		yield ('x', Normshort, (0, None), (False, None), None)
+		yield ('y', Normshort, (0, None), (False, None), None)
+		yield ('z', Normshort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -31,3 +32,6 @@ class Vector4H(BaseStruct):
 		yield 'x', Normshort, (0, None), (False, None)
 		yield 'y', Normshort, (0, None), (False, None)
 		yield 'z', Normshort, (0, None), (False, None)
+
+
+Vector4H.init_attributes()

--- a/generated/formats/manis/compounds/WeirdElementOne.py
+++ b/generated/formats/manis/compounds/WeirdElementOne.py
@@ -23,14 +23,15 @@ class WeirdElementOne(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('float_0', Float, (0, None), (False, None), None),
-		('zero_0', Uint, (0, None), (False, None), None),
-		('floats_0', Array, (0, None, (2,), Float), (False, None), None),
-		('zeros_0', Array, (0, None, (2,), Uint64), (False, None), None),
-		('floats_1', Array, (0, None, (3,), Float), (False, None), None),
-		('countb', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('float_0', Float, (0, None), (False, None), None)
+		yield ('zero_0', Uint, (0, None), (False, None), None)
+		yield ('floats_0', Array, (0, None, (2,), Float), (False, None), None)
+		yield ('zeros_0', Array, (0, None, (2,), Uint64), (False, None), None)
+		yield ('floats_1', Array, (0, None, (3,), Float), (False, None), None)
+		yield ('countb', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class WeirdElementOne(BaseStruct):
 		yield 'zeros_0', Array, (0, None, (2,), Uint64), (False, None)
 		yield 'floats_1', Array, (0, None, (3,), Float), (False, None)
 		yield 'countb', Uint, (0, None), (False, None)
+
+
+WeirdElementOne.init_attributes()

--- a/generated/formats/manis/compounds/WeirdElementTwo.py
+++ b/generated/formats/manis/compounds/WeirdElementTwo.py
@@ -16,11 +16,15 @@ class WeirdElementTwo(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('many_floats', Array, (0, None, (7,), Float), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('many_floats', Array, (0, None, (7,), Float), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'many_floats', Array, (0, None, (7,), Float), (False, None)
+
+
+WeirdElementTwo.init_attributes()

--- a/generated/formats/manis/compounds/WeirdElementTwoReader.py
+++ b/generated/formats/manis/compounds/WeirdElementTwoReader.py
@@ -17,8 +17,9 @@ class WeirdElementTwoReader(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -54,3 +55,6 @@ class WeirdElementTwoReader(BaseStruct):
 		return s
 
 
+
+
+WeirdElementTwoReader.init_attributes()

--- a/generated/formats/matcol/compounds/Attrib.py
+++ b/generated/formats/matcol/compounds/Attrib.py
@@ -21,11 +21,12 @@ class Attrib(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('attrib_name', Pointer, (0, ZString), (False, None), None),
-		('attrib', Array, (0, None, (4,), Byte), (False, None), None),
-		('padding', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('attrib_name', Pointer, (0, ZString), (False, None), None)
+		yield ('attrib', Array, (0, None, (4,), Byte), (False, None), None)
+		yield ('padding', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -33,3 +34,6 @@ class Attrib(MemStruct):
 		yield 'attrib_name', Pointer, (0, ZString), (False, None)
 		yield 'attrib', Array, (0, None, (4,), Byte), (False, None)
 		yield 'padding', Uint, (0, None), (False, None)
+
+
+Attrib.init_attributes()

--- a/generated/formats/matcol/compounds/Info.py
+++ b/generated/formats/matcol/compounds/Info.py
@@ -23,12 +23,13 @@ class Info(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('info_name', Pointer, (0, ZString), (False, None), None),
-		('flags', Array, (0, None, (4,), Byte), (False, None), None),
-		('value', Array, (0, None, (4,), Float), (False, None), None),
-		('padding', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('info_name', Pointer, (0, ZString), (False, None), None)
+		yield ('flags', Array, (0, None, (4,), Byte), (False, None), None)
+		yield ('value', Array, (0, None, (4,), Float), (False, None), None)
+		yield ('padding', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -37,3 +38,6 @@ class Info(MemStruct):
 		yield 'flags', Array, (0, None, (4,), Byte), (False, None)
 		yield 'value', Array, (0, None, (4,), Float), (False, None)
 		yield 'padding', Uint, (0, None), (False, None)
+
+
+Info.init_attributes()

--- a/generated/formats/matcol/compounds/Layer.py
+++ b/generated/formats/matcol/compounds/Layer.py
@@ -23,14 +23,15 @@ class Layer(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('info', LayerFrag, (0, None), (False, None), None),
-		('name', ZString, (0, None), (False, None), None),
-		('infos', Array, (0, None, (None,), Info), (False, None), None),
-		('info_names', Array, (0, None, (None,), ZString), (False, None), None),
-		('attribs', Array, (0, None, (None,), Attrib), (False, None), None),
-		('attrib_names', Array, (0, None, (None,), ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('info', LayerFrag, (0, None), (False, None), None)
+		yield ('name', ZString, (0, None), (False, None), None)
+		yield ('infos', Array, (0, None, (None,), Info), (False, None), None)
+		yield ('info_names', Array, (0, None, (None,), ZString), (False, None), None)
+		yield ('attribs', Array, (0, None, (None,), Attrib), (False, None), None)
+		yield ('attrib_names', Array, (0, None, (None,), ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class Layer(BaseStruct):
 		yield 'info_names', Array, (0, None, (instance.info.info_count,), ZString), (False, None)
 		yield 'attribs', Array, (0, None, (instance.info.attrib_count,), Attrib), (False, None)
 		yield 'attrib_names', Array, (0, None, (instance.info.attrib_count,), ZString), (False, None)
+
+
+Layer.init_attributes()

--- a/generated/formats/matcol/compounds/LayerFrag.py
+++ b/generated/formats/matcol/compounds/LayerFrag.py
@@ -25,17 +25,18 @@ class LayerFrag(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('layer_name', Pointer, (0, ZString), (False, None), None),
-		('u_0', Uint64, (0, None), (False, None), None),
-		('u_1', Uint64, (0, None), (False, None), None),
-		('infos', ArrayPointer, (None, None), (False, None), None),
-		('info_count', Uint64, (0, None), (False, None), None),
-		('u_2', Uint64, (0, None), (False, None), None),
-		('u_3', Uint64, (0, None), (False, None), None),
-		('attribs', ArrayPointer, (None, None), (False, None), None),
-		('attrib_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('layer_name', Pointer, (0, ZString), (False, None), None)
+		yield ('u_0', Uint64, (0, None), (False, None), None)
+		yield ('u_1', Uint64, (0, None), (False, None), None)
+		yield ('infos', ArrayPointer, (None, None), (False, None), None)
+		yield ('info_count', Uint64, (0, None), (False, None), None)
+		yield ('u_2', Uint64, (0, None), (False, None), None)
+		yield ('u_3', Uint64, (0, None), (False, None), None)
+		yield ('attribs', ArrayPointer, (None, None), (False, None), None)
+		yield ('attrib_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -49,3 +50,6 @@ class LayerFrag(MemStruct):
 		yield 'u_3', Uint64, (0, None), (False, None)
 		yield 'attribs', ArrayPointer, (instance.attrib_count, LayerFrag._import_map["matcol.compounds.Attrib"]), (False, None)
 		yield 'attrib_count', Uint64, (0, None), (False, None)
+
+
+LayerFrag.init_attributes()

--- a/generated/formats/matcol/compounds/MatcolRoot.py
+++ b/generated/formats/matcol/compounds/MatcolRoot.py
@@ -22,13 +22,17 @@ class MatcolRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('main', Pointer, (0, None), (False, None), None),
-		('one', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('main', Pointer, (0, None), (False, None), None)
+		yield ('one', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'main', Pointer, (0, MatcolRoot._import_map["matcol.compounds.RootFrag"]), (False, None)
 		yield 'one', Uint64, (0, None), (False, None)
+
+
+MatcolRoot.init_attributes()

--- a/generated/formats/matcol/compounds/RootFrag.py
+++ b/generated/formats/matcol/compounds/RootFrag.py
@@ -25,14 +25,15 @@ class RootFrag(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('mat_type', Uint64, (0, None), (False, None), None),
-		('textures', ArrayPointer, (None, None), (False, None), None),
-		('tex_count', Uint64, (0, None), (False, None), None),
-		('materials', ArrayPointer, (None, None), (False, None), None),
-		('mat_count', Uint64, (0, None), (False, None), None),
-		('unk', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('mat_type', Uint64, (0, None), (False, None), None)
+		yield ('textures', ArrayPointer, (None, None), (False, None), None)
+		yield ('tex_count', Uint64, (0, None), (False, None), None)
+		yield ('materials', ArrayPointer, (None, None), (False, None), None)
+		yield ('mat_count', Uint64, (0, None), (False, None), None)
+		yield ('unk', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -43,3 +44,6 @@ class RootFrag(MemStruct):
 		yield 'materials', ArrayPointer, (instance.mat_count, RootFrag._import_map["matcol.compounds.LayerFrag"]), (False, None)
 		yield 'mat_count', Uint64, (0, None), (False, None)
 		yield 'unk', Uint64, (0, None), (False, None)
+
+
+RootFrag.init_attributes()

--- a/generated/formats/matcol/compounds/Texture.py
+++ b/generated/formats/matcol/compounds/Texture.py
@@ -19,11 +19,12 @@ class Texture(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('fgm_name', Pointer, (0, ZString), (False, None), None),
-		('texture_suffix', Pointer, (0, ZString), (False, None), None),
-		('texture_type', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('fgm_name', Pointer, (0, ZString), (False, None), None)
+		yield ('texture_suffix', Pointer, (0, ZString), (False, None), None)
+		yield ('texture_type', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -31,3 +32,6 @@ class Texture(MemStruct):
 		yield 'fgm_name', Pointer, (0, ZString), (False, None)
 		yield 'texture_suffix', Pointer, (0, ZString), (False, None)
 		yield 'texture_type', Pointer, (0, ZString), (False, None)
+
+
+Texture.init_attributes()

--- a/generated/formats/mechanicresearch/compounds/NextResearch.py
+++ b/generated/formats/mechanicresearch/compounds/NextResearch.py
@@ -18,13 +18,17 @@ class NextResearch(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('item_name', Array, (0, ZString, (None,), Pointer), (False, None), None),
-		('unk_1', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('item_name', Array, (0, ZString, (None,), Pointer), (False, None), None)
+		yield ('unk_1', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'item_name', Array, (0, ZString, (instance.arg,), Pointer), (False, None)
 		yield 'unk_1', Uint64, (0, None), (False, None)
+
+
+NextResearch.init_attributes()

--- a/generated/formats/mechanicresearch/compounds/PtrList.py
+++ b/generated/formats/mechanicresearch/compounds/PtrList.py
@@ -16,11 +16,15 @@ class PtrList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, ZString, (instance.arg,), Pointer), (False, None)
+
+
+PtrList.init_attributes()

--- a/generated/formats/mechanicresearch/compounds/Research.py
+++ b/generated/formats/mechanicresearch/compounds/Research.py
@@ -24,16 +24,17 @@ class Research(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('item_name', Pointer, (0, ZString), (False, None), None),
-		('unk_0', Uint, (0, None), (False, None), None),
-		('is_entry_level', Uint, (0, None), (False, None), None),
-		('unk_2', Uint64, (0, None), (False, None), None),
-		('next_research', Pointer, (None, None), (False, None), None),
-		('next_research_count', Uint64, (0, None), (False, None), None),
-		('unk_3', Uint64, (0, None), (False, None), None),
-		('unk_4', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('item_name', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_0', Uint, (0, None), (False, None), None)
+		yield ('is_entry_level', Uint, (0, None), (False, None), None)
+		yield ('unk_2', Uint64, (0, None), (False, None), None)
+		yield ('next_research', Pointer, (None, None), (False, None), None)
+		yield ('next_research_count', Uint64, (0, None), (False, None), None)
+		yield ('unk_3', Uint64, (0, None), (False, None), None)
+		yield ('unk_4', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -46,3 +47,6 @@ class Research(MemStruct):
 		yield 'next_research_count', Uint64, (0, None), (False, None)
 		yield 'unk_3', Uint64, (0, None), (False, None)
 		yield 'unk_4', Uint64, (0, None), (False, None)
+
+
+Research.init_attributes()

--- a/generated/formats/mechanicresearch/compounds/ResearchRoot.py
+++ b/generated/formats/mechanicresearch/compounds/ResearchRoot.py
@@ -16,13 +16,17 @@ class ResearchRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('levels', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('levels', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'levels', ArrayPointer, (instance.count, ResearchRoot._import_map["mechanicresearch.compounds.Research"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
+
+
+ResearchRoot.init_attributes()

--- a/generated/formats/mergedetails/compounds/MergedetailsRoot.py
+++ b/generated/formats/mergedetails/compounds/MergedetailsRoot.py
@@ -27,15 +27,16 @@ class MergedetailsRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('merge_names', Pointer, (None, None), (False, None), None),
-		('zero_0', Uint64, (0, None), (False, None), None),
-		('zero_1', Uint64, (0, None), (False, None), None),
-		('queries', Pointer, (None, None), (False, None), None),
-		('field_name', Pointer, (0, ZString), (False, None), None),
-		('count', Uint, (0, None), (False, None), None),
-		('flag', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('merge_names', Pointer, (None, None), (False, None), None)
+		yield ('zero_0', Uint64, (0, None), (False, None), None)
+		yield ('zero_1', Uint64, (0, None), (False, None), None)
+		yield ('queries', Pointer, (None, None), (False, None), None)
+		yield ('field_name', Pointer, (0, ZString), (False, None), None)
+		yield ('count', Uint, (0, None), (False, None), None)
+		yield ('flag', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -47,3 +48,6 @@ class MergedetailsRoot(MemStruct):
 		yield 'field_name', Pointer, (0, ZString), (False, None)
 		yield 'count', Uint, (0, None), (False, None)
 		yield 'flag', Uint, (0, None), (False, None)
+
+
+MergedetailsRoot.init_attributes()

--- a/generated/formats/mergedetails/compounds/PtrList.py
+++ b/generated/formats/mergedetails/compounds/PtrList.py
@@ -16,11 +16,15 @@ class PtrList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, ZString, (instance.arg,), Pointer), (False, None)
+
+
+PtrList.init_attributes()

--- a/generated/formats/motiongraph/compounds/Activities.py
+++ b/generated/formats/motiongraph/compounds/Activities.py
@@ -15,11 +15,15 @@ class Activities(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('states', Array, (0, None, (None,), ActivityEntry), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('states', Array, (0, None, (None,), ActivityEntry), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'states', Array, (0, None, (instance.arg,), ActivityEntry), (False, None)
+
+
+Activities.init_attributes()

--- a/generated/formats/motiongraph/compounds/ActivitiesLink.py
+++ b/generated/formats/motiongraph/compounds/ActivitiesLink.py
@@ -14,11 +14,15 @@ class ActivitiesLink(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('linked', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('linked', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'linked', Pointer, (0, None), (False, None)
+
+
+ActivitiesLink.init_attributes()

--- a/generated/formats/motiongraph/compounds/ActivitiesLinks.py
+++ b/generated/formats/motiongraph/compounds/ActivitiesLinks.py
@@ -15,11 +15,15 @@ class ActivitiesLinks(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('activities', Array, (0, None, (None,), ActivitiesLink), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('activities', Array, (0, None, (None,), ActivitiesLink), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'activities', Array, (0, None, (instance.arg,), ActivitiesLink), (False, None)
+
+
+ActivitiesLinks.init_attributes()

--- a/generated/formats/motiongraph/compounds/Activity.py
+++ b/generated/formats/motiongraph/compounds/Activity.py
@@ -38,14 +38,15 @@ class Activity(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('data_type', Pointer, (0, ZString), (False, None), None),
-		('ptr', Pointer, (0, None), (False, None), None),
-		('count_2', Uint64, (0, None), (False, None), None),
-		('count_3', Uint64, (0, None), (False, None), None),
-		('minus_one', Int64, (0, None), (False, None), None),
-		('name_b', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('data_type', Pointer, (0, ZString), (False, None), None)
+		yield ('ptr', Pointer, (0, None), (False, None), None)
+		yield ('count_2', Uint64, (0, None), (False, None), None)
+		yield ('count_3', Uint64, (0, None), (False, None), None)
+		yield ('minus_one', Int64, (0, None), (False, None), None)
+		yield ('name_b', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -68,3 +69,6 @@ class Activity(MemStruct):
 			except:
 				logging.warning(f"Unsupported activity '{activity}'")
 
+
+
+Activity.init_attributes()

--- a/generated/formats/motiongraph/compounds/ActivityEntry.py
+++ b/generated/formats/motiongraph/compounds/ActivityEntry.py
@@ -18,11 +18,15 @@ class ActivityEntry(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('value', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('value', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'value', Pointer, (0, ActivityEntry._import_map["motiongraph.compounds.Activity"]), (False, None)
+
+
+ActivityEntry.init_attributes()

--- a/generated/formats/motiongraph/compounds/AnimationActivityData.py
+++ b/generated/formats/motiongraph/compounds/AnimationActivityData.py
@@ -35,19 +35,20 @@ class AnimationActivityData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('mani', Pointer, (0, ZString), (False, None), None),
-		('animation_flags', AnimationFlags, (0, None), (False, None), None),
-		('priorities', Uint, (0, None), (False, None), None),
-		('weight', FloatInputData, (0, None), (False, None), None),
-		('speed', FloatInputData, (0, None), (False, None), None),
-		('starting_prop_through', Float, (0, None), (False, None), None),
-		('lead_out_time', Float, (0, None), (False, None), None),
-		('sync_prop_through_variable', Pointer, (0, ZString), (False, None), None),
-		('count_6', Uint64, (0, None), (False, None), None),
-		('output_prop_through_variable', Pointer, (0, ZString), (False, None), None),
-		('additional_data_streams', DataStreamResourceDataList, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('mani', Pointer, (0, ZString), (False, None), None)
+		yield ('animation_flags', AnimationFlags, (0, None), (False, None), None)
+		yield ('priorities', Uint, (0, None), (False, None), None)
+		yield ('weight', FloatInputData, (0, None), (False, None), None)
+		yield ('speed', FloatInputData, (0, None), (False, None), None)
+		yield ('starting_prop_through', Float, (0, None), (False, None), None)
+		yield ('lead_out_time', Float, (0, None), (False, None), None)
+		yield ('sync_prop_through_variable', Pointer, (0, ZString), (False, None), None)
+		yield ('count_6', Uint64, (0, None), (False, None), None)
+		yield ('output_prop_through_variable', Pointer, (0, ZString), (False, None), None)
+		yield ('additional_data_streams', DataStreamResourceDataList, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -63,3 +64,6 @@ class AnimationActivityData(MemStruct):
 		yield 'count_6', Uint64, (0, None), (False, None)
 		yield 'output_prop_through_variable', Pointer, (0, ZString), (False, None)
 		yield 'additional_data_streams', DataStreamResourceDataList, (0, None), (False, None)
+
+
+AnimationActivityData.init_attributes()

--- a/generated/formats/motiongraph/compounds/BlendSpaceAxis.py
+++ b/generated/formats/motiongraph/compounds/BlendSpaceAxis.py
@@ -19,11 +19,15 @@ class BlendSpaceAxis(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('variable_name', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('variable_name', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'variable_name', Pointer, (0, ZString), (False, None)
+
+
+BlendSpaceAxis.init_attributes()

--- a/generated/formats/motiongraph/compounds/CoordinatedAnimationActivityData.py
+++ b/generated/formats/motiongraph/compounds/CoordinatedAnimationActivityData.py
@@ -32,18 +32,19 @@ class CoordinatedAnimationActivityData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('coord_group', Pointer, (0, ZString), (False, None), None),
-		('waiting_anim', Pointer, (0, ZString), (False, None), None),
-		('waiting_anim_data_streams', DataStreamResourceDataList, (0, None), (False, None), None),
-		('coordinated_anim', Pointer, (0, ZString), (False, None), None),
-		('coordinated_anim_data_streams', DataStreamResourceDataList, (0, None), (False, None), None),
-		('priorities', Ubyte, (0, None), (False, None), None),
-		('looping', Ubyte, (0, None), (False, None), None),
-		('_pad', Ushort, (0, None), (False, None), None),
-		('blend_time', Float, (0, None), (False, None), None),
-		('output_prop_through_variable', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('coord_group', Pointer, (0, ZString), (False, None), None)
+		yield ('waiting_anim', Pointer, (0, ZString), (False, None), None)
+		yield ('waiting_anim_data_streams', DataStreamResourceDataList, (0, None), (False, None), None)
+		yield ('coordinated_anim', Pointer, (0, ZString), (False, None), None)
+		yield ('coordinated_anim_data_streams', DataStreamResourceDataList, (0, None), (False, None), None)
+		yield ('priorities', Ubyte, (0, None), (False, None), None)
+		yield ('looping', Ubyte, (0, None), (False, None), None)
+		yield ('_pad', Ushort, (0, None), (False, None), None)
+		yield ('blend_time', Float, (0, None), (False, None), None)
+		yield ('output_prop_through_variable', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -58,3 +59,6 @@ class CoordinatedAnimationActivityData(MemStruct):
 		yield '_pad', Ushort, (0, None), (False, None)
 		yield 'blend_time', Float, (0, None), (False, None)
 		yield 'output_prop_through_variable', Pointer, (0, ZString), (False, None)
+
+
+CoordinatedAnimationActivityData.init_attributes()

--- a/generated/formats/motiongraph/compounds/CurveData.py
+++ b/generated/formats/motiongraph/compounds/CurveData.py
@@ -20,13 +20,17 @@ class CurveData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('count', Uint64, (0, None), (False, None), None),
-		('points', Pointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('count', Uint64, (0, None), (False, None), None)
+		yield ('points', Pointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'count', Uint64, (0, None), (False, None)
 		yield 'points', Pointer, (instance.count, CurveData._import_map["motiongraph.compounds.CurveDataPoints"]), (False, None)
+
+
+CurveData.init_attributes()

--- a/generated/formats/motiongraph/compounds/CurveDataPoint.py
+++ b/generated/formats/motiongraph/compounds/CurveDataPoint.py
@@ -24,13 +24,14 @@ class CurveDataPoint(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Short, (0, None), (False, None), None),
-		('sub_curve_type', SubCurveType, (0, None), (False, None), None),
-		('subsequent_curve_param', Short, (0, None), (False, None), None),
-		('subsequent_curve_param_b', Short, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Short, (0, None), (False, None), None)
+		yield ('sub_curve_type', SubCurveType, (0, None), (False, None), None)
+		yield ('subsequent_curve_param', Short, (0, None), (False, None), None)
+		yield ('subsequent_curve_param_b', Short, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -40,3 +41,6 @@ class CurveDataPoint(MemStruct):
 		yield 'sub_curve_type', SubCurveType, (0, None), (False, None)
 		yield 'subsequent_curve_param', Short, (0, None), (False, None)
 		yield 'subsequent_curve_param_b', Short, (0, None), (False, None)
+
+
+CurveDataPoint.init_attributes()

--- a/generated/formats/motiongraph/compounds/CurveDataPoints.py
+++ b/generated/formats/motiongraph/compounds/CurveDataPoints.py
@@ -19,11 +19,15 @@ class CurveDataPoints(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('data', Array, (0, None, (None,), CurveDataPoint), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('data', Array, (0, None, (None,), CurveDataPoint), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'data', Array, (0, None, (instance.arg,), CurveDataPoint), (False, None)
+
+
+CurveDataPoints.init_attributes()

--- a/generated/formats/motiongraph/compounds/DataStreamProducerActivityData.py
+++ b/generated/formats/motiongraph/compounds/DataStreamProducerActivityData.py
@@ -31,17 +31,18 @@ class DataStreamProducerActivityData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('curve_type', Uint64, (0, None), (False, None), None),
-		('ds_name', Pointer, (0, ZString), (False, None), None),
-		('type', Pointer, (0, ZString), (False, None), None),
-		('bone_i_d', Pointer, (0, ZString), (False, None), None),
-		('location', Pointer, (0, ZString), (False, None), None),
-		('curve', CurveData, (0, None), (False, None), None),
-		('time_limit_mode', TimeLimitMode, (0, None), (False, None), None),
-		('data_stream_producer_flags', Uint, (0, None), (False, None), None),
-		('prop_through_variable', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('curve_type', Uint64, (0, None), (False, None), None)
+		yield ('ds_name', Pointer, (0, ZString), (False, None), None)
+		yield ('type', Pointer, (0, ZString), (False, None), None)
+		yield ('bone_i_d', Pointer, (0, ZString), (False, None), None)
+		yield ('location', Pointer, (0, ZString), (False, None), None)
+		yield ('curve', CurveData, (0, None), (False, None), None)
+		yield ('time_limit_mode', TimeLimitMode, (0, None), (False, None), None)
+		yield ('data_stream_producer_flags', Uint, (0, None), (False, None), None)
+		yield ('prop_through_variable', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -55,3 +56,6 @@ class DataStreamProducerActivityData(MemStruct):
 		yield 'time_limit_mode', TimeLimitMode, (0, None), (False, None)
 		yield 'data_stream_producer_flags', Uint, (0, None), (False, None)
 		yield 'prop_through_variable', Pointer, (0, ZString), (False, None)
+
+
+DataStreamProducerActivityData.init_attributes()

--- a/generated/formats/motiongraph/compounds/DataStreamResourceData.py
+++ b/generated/formats/motiongraph/compounds/DataStreamResourceData.py
@@ -26,14 +26,15 @@ class DataStreamResourceData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('curve_type', Uint64, (0, None), (False, None), None),
-		('ds_name', Pointer, (0, ZString), (False, None), None),
-		('type', Pointer, (0, ZString), (False, None), None),
-		('bone_i_d', Pointer, (0, ZString), (False, None), None),
-		('location', Pointer, (0, ZString), (False, None), None),
-		('curve', CurveData, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('curve_type', Uint64, (0, None), (False, None), None)
+		yield ('ds_name', Pointer, (0, ZString), (False, None), None)
+		yield ('type', Pointer, (0, ZString), (False, None), None)
+		yield ('bone_i_d', Pointer, (0, ZString), (False, None), None)
+		yield ('location', Pointer, (0, ZString), (False, None), None)
+		yield ('curve', CurveData, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -44,3 +45,6 @@ class DataStreamResourceData(MemStruct):
 		yield 'bone_i_d', Pointer, (0, ZString), (False, None)
 		yield 'location', Pointer, (0, ZString), (False, None)
 		yield 'curve', CurveData, (0, None), (False, None)
+
+
+DataStreamResourceData.init_attributes()

--- a/generated/formats/motiongraph/compounds/DataStreamResourceDataList.py
+++ b/generated/formats/motiongraph/compounds/DataStreamResourceDataList.py
@@ -20,13 +20,17 @@ class DataStreamResourceDataList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('count', Uint64, (0, None), (False, None), None),
-		('data_stream_resource_data', Pointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('count', Uint64, (0, None), (False, None), None)
+		yield ('data_stream_resource_data', Pointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'count', Uint64, (0, None), (False, None)
 		yield 'data_stream_resource_data', Pointer, (instance.count, DataStreamResourceDataList._import_map["motiongraph.compounds.DataStreamResourceDataPoints"]), (False, None)
+
+
+DataStreamResourceDataList.init_attributes()

--- a/generated/formats/motiongraph/compounds/DataStreamResourceDataPoints.py
+++ b/generated/formats/motiongraph/compounds/DataStreamResourceDataPoints.py
@@ -19,11 +19,15 @@ class DataStreamResourceDataPoints(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('data', Array, (0, None, (None,), DataStreamResourceData), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('data', Array, (0, None, (None,), DataStreamResourceData), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'data', Array, (0, None, (instance.arg,), DataStreamResourceData), (False, None)
+
+
+DataStreamResourceDataPoints.init_attributes()

--- a/generated/formats/motiongraph/compounds/FloatInputData.py
+++ b/generated/formats/motiongraph/compounds/FloatInputData.py
@@ -22,11 +22,12 @@ class FloatInputData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('float', Float, (0, None), (False, None), None),
-		('optional_var_and_curve_count', Uint, (0, None), (False, None), None),
-		('optional_var_and_curve', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('float', Float, (0, None), (False, None), None)
+		yield ('optional_var_and_curve_count', Uint, (0, None), (False, None), None)
+		yield ('optional_var_and_curve', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -34,3 +35,6 @@ class FloatInputData(MemStruct):
 		yield 'float', Float, (0, None), (False, None)
 		yield 'optional_var_and_curve_count', Uint, (0, None), (False, None)
 		yield 'optional_var_and_curve', Uint64, (0, None), (False, None)
+
+
+FloatInputData.init_attributes()

--- a/generated/formats/motiongraph/compounds/FootPlantActivityData.py
+++ b/generated/formats/motiongraph/compounds/FootPlantActivityData.py
@@ -20,11 +20,12 @@ class FootPlantActivityData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('weight', FloatInputData, (0, None), (False, None), None),
-		('rotation_no_i_k_weight', FloatInputData, (0, None), (False, None), None),
-		('sticky_feet_weight', FloatInputData, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('weight', FloatInputData, (0, None), (False, None), None)
+		yield ('rotation_no_i_k_weight', FloatInputData, (0, None), (False, None), None)
+		yield ('sticky_feet_weight', FloatInputData, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -32,3 +33,6 @@ class FootPlantActivityData(MemStruct):
 		yield 'weight', FloatInputData, (0, None), (False, None)
 		yield 'rotation_no_i_k_weight', FloatInputData, (0, None), (False, None)
 		yield 'sticky_feet_weight', FloatInputData, (0, None), (False, None)
+
+
+FootPlantActivityData.init_attributes()

--- a/generated/formats/motiongraph/compounds/ForwardActivityData.py
+++ b/generated/formats/motiongraph/compounds/ForwardActivityData.py
@@ -50,34 +50,35 @@ class ForwardActivityData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('straight_forward_animation', Pointer, (0, ZString), (False, None), None),
-		('left_forward_animation', Pointer, (0, ZString), (False, None), None),
-		('right_forward_animation', Pointer, (0, ZString), (False, None), None),
-		('straight_spot_animation', Pointer, (0, ZString), (False, None), None),
-		('output_prop_through_variable', Pointer, (0, ZString), (False, None), None),
-		('cycled_variable', Pointer, (0, ZString), (False, None), None),
-		('straight_forward_data_streams', DataStreamResourceDataList, (0, None), (False, None), None),
-		('left_forward_data_streams', DataStreamResourceDataList, (0, None), (False, None), None),
-		('right_forward_data_streams', DataStreamResourceDataList, (0, None), (False, None), None),
-		('straight_spot_data_streams', DataStreamResourceDataList, (0, None), (False, None), None),
-		('forward_flags', Ubyte, (0, None), (False, None), None),
-		('suppress_resource_data_streams', Ubyte, (0, None), (False, None), None),
-		('priorities', Ushort, (0, None), (False, None), None),
-		('turn_radius', Float, (0, None), (False, None), None),
-		('turn_radius_value_type', UseValueType, (0, None), (False, None), None),
-		('_pad_0', Ushort, (0, None), (False, None), None),
-		('stride_length', Float, (0, None), (False, None), None),
-		('stride_length_value_type', UseValueType, (0, None), (False, None), None),
-		('_pad_1', Ushort, (0, None), (False, None), None),
-		('lead_out_time', Float, (0, None), (False, None), None),
-		('anticipation_distance', Float, (0, None), (False, None), None),
-		('unfused_cycles', Uint, (0, None), (False, None), None),
-		('cycle_count', Uint, (0, None), (False, None), None),
-		('repeat_count', Uint, (0, None), (False, None), None),
-		('min_cycles', Uint, (0, None), (False, None), None),
-		('playback_rate', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('straight_forward_animation', Pointer, (0, ZString), (False, None), None)
+		yield ('left_forward_animation', Pointer, (0, ZString), (False, None), None)
+		yield ('right_forward_animation', Pointer, (0, ZString), (False, None), None)
+		yield ('straight_spot_animation', Pointer, (0, ZString), (False, None), None)
+		yield ('output_prop_through_variable', Pointer, (0, ZString), (False, None), None)
+		yield ('cycled_variable', Pointer, (0, ZString), (False, None), None)
+		yield ('straight_forward_data_streams', DataStreamResourceDataList, (0, None), (False, None), None)
+		yield ('left_forward_data_streams', DataStreamResourceDataList, (0, None), (False, None), None)
+		yield ('right_forward_data_streams', DataStreamResourceDataList, (0, None), (False, None), None)
+		yield ('straight_spot_data_streams', DataStreamResourceDataList, (0, None), (False, None), None)
+		yield ('forward_flags', Ubyte, (0, None), (False, None), None)
+		yield ('suppress_resource_data_streams', Ubyte, (0, None), (False, None), None)
+		yield ('priorities', Ushort, (0, None), (False, None), None)
+		yield ('turn_radius', Float, (0, None), (False, None), None)
+		yield ('turn_radius_value_type', UseValueType, (0, None), (False, None), None)
+		yield ('_pad_0', Ushort, (0, None), (False, None), None)
+		yield ('stride_length', Float, (0, None), (False, None), None)
+		yield ('stride_length_value_type', UseValueType, (0, None), (False, None), None)
+		yield ('_pad_1', Ushort, (0, None), (False, None), None)
+		yield ('lead_out_time', Float, (0, None), (False, None), None)
+		yield ('anticipation_distance', Float, (0, None), (False, None), None)
+		yield ('unfused_cycles', Uint, (0, None), (False, None), None)
+		yield ('cycle_count', Uint, (0, None), (False, None), None)
+		yield ('repeat_count', Uint, (0, None), (False, None), None)
+		yield ('min_cycles', Uint, (0, None), (False, None), None)
+		yield ('playback_rate', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -108,3 +109,6 @@ class ForwardActivityData(MemStruct):
 		yield 'repeat_count', Uint, (0, None), (False, None)
 		yield 'min_cycles', Uint, (0, None), (False, None)
 		yield 'playback_rate', Float, (0, None), (False, None)
+
+
+ForwardActivityData.init_attributes()

--- a/generated/formats/motiongraph/compounds/Locomotion2ActivityData.py
+++ b/generated/formats/motiongraph/compounds/Locomotion2ActivityData.py
@@ -37,22 +37,23 @@ class Locomotion2ActivityData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('animation_count', Uint64, (0, None), (False, None), None),
-		('animations', ArrayPointer, (None, None), (False, None), None),
-		('flags', Uint, (0, None), (False, None), None),
-		('stopping_distance', Float, (0, None), (False, 0.0), None),
-		('strafe_turn_blend', Float, (0, None), (False, 0.2), None),
-		('turn_blend_limit', Float, (0, None), (False, 1.0), None),
-		('turn_speed_multiplier', Float, (0, None), (False, 1.0), None),
-		('flex_speed_multiplier', Float, (0, None), (False, 1.0), None),
-		('blend_space', Locomotion2BlendSpace, (0, None), (False, None), None),
-		('output_prop_through_variable', Pointer, (0, ZString), (False, None), None),
-		('speed_variable', Pointer, (0, ZString), (False, None), None),
-		('orientation_variable', Pointer, (0, ZString), (False, None), None),
-		('data_streams_count', Uint64, (0, None), (False, None), None),
-		('data_streams', ArrayPointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('animation_count', Uint64, (0, None), (False, None), None)
+		yield ('animations', ArrayPointer, (None, None), (False, None), None)
+		yield ('flags', Uint, (0, None), (False, None), None)
+		yield ('stopping_distance', Float, (0, None), (False, 0.0), None)
+		yield ('strafe_turn_blend', Float, (0, None), (False, 0.2), None)
+		yield ('turn_blend_limit', Float, (0, None), (False, 1.0), None)
+		yield ('turn_speed_multiplier', Float, (0, None), (False, 1.0), None)
+		yield ('flex_speed_multiplier', Float, (0, None), (False, 1.0), None)
+		yield ('blend_space', Locomotion2BlendSpace, (0, None), (False, None), None)
+		yield ('output_prop_through_variable', Pointer, (0, ZString), (False, None), None)
+		yield ('speed_variable', Pointer, (0, ZString), (False, None), None)
+		yield ('orientation_variable', Pointer, (0, ZString), (False, None), None)
+		yield ('data_streams_count', Uint64, (0, None), (False, None), None)
+		yield ('data_streams', ArrayPointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -71,3 +72,6 @@ class Locomotion2ActivityData(MemStruct):
 		yield 'orientation_variable', Pointer, (0, ZString), (False, None)
 		yield 'data_streams_count', Uint64, (0, None), (False, None)
 		yield 'data_streams', ArrayPointer, (instance.data_streams_count, Locomotion2ActivityData._import_map["motiongraph.compounds.DataStreamResourceDataList"]), (False, None)
+
+
+Locomotion2ActivityData.init_attributes()

--- a/generated/formats/motiongraph/compounds/Locomotion2AnimationInfo.py
+++ b/generated/formats/motiongraph/compounds/Locomotion2AnimationInfo.py
@@ -26,13 +26,14 @@ class Locomotion2AnimationInfo(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('anim_name', Pointer, (0, ZString), (False, None), None),
-		('phase_entry_window', Float, (0, None), (False, 1.5), None),
-		('priority', Ushort, (0, None), (False, None), None),
-		('anim_type', Ubyte, (0, None), (False, None), None),
-		('_pad', Ubyte, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('anim_name', Pointer, (0, ZString), (False, None), None)
+		yield ('phase_entry_window', Float, (0, None), (False, 1.5), None)
+		yield ('priority', Ushort, (0, None), (False, None), None)
+		yield ('anim_type', Ubyte, (0, None), (False, None), None)
+		yield ('_pad', Ubyte, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -42,3 +43,6 @@ class Locomotion2AnimationInfo(MemStruct):
 		yield 'priority', Ushort, (0, None), (False, None)
 		yield 'anim_type', Ubyte, (0, None), (False, None)
 		yield '_pad', Ubyte, (0, None), (False, None)
+
+
+Locomotion2AnimationInfo.init_attributes()

--- a/generated/formats/motiongraph/compounds/Locomotion2BlendSpace.py
+++ b/generated/formats/motiongraph/compounds/Locomotion2BlendSpace.py
@@ -23,12 +23,13 @@ class Locomotion2BlendSpace(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('y_axis', BlendSpaceAxis, (0, None), (False, None), None),
-		('x_axis', BlendSpaceAxis, (0, None), (False, None), None),
-		('nodes_count', Uint64, (0, None), (False, None), None),
-		('nodes', ArrayPointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('y_axis', BlendSpaceAxis, (0, None), (False, None), None)
+		yield ('x_axis', BlendSpaceAxis, (0, None), (False, None), None)
+		yield ('nodes_count', Uint64, (0, None), (False, None), None)
+		yield ('nodes', ArrayPointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -37,3 +38,6 @@ class Locomotion2BlendSpace(MemStruct):
 		yield 'x_axis', BlendSpaceAxis, (0, None), (False, None)
 		yield 'nodes_count', Uint64, (0, None), (False, None)
 		yield 'nodes', ArrayPointer, (instance.nodes_count, Locomotion2BlendSpace._import_map["motiongraph.compounds.Locomotion2BlendSpaceNode"]), (False, None)
+
+
+Locomotion2BlendSpace.init_attributes()

--- a/generated/formats/motiongraph/compounds/Locomotion2BlendSpaceNode.py
+++ b/generated/formats/motiongraph/compounds/Locomotion2BlendSpaceNode.py
@@ -22,11 +22,12 @@ class Locomotion2BlendSpaceNode(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('anim_name', Pointer, (0, ZString), (False, None), None),
-		('speed', Float, (0, None), (False, None), None),
-		('orientation', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('anim_name', Pointer, (0, ZString), (False, None), None)
+		yield ('speed', Float, (0, None), (False, None), None)
+		yield ('orientation', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -34,3 +35,6 @@ class Locomotion2BlendSpaceNode(MemStruct):
 		yield 'anim_name', Pointer, (0, ZString), (False, None)
 		yield 'speed', Float, (0, None), (False, None)
 		yield 'orientation', Float, (0, None), (False, None)
+
+
+Locomotion2BlendSpaceNode.init_attributes()

--- a/generated/formats/motiongraph/compounds/LuaModules.py
+++ b/generated/formats/motiongraph/compounds/LuaModules.py
@@ -21,11 +21,12 @@ class LuaModules(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('motion_graph', Pointer, (0, ZString), (False, None), None),
-		('motion_graph_event_handling', Pointer, (0, ZString), (False, None), None),
-		('motion_graph_actions', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('motion_graph', Pointer, (0, ZString), (False, None), None)
+		yield ('motion_graph_event_handling', Pointer, (0, ZString), (False, None), None)
+		yield ('motion_graph_actions', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -33,3 +34,6 @@ class LuaModules(MemStruct):
 		yield 'motion_graph', Pointer, (0, ZString), (False, None)
 		yield 'motion_graph_event_handling', Pointer, (0, ZString), (False, None)
 		yield 'motion_graph_actions', Pointer, (0, ZString), (False, None)
+
+
+LuaModules.init_attributes()

--- a/generated/formats/motiongraph/compounds/MGTwo.py
+++ b/generated/formats/motiongraph/compounds/MGTwo.py
@@ -20,13 +20,17 @@ class MGTwo(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('count', Uint64, (0, None), (False, None), None),
-		('ptr', Pointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('count', Uint64, (0, None), (False, None), None)
+		yield ('ptr', Pointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'count', Uint64, (0, None), (False, None)
 		yield 'ptr', Pointer, (instance.count, MGTwo._import_map["motiongraph.compounds.PtrList"]), (False, None)
+
+
+MGTwo.init_attributes()

--- a/generated/formats/motiongraph/compounds/MRFArray1.py
+++ b/generated/formats/motiongraph/compounds/MRFArray1.py
@@ -15,11 +15,15 @@ class MRFArray1(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('states', Array, (0, None, (None,), MRFEntry1), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('states', Array, (0, None, (None,), MRFEntry1), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'states', Array, (0, None, (instance.arg,), MRFEntry1), (False, None)
+
+
+MRFArray1.init_attributes()

--- a/generated/formats/motiongraph/compounds/MRFArray2.py
+++ b/generated/formats/motiongraph/compounds/MRFArray2.py
@@ -15,11 +15,15 @@ class MRFArray2(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('states', Array, (0, None, (None,), MRFEntry2), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('states', Array, (0, None, (None,), MRFEntry2), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'states', Array, (0, None, (instance.arg,), MRFEntry2), (False, None)
+
+
+MRFArray2.init_attributes()

--- a/generated/formats/motiongraph/compounds/MRFEntry1.py
+++ b/generated/formats/motiongraph/compounds/MRFEntry1.py
@@ -18,11 +18,15 @@ class MRFEntry1(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('value', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('value', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'value', Pointer, (0, MRFEntry1._import_map["motiongraph.compounds.MRFMember1"]), (False, None)
+
+
+MRFEntry1.init_attributes()

--- a/generated/formats/motiongraph/compounds/MRFEntry2.py
+++ b/generated/formats/motiongraph/compounds/MRFEntry2.py
@@ -18,11 +18,15 @@ class MRFEntry2(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('value', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('value', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'value', Pointer, (0, MRFEntry2._import_map["motiongraph.compounds.MRFMember2"]), (False, None)
+
+
+MRFEntry2.init_attributes()

--- a/generated/formats/motiongraph/compounds/MRFMember1.py
+++ b/generated/formats/motiongraph/compounds/MRFMember1.py
@@ -28,17 +28,18 @@ class MRFMember1(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('lua_method', Pointer, (0, ZString), (False, None), None),
-		('count_0', Uint64, (0, None), (False, None), None),
-		('count_1', Uint64, (0, None), (False, None), None),
-		('ptr_1', Pointer, (0, None), (False, None), None),
-		('count_2', Uint64, (0, None), (False, None), None),
-		('count_3', Uint64, (0, None), (False, None), None),
-		('ptr_2', Pointer, (0, None), (False, None), None),
-		('count_4', Uint64, (0, None), (False, None), None),
-		('id', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('lua_method', Pointer, (0, ZString), (False, None), None)
+		yield ('count_0', Uint64, (0, None), (False, None), None)
+		yield ('count_1', Uint64, (0, None), (False, None), None)
+		yield ('ptr_1', Pointer, (0, None), (False, None), None)
+		yield ('count_2', Uint64, (0, None), (False, None), None)
+		yield ('count_3', Uint64, (0, None), (False, None), None)
+		yield ('ptr_2', Pointer, (0, None), (False, None), None)
+		yield ('count_4', Uint64, (0, None), (False, None), None)
+		yield ('id', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -52,3 +53,6 @@ class MRFMember1(MemStruct):
 		yield 'ptr_2', Pointer, (0, None), (False, None)
 		yield 'count_4', Uint64, (0, None), (False, None)
 		yield 'id', Pointer, (0, ZString), (False, None)
+
+
+MRFMember1.init_attributes()

--- a/generated/formats/motiongraph/compounds/MRFMember2.py
+++ b/generated/formats/motiongraph/compounds/MRFMember2.py
@@ -29,17 +29,18 @@ class MRFMember2(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('transition', Pointer, (0, None), (False, None), None),
-		('count_0', Uint64, (0, None), (False, None), None),
-		('count_1', Uint64, (0, None), (False, None), None),
-		('count_2', Uint64, (0, None), (False, None), None),
-		('count_3', Uint64, (0, None), (False, None), None),
-		('count_4', Uint64, (0, None), (False, None), None),
-		('count_5', Uint64, (0, None), (False, None), None),
-		('count_6', Uint64, (0, None), (False, None), None),
-		('id', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('transition', Pointer, (0, None), (False, None), None)
+		yield ('count_0', Uint64, (0, None), (False, None), None)
+		yield ('count_1', Uint64, (0, None), (False, None), None)
+		yield ('count_2', Uint64, (0, None), (False, None), None)
+		yield ('count_3', Uint64, (0, None), (False, None), None)
+		yield ('count_4', Uint64, (0, None), (False, None), None)
+		yield ('count_5', Uint64, (0, None), (False, None), None)
+		yield ('count_6', Uint64, (0, None), (False, None), None)
+		yield ('id', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -53,3 +54,6 @@ class MRFMember2(MemStruct):
 		yield 'count_5', Uint64, (0, None), (False, None)
 		yield 'count_6', Uint64, (0, None), (False, None)
 		yield 'id', Pointer, (0, ZString), (False, None)
+
+
+MRFMember2.init_attributes()

--- a/generated/formats/motiongraph/compounds/MotiongraphHeader.py
+++ b/generated/formats/motiongraph/compounds/MotiongraphHeader.py
@@ -29,18 +29,19 @@ class MotiongraphHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptr_0', Pointer, (0, None), (False, None), None),
-		('state_output_entries', Pointer, (0, None), (False, None), None),
-		('ptr_2', Pointer, (0, None), (False, None), None),
-		('ptr_3', Pointer, (0, None), (False, None), None),
-		('count_0', Uint, (0, None), (False, None), None),
-		('count_1', Uint, (0, None), (False, None), None),
-		('lua_modules', Pointer, (0, None), (False, None), None),
-		('lua_results', Pointer, (0, ZString), (False, None), None),
-		('first_non_transition_state', Pointer, (0, None), (False, None), None),
-		('empty_str', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptr_0', Pointer, (0, None), (False, None), None)
+		yield ('state_output_entries', Pointer, (0, None), (False, None), None)
+		yield ('ptr_2', Pointer, (0, None), (False, None), None)
+		yield ('ptr_3', Pointer, (0, None), (False, None), None)
+		yield ('count_0', Uint, (0, None), (False, None), None)
+		yield ('count_1', Uint, (0, None), (False, None), None)
+		yield ('lua_modules', Pointer, (0, None), (False, None), None)
+		yield ('lua_results', Pointer, (0, ZString), (False, None), None)
+		yield ('first_non_transition_state', Pointer, (0, None), (False, None), None)
+		yield ('empty_str', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -55,3 +56,6 @@ class MotiongraphHeader(MemStruct):
 		yield 'lua_results', Pointer, (0, ZString), (False, None)
 		yield 'first_non_transition_state', Pointer, (0, MotiongraphHeader._import_map["motiongraph.compounds.MRFMember2"]), (False, None)
 		yield 'empty_str', Pointer, (0, ZString), (False, None)
+
+
+MotiongraphHeader.init_attributes()

--- a/generated/formats/motiongraph/compounds/MotiongraphRootFrag.py
+++ b/generated/formats/motiongraph/compounds/MotiongraphRootFrag.py
@@ -26,16 +26,17 @@ class MotiongraphRootFrag(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('num_activities', Uint64, (0, None), (False, None), None),
-		('activities', Pointer, (None, None), (False, None), None),
-		('count_1', Uint64, (0, None), (False, None), None),
-		('ptr_1', Pointer, (None, None), (False, None), None),
-		('count_2', Uint64, (0, None), (False, None), None),
-		('ptr_2', Pointer, (None, None), (False, None), None),
-		('num_xmls', Uint64, (0, None), (False, None), None),
-		('ptr_xmls', Pointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('num_activities', Uint64, (0, None), (False, None), None)
+		yield ('activities', Pointer, (None, None), (False, None), None)
+		yield ('count_1', Uint64, (0, None), (False, None), None)
+		yield ('ptr_1', Pointer, (None, None), (False, None), None)
+		yield ('count_2', Uint64, (0, None), (False, None), None)
+		yield ('ptr_2', Pointer, (None, None), (False, None), None)
+		yield ('num_xmls', Uint64, (0, None), (False, None), None)
+		yield ('ptr_xmls', Pointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -48,3 +49,6 @@ class MotiongraphRootFrag(MemStruct):
 		yield 'ptr_2', Pointer, (instance.count_2, MotiongraphRootFrag._import_map["motiongraph.compounds.MRFArray2"]), (False, None)
 		yield 'num_xmls', Uint64, (0, None), (False, None)
 		yield 'ptr_xmls', Pointer, (instance.num_xmls, MotiongraphRootFrag._import_map["motiongraph.compounds.XMLArray"]), (False, None)
+
+
+MotiongraphRootFrag.init_attributes()

--- a/generated/formats/motiongraph/compounds/PtrList.py
+++ b/generated/formats/motiongraph/compounds/PtrList.py
@@ -19,11 +19,15 @@ class PtrList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, None, (None,), SinglePtr), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, None, (None,), SinglePtr), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, instance.template, (instance.arg,), SinglePtr), (False, None)
+
+
+PtrList.init_attributes()

--- a/generated/formats/motiongraph/compounds/RagdollPhysicsActivityData.py
+++ b/generated/formats/motiongraph/compounds/RagdollPhysicsActivityData.py
@@ -42,28 +42,29 @@ class RagdollPhysicsActivityData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('flag', RagdollPhysicsActivityFlags, (0, None), (False, None), None),
-		('_flag_pad', Uint, (0, None), (False, None), None),
-		('root_bone_name', Pointer, (0, ZString), (False, None), None),
-		('collision_exclude_mask', Uint64, (0, None), (False, None), None),
-		('collision_exclude_0', Pointer, (0, ZString), (False, None), None),
-		('collision_exclude_1', Pointer, (0, ZString), (False, None), None),
-		('collision_exclude_2', Pointer, (0, ZString), (False, None), None),
-		('collision_exclude_3', Pointer, (0, ZString), (False, None), None),
-		('collision_exclude_4', Pointer, (0, ZString), (False, None), None),
-		('collision_exclude_5', Pointer, (0, ZString), (False, None), None),
-		('collision_exclude_6', Pointer, (0, ZString), (False, None), None),
-		('collision_exclude_7', Pointer, (0, ZString), (False, None), None),
-		('min_motor_driving_force', Float, (0, None), (False, None), None),
-		('max_motor_driving_force', Float, (0, None), (False, None), None),
-		('motor_weight_variable', Pointer, (0, ZString), (False, None), None),
-		('pose_match_lin_threshold', Float, (0, None), (False, None), None),
-		('pose_match_ang_threshold', Float, (0, None), (False, None), None),
-		('bone_chain_priority', Uint64, (0, None), (False, None), None),
-		('data_stream_name', Pointer, (0, ZString), (False, None), None),
-		('data_stream_type', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('flag', RagdollPhysicsActivityFlags, (0, None), (False, None), None)
+		yield ('_flag_pad', Uint, (0, None), (False, None), None)
+		yield ('root_bone_name', Pointer, (0, ZString), (False, None), None)
+		yield ('collision_exclude_mask', Uint64, (0, None), (False, None), None)
+		yield ('collision_exclude_0', Pointer, (0, ZString), (False, None), None)
+		yield ('collision_exclude_1', Pointer, (0, ZString), (False, None), None)
+		yield ('collision_exclude_2', Pointer, (0, ZString), (False, None), None)
+		yield ('collision_exclude_3', Pointer, (0, ZString), (False, None), None)
+		yield ('collision_exclude_4', Pointer, (0, ZString), (False, None), None)
+		yield ('collision_exclude_5', Pointer, (0, ZString), (False, None), None)
+		yield ('collision_exclude_6', Pointer, (0, ZString), (False, None), None)
+		yield ('collision_exclude_7', Pointer, (0, ZString), (False, None), None)
+		yield ('min_motor_driving_force', Float, (0, None), (False, None), None)
+		yield ('max_motor_driving_force', Float, (0, None), (False, None), None)
+		yield ('motor_weight_variable', Pointer, (0, ZString), (False, None), None)
+		yield ('pose_match_lin_threshold', Float, (0, None), (False, None), None)
+		yield ('pose_match_ang_threshold', Float, (0, None), (False, None), None)
+		yield ('bone_chain_priority', Uint64, (0, None), (False, None), None)
+		yield ('data_stream_name', Pointer, (0, ZString), (False, None), None)
+		yield ('data_stream_type', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -88,3 +89,6 @@ class RagdollPhysicsActivityData(MemStruct):
 		yield 'bone_chain_priority', Uint64, (0, None), (False, None)
 		yield 'data_stream_name', Pointer, (0, ZString), (False, None)
 		yield 'data_stream_type', Pointer, (0, ZString), (False, None)
+
+
+RagdollPhysicsActivityData.init_attributes()

--- a/generated/formats/motiongraph/compounds/RandomActivityActivityInfoData.py
+++ b/generated/formats/motiongraph/compounds/RandomActivityActivityInfoData.py
@@ -26,13 +26,14 @@ class RandomActivityActivityInfoData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('enum_variable', Pointer, (0, ZString), (False, None), None),
-		('activities', Pointer, (0, None), (False, None), None),
-		('activities_count', Uint64, (0, None), (False, None), None),
-		('blend_time', Float, (0, None), (False, None), None),
-		('mode', SelectActivityActivityMode, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('enum_variable', Pointer, (0, ZString), (False, None), None)
+		yield ('activities', Pointer, (0, None), (False, None), None)
+		yield ('activities_count', Uint64, (0, None), (False, None), None)
+		yield ('blend_time', Float, (0, None), (False, None), None)
+		yield ('mode', SelectActivityActivityMode, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -42,3 +43,6 @@ class RandomActivityActivityInfoData(MemStruct):
 		yield 'activities_count', Uint64, (0, None), (False, None)
 		yield 'blend_time', Float, (0, None), (False, None)
 		yield 'mode', SelectActivityActivityMode, (0, None), (False, None)
+
+
+RandomActivityActivityInfoData.init_attributes()

--- a/generated/formats/motiongraph/compounds/SelectActivityActivityData.py
+++ b/generated/formats/motiongraph/compounds/SelectActivityActivityData.py
@@ -26,13 +26,14 @@ class SelectActivityActivityData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('enum_variable', Pointer, (0, ZString), (False, None), None),
-		('activities', Pointer, (None, None), (False, None), None),
-		('num_activities', Uint64, (0, None), (False, None), None),
-		('blend_time', Float, (0, None), (False, None), None),
-		('mode', SelectActivityActivityMode, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('enum_variable', Pointer, (0, ZString), (False, None), None)
+		yield ('activities', Pointer, (None, None), (False, None), None)
+		yield ('num_activities', Uint64, (0, None), (False, None), None)
+		yield ('blend_time', Float, (0, None), (False, None), None)
+		yield ('mode', SelectActivityActivityMode, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -42,3 +43,6 @@ class SelectActivityActivityData(MemStruct):
 		yield 'num_activities', Uint64, (0, None), (False, None)
 		yield 'blend_time', Float, (0, None), (False, None)
 		yield 'mode', SelectActivityActivityMode, (0, None), (False, None)
+
+
+SelectActivityActivityData.init_attributes()

--- a/generated/formats/motiongraph/compounds/SinglePtr.py
+++ b/generated/formats/motiongraph/compounds/SinglePtr.py
@@ -18,11 +18,15 @@ class SinglePtr(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptr', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptr', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptr', Pointer, (0, instance.template), (False, None)
+
+
+SinglePtr.init_attributes()

--- a/generated/formats/motiongraph/compounds/Sixtyfour.py
+++ b/generated/formats/motiongraph/compounds/Sixtyfour.py
@@ -26,16 +26,17 @@ class Sixtyfour(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('count_0', Uint64, (0, None), (False, None), None),
-		('ptr_0', Pointer, (0, None), (False, None), None),
-		('ptr_1', Pointer, (0, None), (False, None), None),
-		('count_1', Uint64, (0, None), (False, None), None),
-		('count_2', Uint64, (0, None), (False, None), None),
-		('ptr_2', Pointer, (0, None), (False, None), None),
-		('ptr_3', Pointer, (0, None), (False, None), None),
-		('count_3', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('count_0', Uint64, (0, None), (False, None), None)
+		yield ('ptr_0', Pointer, (0, None), (False, None), None)
+		yield ('ptr_1', Pointer, (0, None), (False, None), None)
+		yield ('count_1', Uint64, (0, None), (False, None), None)
+		yield ('count_2', Uint64, (0, None), (False, None), None)
+		yield ('ptr_2', Pointer, (0, None), (False, None), None)
+		yield ('ptr_3', Pointer, (0, None), (False, None), None)
+		yield ('count_3', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -48,3 +49,6 @@ class Sixtyfour(MemStruct):
 		yield 'ptr_2', Pointer, (0, None), (False, None)
 		yield 'ptr_3', Pointer, (0, None), (False, None)
 		yield 'count_3', Uint64, (0, None), (False, None)
+
+
+Sixtyfour.init_attributes()

--- a/generated/formats/motiongraph/compounds/State.py
+++ b/generated/formats/motiongraph/compounds/State.py
@@ -27,14 +27,15 @@ class State(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk', Uint, (0, None), (False, None), None),
-		('activities_count', Uint, (0, None), (False, None), None),
-		('activities', Pointer, (None, None), (False, None), None),
-		('count_2', Uint64, (0, None), (False, None), None),
-		('array_2', Pointer, (None, None), (False, None), None),
-		('id', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk', Uint, (0, None), (False, None), None)
+		yield ('activities_count', Uint, (0, None), (False, None), None)
+		yield ('activities', Pointer, (None, None), (False, None), None)
+		yield ('count_2', Uint64, (0, None), (False, None), None)
+		yield ('array_2', Pointer, (None, None), (False, None), None)
+		yield ('id', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -45,3 +46,6 @@ class State(MemStruct):
 		yield 'count_2', Uint64, (0, None), (False, None)
 		yield 'array_2', Pointer, (instance.count_2, State._import_map["motiongraph.compounds.TransStructStopList"]), (False, None)
 		yield 'id', Pointer, (0, ZString), (False, None)
+
+
+State.init_attributes()

--- a/generated/formats/motiongraph/compounds/StateArray.py
+++ b/generated/formats/motiongraph/compounds/StateArray.py
@@ -20,13 +20,17 @@ class StateArray(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('count', Uint64, (0, None), (False, None), None),
-		('ptr', Pointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('count', Uint64, (0, None), (False, None), None)
+		yield ('ptr', Pointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'count', Uint64, (0, None), (False, None)
 		yield 'ptr', Pointer, (instance.count, StateArray._import_map["motiongraph.compounds.StateList"]), (False, None)
+
+
+StateArray.init_attributes()

--- a/generated/formats/motiongraph/compounds/StateList.py
+++ b/generated/formats/motiongraph/compounds/StateList.py
@@ -19,11 +19,15 @@ class StateList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, None, (None,), SinglePtr), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, None, (None,), SinglePtr), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, StateList._import_map["motiongraph.compounds.State"], (instance.arg,), SinglePtr), (False, None)
+
+
+StateList.init_attributes()

--- a/generated/formats/motiongraph/compounds/ThirdFrag.py
+++ b/generated/formats/motiongraph/compounds/ThirdFrag.py
@@ -28,17 +28,18 @@ class ThirdFrag(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('lua_method', Pointer, (0, ZString), (False, None), None),
-		('count_0', Uint64, (0, None), (False, None), None),
-		('count_1', Uint64, (0, None), (False, None), None),
-		('ptr_1', Pointer, (0, None), (False, None), None),
-		('count_2', Uint64, (0, None), (False, None), None),
-		('count_3', Uint64, (0, None), (False, None), None),
-		('ptr_2', Pointer, (0, None), (False, None), None),
-		('count_4', Uint64, (0, None), (False, None), None),
-		('member', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('lua_method', Pointer, (0, ZString), (False, None), None)
+		yield ('count_0', Uint64, (0, None), (False, None), None)
+		yield ('count_1', Uint64, (0, None), (False, None), None)
+		yield ('ptr_1', Pointer, (0, None), (False, None), None)
+		yield ('count_2', Uint64, (0, None), (False, None), None)
+		yield ('count_3', Uint64, (0, None), (False, None), None)
+		yield ('ptr_2', Pointer, (0, None), (False, None), None)
+		yield ('count_4', Uint64, (0, None), (False, None), None)
+		yield ('member', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -52,3 +53,6 @@ class ThirdFrag(MemStruct):
 		yield 'ptr_2', Pointer, (0, ThirdFrag._import_map["motiongraph.compounds.Sixtyfour"]), (False, None)
 		yield 'count_4', Uint64, (0, None), (False, None)
 		yield 'member', Pointer, (0, ZString), (False, None)
+
+
+ThirdFrag.init_attributes()

--- a/generated/formats/motiongraph/compounds/TransStruct.py
+++ b/generated/formats/motiongraph/compounds/TransStruct.py
@@ -20,13 +20,17 @@ class TransStruct(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('another_mrfentry_2', Pointer, (0, None), (False, None), None),
-		('states', StateArray, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('another_mrfentry_2', Pointer, (0, None), (False, None), None)
+		yield ('states', StateArray, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'another_mrfentry_2', Pointer, (0, None), (False, None)
 		yield 'states', StateArray, (0, None), (False, None)
+
+
+TransStruct.init_attributes()

--- a/generated/formats/motiongraph/compounds/TransStructArray.py
+++ b/generated/formats/motiongraph/compounds/TransStructArray.py
@@ -15,11 +15,15 @@ class TransStructArray(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('array', Array, (0, None, (None,), TransStruct), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('array', Array, (0, None, (None,), TransStruct), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'array', Array, (0, None, (instance.arg,), TransStruct), (False, None)
+
+
+TransStructArray.init_attributes()

--- a/generated/formats/motiongraph/compounds/TransStructStop.py
+++ b/generated/formats/motiongraph/compounds/TransStructStop.py
@@ -21,13 +21,17 @@ class TransStructStop(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('another_mrfentry_2', Pointer, (0, None), (False, None), None),
-		('other_states', MGTwo, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('another_mrfentry_2', Pointer, (0, None), (False, None), None)
+		yield ('other_states', MGTwo, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'another_mrfentry_2', Pointer, (0, None), (False, None)
 		yield 'other_states', MGTwo, (0, None), (False, None)
+
+
+TransStructStop.init_attributes()

--- a/generated/formats/motiongraph/compounds/TransStructStopList.py
+++ b/generated/formats/motiongraph/compounds/TransStructStopList.py
@@ -15,11 +15,15 @@ class TransStructStopList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, None, (None,), TransStructStop), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, None, (None,), TransStructStop), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, None, (instance.arg,), TransStructStop), (False, None)
+
+
+TransStructStopList.init_attributes()

--- a/generated/formats/motiongraph/compounds/Transition.py
+++ b/generated/formats/motiongraph/compounds/Transition.py
@@ -27,14 +27,15 @@ class Transition(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('count_0', Uint, (0, None), (False, None), None),
-		('count_1', Uint, (0, None), (False, None), None),
-		('ptr_0', Pointer, (None, None), (False, None), None),
-		('count_2', Uint64, (0, None), (False, None), None),
-		('ptr_1', Pointer, (None, None), (False, None), None),
-		('id', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('count_0', Uint, (0, None), (False, None), None)
+		yield ('count_1', Uint, (0, None), (False, None), None)
+		yield ('ptr_0', Pointer, (None, None), (False, None), None)
+		yield ('count_2', Uint64, (0, None), (False, None), None)
+		yield ('ptr_1', Pointer, (None, None), (False, None), None)
+		yield ('id', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -45,3 +46,6 @@ class Transition(MemStruct):
 		yield 'count_2', Uint64, (0, None), (False, None)
 		yield 'ptr_1', Pointer, (instance.count_2, Transition._import_map["motiongraph.compounds.TransStructArray"]), (False, None)
 		yield 'id', Pointer, (0, ZString), (False, None)
+
+
+Transition.init_attributes()

--- a/generated/formats/motiongraph/compounds/TurnActivityData.py
+++ b/generated/formats/motiongraph/compounds/TurnActivityData.py
@@ -41,25 +41,26 @@ class TurnActivityData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('spot_animation', Pointer, (0, ZString), (False, None), None),
-		('half_animation', Pointer, (0, ZString), (False, None), None),
-		('full_animation', Pointer, (0, ZString), (False, None), None),
-		('output_prop_through_variable', Pointer, (0, ZString), (False, None), None),
-		('spot_data_streams', DataStreamResourceDataList, (0, None), (False, None), None),
-		('half_data_streams', DataStreamResourceDataList, (0, None), (False, None), None),
-		('full_data_streams', DataStreamResourceDataList, (0, None), (False, None), None),
-		('suppress_resource_data_streams', Ubyte, (0, None), (False, None), None),
-		('_pad_0', Ubyte, (0, None), (False, None), None),
-		('priorities', Ushort, (0, None), (False, None), None),
-		('lead_out_time', Float, (0, None), (False, None), None),
-		('flags', TurnFlags, (0, None), (False, None), None),
-		('_pad_1', Ubyte, (0, None), (False, None), None),
-		('_pad_2', Ushort, (0, None), (False, None), None),
-		('max_angle', Float, (0, None), (False, None), None),
-		('min_cycles', Uint, (0, None), (False, None), None),
-		('playback_rate', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('spot_animation', Pointer, (0, ZString), (False, None), None)
+		yield ('half_animation', Pointer, (0, ZString), (False, None), None)
+		yield ('full_animation', Pointer, (0, ZString), (False, None), None)
+		yield ('output_prop_through_variable', Pointer, (0, ZString), (False, None), None)
+		yield ('spot_data_streams', DataStreamResourceDataList, (0, None), (False, None), None)
+		yield ('half_data_streams', DataStreamResourceDataList, (0, None), (False, None), None)
+		yield ('full_data_streams', DataStreamResourceDataList, (0, None), (False, None), None)
+		yield ('suppress_resource_data_streams', Ubyte, (0, None), (False, None), None)
+		yield ('_pad_0', Ubyte, (0, None), (False, None), None)
+		yield ('priorities', Ushort, (0, None), (False, None), None)
+		yield ('lead_out_time', Float, (0, None), (False, None), None)
+		yield ('flags', TurnFlags, (0, None), (False, None), None)
+		yield ('_pad_1', Ubyte, (0, None), (False, None), None)
+		yield ('_pad_2', Ushort, (0, None), (False, None), None)
+		yield ('max_angle', Float, (0, None), (False, None), None)
+		yield ('min_cycles', Uint, (0, None), (False, None), None)
+		yield ('playback_rate', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -81,3 +82,6 @@ class TurnActivityData(MemStruct):
 		yield 'max_angle', Float, (0, None), (False, None)
 		yield 'min_cycles', Uint, (0, None), (False, None)
 		yield 'playback_rate', Float, (0, None), (False, None)
+
+
+TurnActivityData.init_attributes()

--- a/generated/formats/motiongraph/compounds/TwoPtrFirst.py
+++ b/generated/formats/motiongraph/compounds/TwoPtrFirst.py
@@ -20,13 +20,17 @@ class TwoPtrFirst(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptr', Pointer, (0, None), (False, None), None),
-		('count_0', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptr', Pointer, (0, None), (False, None), None)
+		yield ('count_0', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptr', Pointer, (0, None), (False, None)
 		yield 'count_0', Uint64, (0, None), (False, None)
+
+
+TwoPtrFirst.init_attributes()

--- a/generated/formats/motiongraph/compounds/VariableBlendedAnimationActivityData.py
+++ b/generated/formats/motiongraph/compounds/VariableBlendedAnimationActivityData.py
@@ -29,15 +29,16 @@ class VariableBlendedAnimationActivityData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('priorities', Uint, (0, None), (False, None), None),
-		('_pad', Uint, (0, None), (False, None), None),
-		('weight', FloatInputData, (0, None), (False, None), None),
-		('animations', ArrayPointer, (None, None), (False, None), None),
-		('animation_count', Uint64, (0, None), (False, None), None),
-		('variable', Pointer, (0, ZString), (False, None), None),
-		('variable_blended_animation_flags', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('priorities', Uint, (0, None), (False, None), None)
+		yield ('_pad', Uint, (0, None), (False, None), None)
+		yield ('weight', FloatInputData, (0, None), (False, None), None)
+		yield ('animations', ArrayPointer, (None, None), (False, None), None)
+		yield ('animation_count', Uint64, (0, None), (False, None), None)
+		yield ('variable', Pointer, (0, ZString), (False, None), None)
+		yield ('variable_blended_animation_flags', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -49,3 +50,6 @@ class VariableBlendedAnimationActivityData(MemStruct):
 		yield 'animation_count', Uint64, (0, None), (False, None)
 		yield 'variable', Pointer, (0, ZString), (False, None)
 		yield 'variable_blended_animation_flags', Uint, (0, None), (False, None)
+
+
+VariableBlendedAnimationActivityData.init_attributes()

--- a/generated/formats/motiongraph/compounds/VariableBlendedAnimationData.py
+++ b/generated/formats/motiongraph/compounds/VariableBlendedAnimationData.py
@@ -25,12 +25,13 @@ class VariableBlendedAnimationData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('animation', Pointer, (0, ZString), (False, None), None),
-		('value', Float, (0, None), (False, 0.0), None),
-		('_pad', Uint, (0, None), (False, None), None),
-		('additional_data_streams', DataStreamResourceDataList, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('animation', Pointer, (0, ZString), (False, None), None)
+		yield ('value', Float, (0, None), (False, 0.0), None)
+		yield ('_pad', Uint, (0, None), (False, None), None)
+		yield ('additional_data_streams', DataStreamResourceDataList, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -39,3 +40,6 @@ class VariableBlendedAnimationData(MemStruct):
 		yield 'value', Float, (0, None), (False, 0.0)
 		yield '_pad', Uint, (0, None), (False, None)
 		yield 'additional_data_streams', DataStreamResourceDataList, (0, None), (False, None)
+
+
+VariableBlendedAnimationData.init_attributes()

--- a/generated/formats/motiongraph/compounds/XMLArray.py
+++ b/generated/formats/motiongraph/compounds/XMLArray.py
@@ -15,11 +15,15 @@ class XMLArray(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('xmls', Array, (0, None, (None,), XMLEntry), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('xmls', Array, (0, None, (None,), XMLEntry), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'xmls', Array, (0, None, (instance.arg,), XMLEntry), (False, None)
+
+
+XMLArray.init_attributes()

--- a/generated/formats/motiongraph/compounds/XMLEntry.py
+++ b/generated/formats/motiongraph/compounds/XMLEntry.py
@@ -19,11 +19,15 @@ class XMLEntry(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('xml_string', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('xml_string', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'xml_string', Pointer, (0, ZString), (False, None)
+
+
+XMLEntry.init_attributes()

--- a/generated/formats/ms2/compounds/AbstractPointer.py
+++ b/generated/formats/ms2/compounds/AbstractPointer.py
@@ -11,8 +11,9 @@ class AbstractPointer(BaseStruct):
 
 	_import_key = 'ms2.compounds.AbstractPointer'
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -28,3 +29,6 @@ class AbstractPointer(BaseStruct):
 		n = self.joint.name if self.joint else None
 		return f"{self.index} -> {n}"
 
+
+
+AbstractPointer.init_attributes()

--- a/generated/formats/ms2/compounds/AxisAngle.py
+++ b/generated/formats/ms2/compounds/AxisAngle.py
@@ -17,12 +17,13 @@ class AxisAngle(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('a', Float, (0, None), (False, 1.0), None),
-		('x', Float, (0, None), (False, 0.0), None),
-		('y', Float, (0, None), (False, 0.0), None),
-		('z', Float, (0, None), (False, 0.0), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('a', Float, (0, None), (False, 1.0), None)
+		yield ('x', Float, (0, None), (False, 0.0), None)
+		yield ('y', Float, (0, None), (False, 0.0), None)
+		yield ('z', Float, (0, None), (False, 0.0), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -31,3 +32,6 @@ class AxisAngle(BaseStruct):
 		yield 'x', Float, (0, None), (False, 0.0)
 		yield 'y', Float, (0, None), (False, 0.0)
 		yield 'z', Float, (0, None), (False, 0.0)
+
+
+AxisAngle.init_attributes()

--- a/generated/formats/ms2/compounds/BioMeshData.py
+++ b/generated/formats/ms2/compounds/BioMeshData.py
@@ -55,16 +55,17 @@ class BioMeshData(MeshData):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MeshData._attribute_list + [
-		('chunks_offset', Uint, (0, None), (False, None), None),
-		('chunks_count', Uint, (0, None), (False, None), None),
-		('tris_count', Uint, (0, None), (False, None), None),
-		('vertex_count', Uint, (0, None), (False, None), None),
-		('zero_1', Uint64, (0, None), (False, None), None),
-		('poweroftwo', Uint, (0, None), (False, None), None),
-		('unk_floats', Array, (0, None, (2,), Float), (False, None), None),
-		('flag', BioModelFlag, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('chunks_offset', Uint, (0, None), (False, None), None)
+		yield ('chunks_count', Uint, (0, None), (False, None), None)
+		yield ('tris_count', Uint, (0, None), (False, None), None)
+		yield ('vertex_count', Uint, (0, None), (False, None), None)
+		yield ('zero_1', Uint64, (0, None), (False, None), None)
+		yield ('poweroftwo', Uint, (0, None), (False, None), None)
+		yield ('unk_floats', Array, (0, None, (2,), Float), (False, None), None)
+		yield ('flag', BioModelFlag, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -476,3 +477,6 @@ class BioMeshData(MeshData):
 		Array.to_stream(self.tri_chunks, self.buffer_info.tri_chunks, self.context, dtype=TriChunk)
 		Array.to_stream(self.vert_chunks, self.buffer_info.vert_chunks, self.context, dtype=VertChunk)
 
+
+
+BioMeshData.init_attributes()

--- a/generated/formats/ms2/compounds/Bone.py
+++ b/generated/formats/ms2/compounds/Bone.py
@@ -25,14 +25,15 @@ class Bone(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('loc', Vector3, (0, None), (False, None), True),
-		('scale', Float, (0, None), (False, None), True),
-		('rot', Vector4, (0, None), (False, None), True),
-		('rot', Vector4, (0, None), (False, None), True),
-		('loc', Vector3, (0, None), (False, None), True),
-		('scale', Float, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('loc', Vector3, (0, None), (False, None), True)
+		yield ('scale', Float, (0, None), (False, None), True)
+		yield ('rot', Vector4, (0, None), (False, None), True)
+		yield ('rot', Vector4, (0, None), (False, None), True)
+		yield ('loc', Vector3, (0, None), (False, None), True)
+		yield ('scale', Float, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -52,3 +53,6 @@ class Bone(BaseStruct):
 		self.rot.x, self.rot.y, self.rot.z, self.rot.w = quat.x, quat.y, quat.z, quat.w
 		self.scale = sca.x
 
+
+
+Bone.init_attributes()

--- a/generated/formats/ms2/compounds/BoneInfo.py
+++ b/generated/formats/ms2/compounds/BoneInfo.py
@@ -116,52 +116,53 @@ class BoneInfo(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('name_count', Uint, (0, None), (False, None), None),
-		('z_0', Ushort, (0, None), (False, None), None),
-		('inv_names_count', Ushort, (0, None), (False, None), None),
-		('knownff', Short, (0, None), (False, -1), True),
-		('zero_0', Short, (0, None), (False, 0), True),
-		('unknown_0_c', Uint, (0, None), (False, None), True),
-		('unk_count', Uint64, (0, None), (False, None), None),
-		('bind_matrix_count', Uint64, (0, None), (False, None), None),
-		('zeros', Array, (0, None, (2,), Uint64), (False, None), None),
-		('inv_data_count', Uint64, (0, None), (False, None), None),
-		('bone_count', Uint64, (0, None), (False, None), None),
-		('unknown_40', Uint64, (0, None), (False, None), None),
-		('parents_count', Uint64, (0, None), (False, None), None),
-		('extra_zero', Uint64, (0, None), (False, None), True),
-		('new_uint_64', Uint64, (0, None), (False, None), True),
-		('enum_count', Uint64, (0, None), (False, None), None),
-		('unknown_58', Uint64, (0, None), (False, None), None),
-		('one', Uint64, (0, None), (False, 1), None),
-		('zeros_count', Uint64, (0, None), (False, None), None),
-		('unk_pc_count', Uint64, (0, None), (False, None), True),
-		('ik_count', Uint64, (0, None), (False, None), None),
-		('joint_count', Uint64, (0, None), (False, None), None),
-		('zero_1', Uint64, (0, None), (False, 0), None),
-		('zero_2', Uint64, (0, None), (False, 0), True),
-		('zero_3', Uint64, (0, None), (False, 0), True),
-		('names_ref', Empty, (0, None), (False, None), None),
-		('name_indices', Array, (0, None, (None,), Ushort), (False, None), True),
-		('name_indices', Array, (0, None, (None,), Uint), (False, None), True),
-		('inventory_name_indices', Array, (0, None, (None,), Ushort), (False, None), True),
-		('name_padding', PadAlign, (16, None), (False, None), None),
-		('inverse_bind_matrices', Array, (0, None, (None,), Matrix44), (False, None), None),
-		('bones', Array, (0, None, (None,), Bone), (False, None), None),
-		('parents', Array, (0, None, (None,), Ubyte), (False, None), None),
-		('parents_padding', PadAlign, (8, None), (False, None), True),
-		('enumeration', Array, (0, None, (None, 2,), Uint), (False, None), True),
-		('enumeration', Array, (0, None, (None,), Ubyte), (False, None), True),
-		('inventory_datas', Array, (0, None, (None, 6,), Byte), (False, None), True),
-		('weirdness', Array, (0, None, (8,), Short), (False, None), True),
-		('weirdness', Array, (0, None, (10,), Short), (False, None), True),
-		('inventory_datas_2', Array, (0, None, (None, 2,), Int), (False, None), True),
-		('minus_padding', MinusPadding, (None, None), (False, None), True),
-		('zeros_padding', ZerosPadding, (None, None), (False, None), True),
-		('ik_info', IKInfo, (None, None), (False, None), True),
-		('joints', JointData, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('name_count', Uint, (0, None), (False, None), None)
+		yield ('z_0', Ushort, (0, None), (False, None), None)
+		yield ('inv_names_count', Ushort, (0, None), (False, None), None)
+		yield ('knownff', Short, (0, None), (False, -1), True)
+		yield ('zero_0', Short, (0, None), (False, 0), True)
+		yield ('unknown_0_c', Uint, (0, None), (False, None), True)
+		yield ('unk_count', Uint64, (0, None), (False, None), None)
+		yield ('bind_matrix_count', Uint64, (0, None), (False, None), None)
+		yield ('zeros', Array, (0, None, (2,), Uint64), (False, None), None)
+		yield ('inv_data_count', Uint64, (0, None), (False, None), None)
+		yield ('bone_count', Uint64, (0, None), (False, None), None)
+		yield ('unknown_40', Uint64, (0, None), (False, None), None)
+		yield ('parents_count', Uint64, (0, None), (False, None), None)
+		yield ('extra_zero', Uint64, (0, None), (False, None), True)
+		yield ('new_uint_64', Uint64, (0, None), (False, None), True)
+		yield ('enum_count', Uint64, (0, None), (False, None), None)
+		yield ('unknown_58', Uint64, (0, None), (False, None), None)
+		yield ('one', Uint64, (0, None), (False, 1), None)
+		yield ('zeros_count', Uint64, (0, None), (False, None), None)
+		yield ('unk_pc_count', Uint64, (0, None), (False, None), True)
+		yield ('ik_count', Uint64, (0, None), (False, None), None)
+		yield ('joint_count', Uint64, (0, None), (False, None), None)
+		yield ('zero_1', Uint64, (0, None), (False, 0), None)
+		yield ('zero_2', Uint64, (0, None), (False, 0), True)
+		yield ('zero_3', Uint64, (0, None), (False, 0), True)
+		yield ('names_ref', Empty, (0, None), (False, None), None)
+		yield ('name_indices', Array, (0, None, (None,), Ushort), (False, None), True)
+		yield ('name_indices', Array, (0, None, (None,), Uint), (False, None), True)
+		yield ('inventory_name_indices', Array, (0, None, (None,), Ushort), (False, None), True)
+		yield ('name_padding', PadAlign, (16, None), (False, None), None)
+		yield ('inverse_bind_matrices', Array, (0, None, (None,), Matrix44), (False, None), None)
+		yield ('bones', Array, (0, None, (None,), Bone), (False, None), None)
+		yield ('parents', Array, (0, None, (None,), Ubyte), (False, None), None)
+		yield ('parents_padding', PadAlign, (8, None), (False, None), True)
+		yield ('enumeration', Array, (0, None, (None, 2,), Uint), (False, None), True)
+		yield ('enumeration', Array, (0, None, (None,), Ubyte), (False, None), True)
+		yield ('inventory_datas', Array, (0, None, (None, 6,), Byte), (False, None), True)
+		yield ('weirdness', Array, (0, None, (8,), Short), (False, None), True)
+		yield ('weirdness', Array, (0, None, (10,), Short), (False, None), True)
+		yield ('inventory_datas_2', Array, (0, None, (None, 2,), Int), (False, None), True)
+		yield ('minus_padding', MinusPadding, (None, None), (False, None), True)
+		yield ('zeros_padding', ZerosPadding, (None, None), (False, None), True)
+		yield ('ik_info', IKInfo, (None, None), (False, None), True)
+		yield ('joints', JointData, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -229,3 +230,6 @@ class BoneInfo(BaseStruct):
 			yield 'ik_info', IKInfo, (instance, None), (False, None)
 		if instance.joint_count:
 			yield 'joints', JointData, (0, None), (False, None)
+
+
+BoneInfo.init_attributes()

--- a/generated/formats/ms2/compounds/BonePointer.py
+++ b/generated/formats/ms2/compounds/BonePointer.py
@@ -16,11 +16,15 @@ class BonePointer(AbstractPointer):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = AbstractPointer._attribute_list + [
-		('index', Ubyte, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('index', Ubyte, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'index', Ubyte, (0, None), (False, None)
+
+
+BonePointer.init_attributes()

--- a/generated/formats/ms2/compounds/BoundingBox.py
+++ b/generated/formats/ms2/compounds/BoundingBox.py
@@ -27,12 +27,13 @@ class BoundingBox(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('rotation', Matrix33, (0, None), (False, None), None),
-		('center', Vector3, (0, None), (False, None), None),
-		('extent', Vector3, (0, None), (False, None), None),
-		('zeros', Array, (0, None, (3,), Uint), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('rotation', Matrix33, (0, None), (False, None), None)
+		yield ('center', Vector3, (0, None), (False, None), None)
+		yield ('extent', Vector3, (0, None), (False, None), None)
+		yield ('zeros', Array, (0, None, (3,), Uint), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -42,3 +43,6 @@ class BoundingBox(BaseStruct):
 		yield 'extent', Vector3, (0, None), (False, None)
 		if instance.context.version == 32:
 			yield 'zeros', Array, (0, None, (3,), Uint), (False, None)
+
+
+BoundingBox.init_attributes()

--- a/generated/formats/ms2/compounds/Buffer0.py
+++ b/generated/formats/ms2/compounds/Buffer0.py
@@ -28,12 +28,13 @@ class Buffer0(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('name_hashes', Array, (0, None, (None,), Uint), (False, None), None),
-		('names', Array, (0, None, (None,), ZString), (False, None), None),
-		('names_padding', PadAlign, (4, None), (False, None), True),
-		('zt_streams_header', StreamsZTHeader, (None, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('name_hashes', Array, (0, None, (None,), Uint), (False, None), None)
+		yield ('names', Array, (0, None, (None,), ZString), (False, None), None)
+		yield ('names_padding', PadAlign, (4, None), (False, None), True)
+		yield ('zt_streams_header', StreamsZTHeader, (None, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -44,3 +45,6 @@ class Buffer0(BaseStruct):
 			yield 'names_padding', PadAlign, (4, instance.names), (False, None)
 		if instance.context.version <= 13:
 			yield 'zt_streams_header', StreamsZTHeader, (instance.arg, None), (False, None)
+
+
+Buffer0.init_attributes()

--- a/generated/formats/ms2/compounds/BufferInfo.py
+++ b/generated/formats/ms2/compounds/BufferInfo.py
@@ -44,25 +44,26 @@ class BufferInfo(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('u_0', Uint64, (0, None), (False, None), True),
-		('u_1', Uint64, (0, None), (False, None), True),
-		('tri_chunks_size', Uint64, (0, None), (False, None), True),
-		('tri_chunks_ptr', Uint64, (0, None), (False, None), True),
-		('vert_chunks_size', Uint64, (0, None), (False, None), True),
-		('vert_chunks_ptr', Uint64, (0, None), (False, None), True),
-		('verts_size', Uint64, (0, None), (False, None), None),
-		('verts_ptr', Uint64, (0, None), (False, None), None),
-		('u_3', Uint64, (0, None), (False, None), True),
-		('tris_size', Uint64, (0, None), (False, None), True),
-		('tris_ptr', Uint64, (0, None), (False, None), True),
-		('u_5', Uint64, (0, None), (False, None), True),
-		('u_6', Uint64, (0, None), (False, None), True),
-		('u_5', Uint64, (0, None), (False, None), True),
-		('uvs_size', Uint64, (0, None), (False, None), True),
-		('u_6', Uint64, (0, None), (False, None), True),
-		('u_7', Uint64, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('u_0', Uint64, (0, None), (False, None), True)
+		yield ('u_1', Uint64, (0, None), (False, None), True)
+		yield ('tri_chunks_size', Uint64, (0, None), (False, None), True)
+		yield ('tri_chunks_ptr', Uint64, (0, None), (False, None), True)
+		yield ('vert_chunks_size', Uint64, (0, None), (False, None), True)
+		yield ('vert_chunks_ptr', Uint64, (0, None), (False, None), True)
+		yield ('verts_size', Uint64, (0, None), (False, None), None)
+		yield ('verts_ptr', Uint64, (0, None), (False, None), None)
+		yield ('u_3', Uint64, (0, None), (False, None), True)
+		yield ('tris_size', Uint64, (0, None), (False, None), True)
+		yield ('tris_ptr', Uint64, (0, None), (False, None), True)
+		yield ('u_5', Uint64, (0, None), (False, None), True)
+		yield ('u_6', Uint64, (0, None), (False, None), True)
+		yield ('u_5', Uint64, (0, None), (False, None), True)
+		yield ('uvs_size', Uint64, (0, None), (False, None), True)
+		yield ('u_6', Uint64, (0, None), (False, None), True)
+		yield ('u_7', Uint64, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -90,3 +91,6 @@ class BufferInfo(BaseStruct):
 			yield 'uvs_size', Uint64, (0, None), (False, None)
 			yield 'u_6', Uint64, (0, None), (False, None)
 			yield 'u_7', Uint64, (0, None), (False, None)
+
+
+BufferInfo.init_attributes()

--- a/generated/formats/ms2/compounds/BufferPresence.py
+++ b/generated/formats/ms2/compounds/BufferPresence.py
@@ -16,11 +16,15 @@ class BufferPresence(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('dependency_name', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('dependency_name', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'dependency_name', Pointer, (0, None), (False, None)
+
+
+BufferPresence.init_attributes()

--- a/generated/formats/ms2/compounds/Capsule.py
+++ b/generated/formats/ms2/compounds/Capsule.py
@@ -30,13 +30,14 @@ class Capsule(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('offset', Vector3, (0, None), (False, None), None),
-		('direction', Vector3, (0, None), (False, None), None),
-		('radius', Float, (0, None), (False, None), None),
-		('extent', Float, (0, None), (False, None), None),
-		('zero', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('offset', Vector3, (0, None), (False, None), None)
+		yield ('direction', Vector3, (0, None), (False, None), None)
+		yield ('radius', Float, (0, None), (False, None), None)
+		yield ('extent', Float, (0, None), (False, None), None)
+		yield ('zero', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -46,3 +47,6 @@ class Capsule(BaseStruct):
 		yield 'radius', Float, (0, None), (False, None)
 		yield 'extent', Float, (0, None), (False, None)
 		yield 'zero', Uint, (0, None), (False, None)
+
+
+Capsule.init_attributes()

--- a/generated/formats/ms2/compounds/Constraint.py
+++ b/generated/formats/ms2/compounds/Constraint.py
@@ -15,13 +15,17 @@ class Constraint(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('parent', JointPointer, (0, None), (False, None), None),
-		('child', JointPointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('parent', JointPointer, (0, None), (False, None), None)
+		yield ('child', JointPointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'parent', JointPointer, (0, None), (False, None)
 		yield 'child', JointPointer, (0, None), (False, None)
+
+
+Constraint.init_attributes()

--- a/generated/formats/ms2/compounds/ConvexHull.py
+++ b/generated/formats/ms2/compounds/ConvexHull.py
@@ -27,13 +27,14 @@ class ConvexHull(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('vertex_count', Uint, (0, None), (False, None), None),
-		('rotation', Matrix33, (0, None), (False, None), None),
-		('offset', Vector3, (0, None), (False, None), None),
-		('zeros', Array, (0, None, (5,), Uint), (False, None), True),
-		('zeros', Array, (0, None, (2,), Uint), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('vertex_count', Uint, (0, None), (False, None), None)
+		yield ('rotation', Matrix33, (0, None), (False, None), None)
+		yield ('offset', Vector3, (0, None), (False, None), None)
+		yield ('zeros', Array, (0, None, (5,), Uint), (False, None), True)
+		yield ('zeros', Array, (0, None, (2,), Uint), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -45,3 +46,6 @@ class ConvexHull(BaseStruct):
 			yield 'zeros', Array, (0, None, (5,), Uint), (False, None)
 		if instance.context.version >= 48:
 			yield 'zeros', Array, (0, None, (2,), Uint), (False, None)
+
+
+ConvexHull.init_attributes()

--- a/generated/formats/ms2/compounds/Cylinder.py
+++ b/generated/formats/ms2/compounds/Cylinder.py
@@ -16,9 +16,13 @@ class Cylinder(Capsule):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = Capsule._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
+
+
+Cylinder.init_attributes()

--- a/generated/formats/ms2/compounds/DLAPreBones.py
+++ b/generated/formats/ms2/compounds/DLAPreBones.py
@@ -16,11 +16,15 @@ class DLAPreBones(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('unk', Array, (0, None, (120,), Ubyte), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk', Array, (0, None, (120,), Ubyte), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'unk', Array, (0, None, (120,), Ubyte), (False, None)
+
+
+DLAPreBones.init_attributes()

--- a/generated/formats/ms2/compounds/FloatsY.py
+++ b/generated/formats/ms2/compounds/FloatsY.py
@@ -18,13 +18,17 @@ class FloatsY(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('floats', Array, (0, None, (8,), Float), (False, None), None),
-		('index', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('floats', Array, (0, None, (8,), Float), (False, None), None)
+		yield ('index', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'floats', Array, (0, None, (8,), Float), (False, None)
 		yield 'index', Uint, (0, None), (False, None)
+
+
+FloatsY.init_attributes()

--- a/generated/formats/ms2/compounds/HitCheck.py
+++ b/generated/formats/ms2/compounds/HitCheck.py
@@ -47,24 +47,25 @@ class HitCheck(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('dtype', CollisionType, (0, None), (False, None), None),
-		('flag_0', Ushort, (0, None), (False, 0), None),
-		('flag_1', Ushort, (0, None), (False, 0), None),
-		('collision_layers', Uint64, (0, None), (False, None), True),
-		('collision_ignore', OffsetString, (None, None), (False, None), True),
-		('collision_use', OffsetString, (None, None), (False, None), True),
-		('zero_extra_pc', Uint, (0, None), (False, None), True),
-		('name', OffsetString, (None, None), (False, None), None),
-		('collider', Sphere, (0, None), (False, None), True),
-		('collider', BoundingBox, (0, None), (False, None), True),
-		('collider', Capsule, (0, None), (False, None), True),
-		('collider', Cylinder, (0, None), (False, None), True),
-		('collider', ConvexHull, (0, None), (False, None), True),
-		('collider', ConvexHull, (0, None), (False, None), True),
-		('collider', MeshCollision, (0, None), (False, None), True),
-		('zero_extra_zt', Uint, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('dtype', CollisionType, (0, None), (False, None), None)
+		yield ('flag_0', Ushort, (0, None), (False, 0), None)
+		yield ('flag_1', Ushort, (0, None), (False, 0), None)
+		yield ('collision_layers', Uint64, (0, None), (False, None), True)
+		yield ('collision_ignore', OffsetString, (None, None), (False, None), True)
+		yield ('collision_use', OffsetString, (None, None), (False, None), True)
+		yield ('zero_extra_pc', Uint, (0, None), (False, None), True)
+		yield ('name', OffsetString, (None, None), (False, None), None)
+		yield ('collider', Sphere, (0, None), (False, None), True)
+		yield ('collider', BoundingBox, (0, None), (False, None), True)
+		yield ('collider', Capsule, (0, None), (False, None), True)
+		yield ('collider', Cylinder, (0, None), (False, None), True)
+		yield ('collider', ConvexHull, (0, None), (False, None), True)
+		yield ('collider', ConvexHull, (0, None), (False, None), True)
+		yield ('collider', MeshCollision, (0, None), (False, None), True)
+		yield ('zero_extra_zt', Uint, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -96,3 +97,6 @@ class HitCheck(BaseStruct):
 			yield 'collider', MeshCollision, (0, None), (False, None)
 		if instance.context.version == 13:
 			yield 'zero_extra_zt', Uint, (0, None), (False, None)
+
+
+HitCheck.init_attributes()

--- a/generated/formats/ms2/compounds/HitcheckReader.py
+++ b/generated/formats/ms2/compounds/HitcheckReader.py
@@ -14,8 +14,9 @@ class HitcheckReader(BaseStruct):
 
 	_import_key = 'ms2.compounds.HitcheckReader'
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -53,3 +54,6 @@ class HitcheckReader(BaseStruct):
 			return "Bad arg?"
 
 
+
+
+HitcheckReader.init_attributes()

--- a/generated/formats/ms2/compounds/IKEntry.py
+++ b/generated/formats/ms2/compounds/IKEntry.py
@@ -30,15 +30,16 @@ class IKEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('child', BonePointer, (0, None), (False, None), None),
-		('parent', BonePointer, (0, None), (False, None), None),
-		('unk_0', Ushort, (0, None), (False, 0), None),
-		('matrix', Matrix33, (0, None), (False, None), None),
-		('yaw', RotationRange, (0, None), (False, None), None),
-		('pitch', RotationRange, (0, None), (False, None), None),
-		('unk_1', Uint, (0, None), (False, 1), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('child', BonePointer, (0, None), (False, None), None)
+		yield ('parent', BonePointer, (0, None), (False, None), None)
+		yield ('unk_0', Ushort, (0, None), (False, 0), None)
+		yield ('matrix', Matrix33, (0, None), (False, None), None)
+		yield ('yaw', RotationRange, (0, None), (False, None), None)
+		yield ('pitch', RotationRange, (0, None), (False, None), None)
+		yield ('unk_1', Uint, (0, None), (False, 1), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -50,3 +51,6 @@ class IKEntry(BaseStruct):
 		yield 'yaw', RotationRange, (0, None), (False, None)
 		yield 'pitch', RotationRange, (0, None), (False, None)
 		yield 'unk_1', Uint, (0, None), (False, 1)
+
+
+IKEntry.init_attributes()

--- a/generated/formats/ms2/compounds/IKInfo.py
+++ b/generated/formats/ms2/compounds/IKInfo.py
@@ -40,19 +40,20 @@ class IKInfo(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('weird_padding', SmartPadding, (0, None), (False, None), True),
-		('ik_count', Uint64, (0, None), (False, None), None),
-		('ik_ptr', Uint64, (0, None), (False, None), None),
-		('ik_targets_count', Uint64, (0, None), (False, None), True),
-		('ik_targets_ptr', Uint64, (0, None), (False, None), True),
-		('ik_ref', Empty, (0, None), (False, None), None),
-		('ik_list', Array, (0, None, (None,), UACJoint), (False, None), True),
-		('ik_list', Array, (0, None, (None,), IKEntry), (False, None), True),
-		('padding_0', PadAlign, (8, None), (False, None), None),
-		('ik_targets', Array, (0, None, (None,), IKTarget), (False, None), True),
-		('padding_1', PadAlign, (8, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('weird_padding', SmartPadding, (0, None), (False, None), True)
+		yield ('ik_count', Uint64, (0, None), (False, None), None)
+		yield ('ik_ptr', Uint64, (0, None), (False, None), None)
+		yield ('ik_targets_count', Uint64, (0, None), (False, None), True)
+		yield ('ik_targets_ptr', Uint64, (0, None), (False, None), True)
+		yield ('ik_ref', Empty, (0, None), (False, None), None)
+		yield ('ik_list', Array, (0, None, (None,), UACJoint), (False, None), True)
+		yield ('ik_list', Array, (0, None, (None,), IKEntry), (False, None), True)
+		yield ('padding_0', PadAlign, (8, None), (False, None), None)
+		yield ('ik_targets', Array, (0, None, (None,), IKTarget), (False, None), True)
+		yield ('padding_1', PadAlign, (8, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -95,3 +96,6 @@ class IKInfo(BaseStruct):
 			ptr.index = bones_map.get(ptr.joint)
 		super().write_fields(stream, instance)
 
+
+
+IKInfo.init_attributes()

--- a/generated/formats/ms2/compounds/IKTarget.py
+++ b/generated/formats/ms2/compounds/IKTarget.py
@@ -19,13 +19,17 @@ class IKTarget(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('ik_blend', BonePointer, (0, None), (False, None), None),
-		('ik_end', BonePointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ik_blend', BonePointer, (0, None), (False, None), None)
+		yield ('ik_end', BonePointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ik_blend', BonePointer, (0, None), (False, None)
 		yield 'ik_end', BonePointer, (0, None), (False, None)
+
+
+IKTarget.init_attributes()

--- a/generated/formats/ms2/compounds/InfoZTMemPool.py
+++ b/generated/formats/ms2/compounds/InfoZTMemPool.py
@@ -21,13 +21,17 @@ class InfoZTMemPool(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('unk_count', Ushort, (0, None), (False, None), None),
-		('unks', Array, (0, None, (None, 2,), Ushort), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_count', Ushort, (0, None), (False, None), None)
+		yield ('unks', Array, (0, None, (None, 2,), Ushort), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'unk_count', Ushort, (0, None), (False, None)
 		yield 'unks', Array, (0, None, (instance.unk_count, 2,), Ushort), (False, None)
+
+
+InfoZTMemPool.init_attributes()

--- a/generated/formats/ms2/compounds/JointData.py
+++ b/generated/formats/ms2/compounds/JointData.py
@@ -106,44 +106,45 @@ class JointData(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('start_pc', SmartPadding, (0, None), (False, None), True),
-		('before_dla_0', Uint64, (0, None), (False, None), True),
-		('before_dla_1', Uint64, (0, None), (False, None), True),
-		('joint_count', Uint, (0, None), (False, None), None),
-		('num_push_constraints', Uint, (0, None), (False, None), None),
-		('num_stretch_constraints', Uint, (0, None), (False, None), None),
-		('num_ragdoll_constraints', Uint, (0, None), (False, None), None),
-		('zero_0', Uint, (0, None), (False, None), True),
-		('zero_1', Uint, (0, None), (False, None), True),
-		('namespace_length', Uint, (0, None), (False, None), None),
-		('zeros_0', Array, (0, None, (5,), Uint), (False, None), None),
-		('pc_count', Uint, (0, None), (False, None), None),
-		('zeros_1', Array, (0, None, (7,), Uint), (False, None), None),
-		('extra_zeros_2', Array, (0, None, (4,), Uint), (False, None), True),
-		('one_0', Uint64, (0, None), (False, 1), True),
-		('one_1', Uint64, (0, None), (False, 1), True),
-		('bone_count', Uint, (0, None), (False, None), None),
-		('joint_entry_count', Uint, (0, None), (False, None), None),
-		('zeros_2', Array, (0, None, (4,), Uint), (False, None), None),
-		('zeros_3', Uint, (0, None), (False, None), True),
-		('names_ref', Empty, (0, None), (False, None), None),
-		('joint_transforms', Array, (0, None, (None,), JointTransform), (False, None), None),
-		('rigid_body_pointers', Array, (0, None, (None,), Uint64), (False, None), True),
-		('rigid_body_list', Array, (0, None, (None,), RigidBody), (False, None), True),
-		('push_constraints', Array, (0, None, (None,), PushConstraint), (False, None), True),
-		('stretch_constraints', Array, (0, None, (None,), StretchConstraint), (False, None), True),
-		('ragdoll_constraints', Array, (0, None, (None,), RagdollConstraint), (False, None), True),
-		('joint_infos', Array, (0, None, (None,), UACJointFF), (False, None), True),
-		('pc_floats', Array, (0, None, (None, 10,), Float), (False, None), True),
-		('joint_to_bone', Array, (0, None, (None,), Int), (False, None), None),
-		('bone_to_joint', Array, (0, None, (None,), Int), (False, None), None),
-		('joint_names', ZStringBuffer, (None, None), (False, None), None),
-		('joint_names_padding', PadAlign, (8, None), (False, None), True),
-		('joint_names_padding', SmartPadding, (0, None), (False, None), True),
-		('joint_infos', Array, (None, None, (None,), JointInfo), (False, None), True),
-		('hitcheck_reader', HitcheckReader, (None, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('start_pc', SmartPadding, (0, None), (False, None), True)
+		yield ('before_dla_0', Uint64, (0, None), (False, None), True)
+		yield ('before_dla_1', Uint64, (0, None), (False, None), True)
+		yield ('joint_count', Uint, (0, None), (False, None), None)
+		yield ('num_push_constraints', Uint, (0, None), (False, None), None)
+		yield ('num_stretch_constraints', Uint, (0, None), (False, None), None)
+		yield ('num_ragdoll_constraints', Uint, (0, None), (False, None), None)
+		yield ('zero_0', Uint, (0, None), (False, None), True)
+		yield ('zero_1', Uint, (0, None), (False, None), True)
+		yield ('namespace_length', Uint, (0, None), (False, None), None)
+		yield ('zeros_0', Array, (0, None, (5,), Uint), (False, None), None)
+		yield ('pc_count', Uint, (0, None), (False, None), None)
+		yield ('zeros_1', Array, (0, None, (7,), Uint), (False, None), None)
+		yield ('extra_zeros_2', Array, (0, None, (4,), Uint), (False, None), True)
+		yield ('one_0', Uint64, (0, None), (False, 1), True)
+		yield ('one_1', Uint64, (0, None), (False, 1), True)
+		yield ('bone_count', Uint, (0, None), (False, None), None)
+		yield ('joint_entry_count', Uint, (0, None), (False, None), None)
+		yield ('zeros_2', Array, (0, None, (4,), Uint), (False, None), None)
+		yield ('zeros_3', Uint, (0, None), (False, None), True)
+		yield ('names_ref', Empty, (0, None), (False, None), None)
+		yield ('joint_transforms', Array, (0, None, (None,), JointTransform), (False, None), None)
+		yield ('rigid_body_pointers', Array, (0, None, (None,), Uint64), (False, None), True)
+		yield ('rigid_body_list', Array, (0, None, (None,), RigidBody), (False, None), True)
+		yield ('push_constraints', Array, (0, None, (None,), PushConstraint), (False, None), True)
+		yield ('stretch_constraints', Array, (0, None, (None,), StretchConstraint), (False, None), True)
+		yield ('ragdoll_constraints', Array, (0, None, (None,), RagdollConstraint), (False, None), True)
+		yield ('joint_infos', Array, (0, None, (None,), UACJointFF), (False, None), True)
+		yield ('pc_floats', Array, (0, None, (None, 10,), Float), (False, None), True)
+		yield ('joint_to_bone', Array, (0, None, (None,), Int), (False, None), None)
+		yield ('bone_to_joint', Array, (0, None, (None,), Int), (False, None), None)
+		yield ('joint_names', ZStringBuffer, (None, None), (False, None), None)
+		yield ('joint_names_padding', PadAlign, (8, None), (False, None), True)
+		yield ('joint_names_padding', SmartPadding, (0, None), (False, None), True)
+		yield ('joint_infos', Array, (None, None, (None,), JointInfo), (False, None), True)
+		yield ('hitcheck_reader', HitcheckReader, (None, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -242,3 +243,6 @@ class JointData(BaseStruct):
 			ptr.index = joints_map.get(ptr.joint)
 		super().write_fields(stream, instance)
 
+
+
+JointData.init_attributes()

--- a/generated/formats/ms2/compounds/JointInfo.py
+++ b/generated/formats/ms2/compounds/JointInfo.py
@@ -37,17 +37,18 @@ class JointInfo(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('eleven', Uint, (0, None), (False, 11), None),
-		('zero_0', Int, (0, None), (False, 0), None),
-		('zero_1', Int, (0, None), (False, 0), None),
-		('minus_1', Int, (0, None), (False, -1), None),
-		('name', OffsetString, (None, None), (False, None), None),
-		('hitcheck_count', Uint, (0, None), (False, None), None),
-		('zero_2', Uint64, (0, None), (False, None), None),
-		('hitcheck_pointers', Array, (0, None, (None,), Uint64), (False, None), None),
-		('hitchecks', Array, (None, None, (None,), HitCheck), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('eleven', Uint, (0, None), (False, 11), None)
+		yield ('zero_0', Int, (0, None), (False, 0), None)
+		yield ('zero_1', Int, (0, None), (False, 0), None)
+		yield ('minus_1', Int, (0, None), (False, -1), None)
+		yield ('name', OffsetString, (None, None), (False, None), None)
+		yield ('hitcheck_count', Uint, (0, None), (False, None), None)
+		yield ('zero_2', Uint64, (0, None), (False, None), None)
+		yield ('hitcheck_pointers', Array, (0, None, (None,), Uint64), (False, None), None)
+		yield ('hitchecks', Array, (None, None, (None,), HitCheck), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -61,3 +62,6 @@ class JointInfo(BaseStruct):
 		yield 'zero_2', Uint64, (0, None), (False, None)
 		yield 'hitcheck_pointers', Array, (0, None, (instance.hitcheck_count,), Uint64), (False, None)
 		yield 'hitchecks', Array, (instance.arg, None, (instance.hitcheck_count,), HitCheck), (False, None)
+
+
+JointInfo.init_attributes()

--- a/generated/formats/ms2/compounds/JointPointer.py
+++ b/generated/formats/ms2/compounds/JointPointer.py
@@ -16,11 +16,15 @@ class JointPointer(AbstractPointer):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = AbstractPointer._attribute_list + [
-		('index', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('index', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'index', Ushort, (0, None), (False, None)
+
+
+JointPointer.init_attributes()

--- a/generated/formats/ms2/compounds/JointTransform.py
+++ b/generated/formats/ms2/compounds/JointTransform.py
@@ -24,13 +24,17 @@ class JointTransform(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('rot', Matrix33, (0, None), (False, None), None),
-		('loc', Vector3, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('rot', Matrix33, (0, None), (False, None), None)
+		yield ('loc', Vector3, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'rot', Matrix33, (0, None), (False, None)
 		yield 'loc', Vector3, (0, None), (False, None)
+
+
+JointTransform.init_attributes()

--- a/generated/formats/ms2/compounds/LodInfo.py
+++ b/generated/formats/ms2/compounds/LodInfo.py
@@ -54,20 +54,21 @@ class LodInfo(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('full', Short, (0, None), (False, None), True),
-		('half', Short, (0, None), (False, None), True),
-		('lod_index', Ushort, (0, None), (False, None), True),
-		('distance', Float, (0, None), (False, None), True),
-		('stream_index', Ushort, (0, None), (False, None), True),
-		('bone_index', Ushort, (0, None), (False, None), None),
-		('first_object_index', Ushort, (0, None), (False, None), None),
-		('first_object_index_1', Ushort, (0, None), (False, None), True),
-		('first_object_index_2', Ushort, (0, None), (False, None), True),
-		('last_object_index', Ushort, (0, None), (False, None), None),
-		('vertex_count', Uint, (0, None), (False, None), True),
-		('tri_index_count', Uint, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('full', Short, (0, None), (False, None), True)
+		yield ('half', Short, (0, None), (False, None), True)
+		yield ('lod_index', Ushort, (0, None), (False, None), True)
+		yield ('distance', Float, (0, None), (False, None), True)
+		yield ('stream_index', Ushort, (0, None), (False, None), True)
+		yield ('bone_index', Ushort, (0, None), (False, None), None)
+		yield ('first_object_index', Ushort, (0, None), (False, None), None)
+		yield ('first_object_index_1', Ushort, (0, None), (False, None), True)
+		yield ('first_object_index_2', Ushort, (0, None), (False, None), True)
+		yield ('last_object_index', Ushort, (0, None), (False, None), None)
+		yield ('vertex_count', Uint, (0, None), (False, None), True)
+		yield ('tri_index_count', Uint, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -88,3 +89,6 @@ class LodInfo(BaseStruct):
 		if instance.context.version >= 32 and not (((instance.context.version == 51) or (instance.context.version == 52)) and instance.context.biosyn):
 			yield 'vertex_count', Uint, (0, None), (False, None)
 			yield 'tri_index_count', Uint, (0, None), (False, None)
+
+
+LodInfo.init_attributes()

--- a/generated/formats/ms2/compounds/MaterialName.py
+++ b/generated/formats/ms2/compounds/MaterialName.py
@@ -22,12 +22,13 @@ class MaterialName(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('name_index', Ushort, (0, None), (False, None), True),
-		('name_index', Uint, (0, None), (False, None), True),
-		('blend_mode', Ushort, (0, None), (False, None), True),
-		('blend_mode', Uint, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('name_index', Ushort, (0, None), (False, None), True)
+		yield ('name_index', Uint, (0, None), (False, None), True)
+		yield ('blend_mode', Ushort, (0, None), (False, None), True)
+		yield ('blend_mode', Uint, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -40,3 +41,6 @@ class MaterialName(BaseStruct):
 			yield 'blend_mode', Ushort, (0, None), (False, None)
 		if instance.context.version >= 47:
 			yield 'blend_mode', Uint, (0, None), (False, None)
+
+
+MaterialName.init_attributes()

--- a/generated/formats/ms2/compounds/Matrix33.py
+++ b/generated/formats/ms2/compounds/Matrix33.py
@@ -22,11 +22,15 @@ class Matrix33(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('data', Array, (0, None, (3, 3,), Float), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('data', Array, (0, None, (3, 3,), Float), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'data', Array, (0, None, (3, 3,), Float), (False, None)
+
+
+Matrix33.init_attributes()

--- a/generated/formats/ms2/compounds/Matrix44.py
+++ b/generated/formats/ms2/compounds/Matrix44.py
@@ -22,9 +22,10 @@ class Matrix44(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('data', Array, (0, None, (4, 4,), Float), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('data', Array, (0, None, (4, 4,), Float), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -35,3 +36,6 @@ class Matrix44(BaseStruct):
 		"""Set matrix from rows."""
 		self.data[:] = mat.transposed()
 
+
+
+Matrix44.init_attributes()

--- a/generated/formats/ms2/compounds/MeshCollision.py
+++ b/generated/formats/ms2/compounds/MeshCollision.py
@@ -56,23 +56,24 @@ class MeshCollision(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('rotation', Matrix33, (0, None), (False, None), None),
-		('offset', Vector3, (0, None), (False, None), None),
-		('unk_1', Array, (0, None, (3,), SubA), (False, None), None),
-		('vertex_count', Uint64, (0, None), (False, None), None),
-		('tri_count', Uint64, (0, None), (False, None), None),
-		('bounds_min', Vector3, (0, None), (False, None), None),
-		('bounds_max', Vector3, (0, None), (False, None), None),
-		('flag_0', Uint64, (0, None), (False, 1), None),
-		('flag_1', Uint64, (0, None), (False, 1), None),
-		('has_sub_coll_chunk', Uint64, (0, None), (False, None), None),
-		('zeros_1', Array, (0, None, (4,), Uint64), (False, None), None),
-		('ff', Int, (0, None), (False, -1), None),
-		('zeros_2', Array, (0, None, (7,), Int), (False, None), None),
-		('weird_padding', SmartPadding, (4, None), (False, None), None),
-		('sub_coll_chunk', SubCollChunk, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('rotation', Matrix33, (0, None), (False, None), None)
+		yield ('offset', Vector3, (0, None), (False, None), None)
+		yield ('unk_1', Array, (0, None, (3,), SubA), (False, None), None)
+		yield ('vertex_count', Uint64, (0, None), (False, None), None)
+		yield ('tri_count', Uint64, (0, None), (False, None), None)
+		yield ('bounds_min', Vector3, (0, None), (False, None), None)
+		yield ('bounds_max', Vector3, (0, None), (False, None), None)
+		yield ('flag_0', Uint64, (0, None), (False, 1), None)
+		yield ('flag_1', Uint64, (0, None), (False, 1), None)
+		yield ('has_sub_coll_chunk', Uint64, (0, None), (False, None), None)
+		yield ('zeros_1', Array, (0, None, (4,), Uint64), (False, None), None)
+		yield ('ff', Int, (0, None), (False, -1), None)
+		yield ('zeros_2', Array, (0, None, (7,), Int), (False, None), None)
+		yield ('weird_padding', SmartPadding, (4, None), (False, None), None)
+		yield ('sub_coll_chunk', SubCollChunk, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -93,3 +94,6 @@ class MeshCollision(BaseStruct):
 		yield 'weird_padding', SmartPadding, (4, None), (False, None)
 		if instance.has_sub_coll_chunk:
 			yield 'sub_coll_chunk', SubCollChunk, (0, None), (False, None)
+
+
+MeshCollision.init_attributes()

--- a/generated/formats/ms2/compounds/MeshCollisionBit.py
+++ b/generated/formats/ms2/compounds/MeshCollisionBit.py
@@ -31,13 +31,14 @@ class MeshCollisionBit(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('a', Array, (0, None, (24,), Ushort), (False, None), None),
-		('b', Array, (0, None, (8,), Ushort), (False, None), None),
-		('min_of_b', Ushort, (0, None), (False, None), None),
-		('c', Ushort, (0, None), (False, None), None),
-		('consts', Array, (0, None, (3,), Uint), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('a', Array, (0, None, (24,), Ushort), (False, None), None)
+		yield ('b', Array, (0, None, (8,), Ushort), (False, None), None)
+		yield ('min_of_b', Ushort, (0, None), (False, None), None)
+		yield ('c', Ushort, (0, None), (False, None), None)
+		yield ('consts', Array, (0, None, (3,), Uint), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -47,3 +48,6 @@ class MeshCollisionBit(BaseStruct):
 		yield 'min_of_b', Ushort, (0, None), (False, None)
 		yield 'c', Ushort, (0, None), (False, None)
 		yield 'consts', Array, (0, None, (3,), Uint), (False, None)
+
+
+MeshCollisionBit.init_attributes()

--- a/generated/formats/ms2/compounds/MeshCollisionData.py
+++ b/generated/formats/ms2/compounds/MeshCollisionData.py
@@ -38,16 +38,17 @@ class MeshCollisionData(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('tris_salt', Array, (0, None, (4,), Uint), (False, None), True),
-		('vertices_addr', Empty, (0, None), (False, None), None),
-		('vertices', Array, (0, None, (None, 3,), Float), (False, None), None),
-		('triangles_addr', Empty, (0, None), (False, None), None),
-		('triangles', Array, (0, None, (None, 3,), Ushort), (False, None), None),
-		('const', Uint, (0, None), (False, None), True),
-		('triangle_flags', Array, (0, None, (None,), Uint), (False, None), True),
-		('zero_end', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('tris_salt', Array, (0, None, (4,), Uint), (False, None), True)
+		yield ('vertices_addr', Empty, (0, None), (False, None), None)
+		yield ('vertices', Array, (0, None, (None, 3,), Float), (False, None), None)
+		yield ('triangles_addr', Empty, (0, None), (False, None), None)
+		yield ('triangles', Array, (0, None, (None, 3,), Ushort), (False, None), None)
+		yield ('const', Uint, (0, None), (False, None), True)
+		yield ('triangle_flags', Array, (0, None, (None,), Uint), (False, None), True)
+		yield ('zero_end', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -63,3 +64,6 @@ class MeshCollisionData(BaseStruct):
 		if instance.context.version <= 47 and instance.const:
 			yield 'triangle_flags', Array, (0, None, (instance.arg.tri_flags_count,), Uint), (False, None)
 		yield 'zero_end', Uint, (0, None), (False, None)
+
+
+MeshCollisionData.init_attributes()

--- a/generated/formats/ms2/compounds/MeshData.py
+++ b/generated/formats/ms2/compounds/MeshData.py
@@ -38,12 +38,13 @@ class MeshData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('stream_index', Uint64, (0, None), (False, None), True),
-		('stream_info', Pointer, (0, None), (False, None), True),
-		('some_index', Uint, (0, None), (False, None), True),
-		('some_index_2', Uint, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('stream_index', Uint64, (0, None), (False, None), True)
+		yield ('stream_info', Pointer, (0, None), (False, None), True)
+		yield ('some_index', Uint, (0, None), (False, None), True)
+		yield ('some_index_2', Uint, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -274,3 +275,6 @@ class MeshData(MemStruct):
 			return (0, 0, 0, 0), (0, 0, 0, 0)
 
 
+
+
+MeshData.init_attributes()

--- a/generated/formats/ms2/compounds/MeshDataWrap.py
+++ b/generated/formats/ms2/compounds/MeshDataWrap.py
@@ -17,13 +17,14 @@ class MeshDataWrap(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('mesh', BioMeshData, (0, None), (False, None), True),
-		('mesh', NewMeshData, (0, None), (False, None), True),
-		('mesh', PcMeshData, (0, None), (False, None), True),
-		('mesh', ZtMeshData, (0, None), (False, None), True),
-		('mesh', ZtMeshData, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('mesh', BioMeshData, (0, None), (False, None), True)
+		yield ('mesh', NewMeshData, (0, None), (False, None), True)
+		yield ('mesh', PcMeshData, (0, None), (False, None), True)
+		yield ('mesh', ZtMeshData, (0, None), (False, None), True)
+		yield ('mesh', ZtMeshData, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class MeshDataWrap(MemStruct):
 			yield 'mesh', ZtMeshData, (0, None), (False, None)
 		if instance.context.version == 7:
 			yield 'mesh', ZtMeshData, (0, None), (False, None)
+
+
+MeshDataWrap.init_attributes()

--- a/generated/formats/ms2/compounds/MinusPadding.py
+++ b/generated/formats/ms2/compounds/MinusPadding.py
@@ -26,13 +26,17 @@ class MinusPadding(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('indices', Array, (0, None, (None,), Short), (False, None), None),
-		('padding', Array, (0, None, (None,), Byte), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('indices', Array, (0, None, (None,), Short), (False, None), None)
+		yield ('padding', Array, (0, None, (None,), Byte), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'indices', Array, (0, None, (instance.arg,), Short), (False, None)
 		yield 'padding', Array, (0, None, ((16 - ((instance.arg * 2) % 16)) % 16,), Byte), (False, None)
+
+
+MinusPadding.init_attributes()

--- a/generated/formats/ms2/compounds/Model.py
+++ b/generated/formats/ms2/compounds/Model.py
@@ -42,17 +42,18 @@ class Model(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('start_ref', Empty, (0, None), (False, None), None),
-		('materials', Array, (0, None, (None,), MaterialName), (False, None), None),
-		('lods', Array, (0, None, (None,), LodInfo), (False, None), None),
-		('objects', Array, (0, None, (None,), Object), (False, None), None),
-		('mesh_aligner', PadAlign, (8, None), (False, None), True),
-		('meshes', Array, (0, None, (None,), MeshDataWrap), (False, None), None),
-		('pre_bones', ZTPreBones, (0, None), (False, None), True),
-		('pre_bones', DLAPreBones, (0, None), (False, None), True),
-		('floatsy', Array, (0, None, (None,), FloatsY), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('start_ref', Empty, (0, None), (False, None), None)
+		yield ('materials', Array, (0, None, (None,), MaterialName), (False, None), None)
+		yield ('lods', Array, (0, None, (None,), LodInfo), (False, None), None)
+		yield ('objects', Array, (0, None, (None,), Object), (False, None), None)
+		yield ('mesh_aligner', PadAlign, (8, None), (False, None), True)
+		yield ('meshes', Array, (0, None, (None,), MeshDataWrap), (False, None), None)
+		yield ('pre_bones', ZTPreBones, (0, None), (False, None), True)
+		yield ('pre_bones', DLAPreBones, (0, None), (False, None), True)
+		yield ('floatsy', Array, (0, None, (None,), FloatsY), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -70,3 +71,6 @@ class Model(BaseStruct):
 			yield 'pre_bones', DLAPreBones, (0, None), (False, None)
 		if instance.context.version <= 32:
 			yield 'floatsy', Array, (0, None, (instance.arg.render_flag,), FloatsY), (False, None)
+
+
+Model.init_attributes()

--- a/generated/formats/ms2/compounds/ModelInfo.py
+++ b/generated/formats/ms2/compounds/ModelInfo.py
@@ -92,38 +92,39 @@ class ModelInfo(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk_dla', Uint64, (0, None), (False, None), True),
-		('bounds_min', Vector3, (0, None), (False, None), None),
-		('unk_float_a', Float, (0, None), (False, None), True),
-		('bounds_max', Vector3, (0, None), (False, None), None),
-		('pack_base', Float, (0, None), (False, None), True),
-		('center', Vector3, (0, None), (False, None), None),
-		('radius', Float, (0, None), (False, None), None),
-		('num_lods_2', Uint64, (0, None), (False, None), True),
-		('zero', Uint64, (0, None), (False, None), True),
-		('bounds_min_repeat', Vector3, (0, None), (False, None), True),
-		('bounds_max_repeat', Vector3, (0, None), (False, None), True),
-		('num_materials', Ushort, (0, None), (False, None), None),
-		('num_lods', Ushort, (0, None), (False, None), None),
-		('num_objects', Ushort, (0, None), (False, None), None),
-		('num_meshes', Ushort, (0, None), (False, None), None),
-		('last_count', Ushort, (0, None), (False, None), None),
-		('render_flag', RenderFlag, (0, None), (False, None), None),
-		('unks', Array, (0, None, (7,), Ushort), (False, None), None),
-		('pad', Array, (0, None, (3,), Ushort), (False, None), None),
-		('materials', ArrayPointer, (None, None), (False, None), None),
-		('lods', ArrayPointer, (None, None), (False, None), None),
-		('objects', ArrayPointer, (None, None), (False, None), None),
-		('meshes', ArrayPointer, (None, None), (False, None), None),
-		('first_model', Pointer, (0, None), (False, None), None),
-		('zeros', Array, (0, None, (4,), Uint64), (False, None), True),
-		('zeros', Array, (0, None, (2,), Uint64), (False, None), True),
-		('increment_flag', Uint64, (0, None), (False, None), None),
-		('zero_0', Uint64, (0, None), (False, None), True),
-		('zero_1', Uint64, (0, None), (False, None), True),
-		('zero_2', Uint64, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_dla', Uint64, (0, None), (False, None), True)
+		yield ('bounds_min', Vector3, (0, None), (False, None), None)
+		yield ('unk_float_a', Float, (0, None), (False, None), True)
+		yield ('bounds_max', Vector3, (0, None), (False, None), None)
+		yield ('pack_base', Float, (0, None), (False, None), True)
+		yield ('center', Vector3, (0, None), (False, None), None)
+		yield ('radius', Float, (0, None), (False, None), None)
+		yield ('num_lods_2', Uint64, (0, None), (False, None), True)
+		yield ('zero', Uint64, (0, None), (False, None), True)
+		yield ('bounds_min_repeat', Vector3, (0, None), (False, None), True)
+		yield ('bounds_max_repeat', Vector3, (0, None), (False, None), True)
+		yield ('num_materials', Ushort, (0, None), (False, None), None)
+		yield ('num_lods', Ushort, (0, None), (False, None), None)
+		yield ('num_objects', Ushort, (0, None), (False, None), None)
+		yield ('num_meshes', Ushort, (0, None), (False, None), None)
+		yield ('last_count', Ushort, (0, None), (False, None), None)
+		yield ('render_flag', RenderFlag, (0, None), (False, None), None)
+		yield ('unks', Array, (0, None, (7,), Ushort), (False, None), None)
+		yield ('pad', Array, (0, None, (3,), Ushort), (False, None), None)
+		yield ('materials', ArrayPointer, (None, None), (False, None), None)
+		yield ('lods', ArrayPointer, (None, None), (False, None), None)
+		yield ('objects', ArrayPointer, (None, None), (False, None), None)
+		yield ('meshes', ArrayPointer, (None, None), (False, None), None)
+		yield ('first_model', Pointer, (0, None), (False, None), None)
+		yield ('zeros', Array, (0, None, (4,), Uint64), (False, None), True)
+		yield ('zeros', Array, (0, None, (2,), Uint64), (False, None), True)
+		yield ('increment_flag', Uint64, (0, None), (False, None), None)
+		yield ('zero_0', Uint64, (0, None), (False, None), True)
+		yield ('zero_1', Uint64, (0, None), (False, None), True)
+		yield ('zero_2', Uint64, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -168,3 +169,6 @@ class ModelInfo(MemStruct):
 			yield 'zero_1', Uint64, (0, None), (False, None)
 		if instance.context.version >= 47 and not (((instance.context.version == 51) or (instance.context.version == 52)) and instance.context.biosyn):
 			yield 'zero_2', Uint64, (0, None), (False, None)
+
+
+ModelInfo.init_attributes()

--- a/generated/formats/ms2/compounds/ModelReader.py
+++ b/generated/formats/ms2/compounds/ModelReader.py
@@ -24,8 +24,9 @@ class ModelReader(BaseStruct):
 
 	_import_key = 'ms2.compounds.ModelReader'
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -247,3 +248,6 @@ class ModelReader(BaseStruct):
 			s += str(model_info.bone_info)
 		return s
 
+
+
+ModelReader.init_attributes()

--- a/generated/formats/ms2/compounds/Ms2InfoHeader.py
+++ b/generated/formats/ms2/compounds/Ms2InfoHeader.py
@@ -41,19 +41,20 @@ class Ms2InfoHeader(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('biosyn', BiosynVersion, (0, None), (False, None), None),
-		('bone_info_size', Uint, (0, None), (False, None), None),
-		('num_streams', Uint, (0, None), (False, None), None),
-		('info', Ms2Root, (0, None), (False, None), None),
-		('buffer_pointers', Array, (0, None, (None,), BufferPresence), (False, None), True),
-		('mdl_2_names', Array, (0, None, (None,), ZString), (False, None), None),
-		('modelstream_names', Array, (0, None, (None,), ZString), (False, None), None),
-		('buffer_0', Buffer0, (None, None), (False, None), None),
-		('buffer_infos', Array, (0, None, (None,), BufferInfo), (False, None), None),
-		('model_infos', Array, (0, None, (None,), ModelInfo), (False, None), None),
-		('models_reader', ModelReader, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('biosyn', BiosynVersion, (0, None), (False, None), None)
+		yield ('bone_info_size', Uint, (0, None), (False, None), None)
+		yield ('num_streams', Uint, (0, None), (False, None), None)
+		yield ('info', Ms2Root, (0, None), (False, None), None)
+		yield ('buffer_pointers', Array, (0, None, (None,), BufferPresence), (False, None), True)
+		yield ('mdl_2_names', Array, (0, None, (None,), ZString), (False, None), None)
+		yield ('modelstream_names', Array, (0, None, (None,), ZString), (False, None), None)
+		yield ('buffer_0', Buffer0, (None, None), (False, None), None)
+		yield ('buffer_infos', Array, (0, None, (None,), BufferInfo), (False, None), None)
+		yield ('model_infos', Array, (0, None, (None,), ModelInfo), (False, None), None)
+		yield ('models_reader', ModelReader, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -70,3 +71,6 @@ class Ms2InfoHeader(BaseStruct):
 		yield 'buffer_infos', Array, (0, None, (instance.info.vertex_buffer_count,), BufferInfo), (False, None)
 		yield 'model_infos', Array, (0, None, (instance.info.mdl_2_count,), ModelInfo), (False, None)
 		yield 'models_reader', ModelReader, (instance.model_infos, None), (False, None)
+
+
+Ms2InfoHeader.init_attributes()

--- a/generated/formats/ms2/compounds/Ms2Root.py
+++ b/generated/formats/ms2/compounds/Ms2Root.py
@@ -47,17 +47,18 @@ class Ms2Root(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('version', MainVersion, (0, None), (False, None), None),
-		('vertex_buffer_count', Ushort, (0, None), (False, None), None),
-		('mdl_2_count', Ushort, (0, None), (False, None), None),
-		('name_count', Ushort, (0, None), (False, None), None),
-		('static_buffer_index', Short, (0, None), (False, None), None),
-		('zeros', Array, (0, None, (3,), Uint), (False, None), None),
-		('buffer_infos', ArrayPointer, (None, None), (False, None), None),
-		('model_infos', ArrayPointer, (None, None), (False, None), None),
-		('buffer_pointers', ArrayPointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('version', MainVersion, (0, None), (False, None), None)
+		yield ('vertex_buffer_count', Ushort, (0, None), (False, None), None)
+		yield ('mdl_2_count', Ushort, (0, None), (False, None), None)
+		yield ('name_count', Ushort, (0, None), (False, None), None)
+		yield ('static_buffer_index', Short, (0, None), (False, None), None)
+		yield ('zeros', Array, (0, None, (3,), Uint), (False, None), None)
+		yield ('buffer_infos', ArrayPointer, (None, None), (False, None), None)
+		yield ('model_infos', ArrayPointer, (None, None), (False, None), None)
+		yield ('buffer_pointers', ArrayPointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -71,3 +72,6 @@ class Ms2Root(MemStruct):
 		yield 'buffer_infos', ArrayPointer, (instance.vertex_buffer_count, Ms2Root._import_map["ms2.compounds.BufferInfo"]), (False, None)
 		yield 'model_infos', ArrayPointer, (instance.mdl_2_count, Ms2Root._import_map["ms2.compounds.ModelInfo"]), (False, None)
 		yield 'buffer_pointers', ArrayPointer, (instance.vertex_buffer_count, Ms2Root._import_map["ms2.compounds.BufferPresence"]), (False, None)
+
+
+Ms2Root.init_attributes()

--- a/generated/formats/ms2/compounds/NewMeshData.py
+++ b/generated/formats/ms2/compounds/NewMeshData.py
@@ -55,19 +55,20 @@ class NewMeshData(MeshData):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MeshData._attribute_list + [
-		('vertex_count', Uint, (0, None), (False, None), None),
-		('tri_index_count', Uint, (0, None), (False, None), None),
-		('zero_1', Uint, (0, None), (False, None), None),
-		('poweroftwo', Uint, (0, None), (False, None), None),
-		('vertex_offset', Uint, (0, None), (False, None), None),
-		('size_of_vertex', Uint, (0, None), (False, 48), None),
-		('tri_offset', Uint, (0, None), (False, None), None),
-		('zero_2', Uint, (0, None), (False, None), None),
-		('unk_floats', Array, (0, None, (2,), Float), (False, None), None),
-		('zero_3', Uint, (0, None), (False, None), None),
-		('flag', ModelFlag, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('vertex_count', Uint, (0, None), (False, None), None)
+		yield ('tri_index_count', Uint, (0, None), (False, None), None)
+		yield ('zero_1', Uint, (0, None), (False, None), None)
+		yield ('poweroftwo', Uint, (0, None), (False, None), None)
+		yield ('vertex_offset', Uint, (0, None), (False, None), None)
+		yield ('size_of_vertex', Uint, (0, None), (False, 48), None)
+		yield ('tri_offset', Uint, (0, None), (False, None), None)
+		yield ('zero_2', Uint, (0, None), (False, None), None)
+		yield ('unk_floats', Array, (0, None, (2,), Float), (False, None), None)
+		yield ('zero_3', Uint, (0, None), (False, None), None)
+		yield ('flag', ModelFlag, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -263,3 +264,6 @@ class NewMeshData(MeshData):
 			if "bone ids" in self.dt.fields:
 				vert["bone ids"], vert["bone weights"] = self.unpack_weights_list(weight)
 
+
+
+NewMeshData.init_attributes()

--- a/generated/formats/ms2/compounds/Object.py
+++ b/generated/formats/ms2/compounds/Object.py
@@ -19,13 +19,17 @@ class Object(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('material_index', Ushort, (0, None), (False, None), None),
-		('mesh_index', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('material_index', Ushort, (0, None), (False, None), None)
+		yield ('mesh_index', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'material_index', Ushort, (0, None), (False, None)
 		yield 'mesh_index', Ushort, (0, None), (False, None)
+
+
+Object.init_attributes()

--- a/generated/formats/ms2/compounds/PcMeshData.py
+++ b/generated/formats/ms2/compounds/PcMeshData.py
@@ -59,23 +59,24 @@ class PcMeshData(MeshData):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MeshData._attribute_list + [
-		('tri_index_count_a', Uint, (0, None), (False, None), None),
-		('vertex_count', Uint, (0, None), (False, None), None),
-		('tri_offset', Uint, (0, None), (False, None), None),
-		('tri_index_count', Uint, (0, None), (False, None), None),
-		('vertex_offset', Uint, (0, None), (False, None), None),
-		('weights_offset', Uint, (0, None), (False, None), None),
-		('uv_offset', Uint, (0, None), (False, None), None),
-		('zero_a', Uint, (0, None), (False, 0), None),
-		('vertex_color_offset', Uint, (0, None), (False, None), None),
-		('vertex_offset_within_lod', Uint, (0, None), (False, None), None),
-		('poweroftwo', Uint, (0, None), (False, None), None),
-		('zero_b', Uint, (0, None), (False, 0), None),
-		('unk_float', Float, (0, None), (False, None), None),
-		('flag', ModelFlag, (0, None), (False, None), None),
-		('zero_c', Uint, (0, None), (False, 0), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('tri_index_count_a', Uint, (0, None), (False, None), None)
+		yield ('vertex_count', Uint, (0, None), (False, None), None)
+		yield ('tri_offset', Uint, (0, None), (False, None), None)
+		yield ('tri_index_count', Uint, (0, None), (False, None), None)
+		yield ('vertex_offset', Uint, (0, None), (False, None), None)
+		yield ('weights_offset', Uint, (0, None), (False, None), None)
+		yield ('uv_offset', Uint, (0, None), (False, None), None)
+		yield ('zero_a', Uint, (0, None), (False, 0), None)
+		yield ('vertex_color_offset', Uint, (0, None), (False, None), None)
+		yield ('vertex_offset_within_lod', Uint, (0, None), (False, None), None)
+		yield ('poweroftwo', Uint, (0, None), (False, None), None)
+		yield ('zero_b', Uint, (0, None), (False, 0), None)
+		yield ('unk_float', Float, (0, None), (False, None), None)
+		yield ('flag', ModelFlag, (0, None), (False, None), None)
+		yield ('zero_c', Uint, (0, None), (False, 0), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -183,3 +184,6 @@ class PcMeshData(MeshData):
 		index_count = self.tri_index_count // self.shell_count
 		self.tri_indices = self.read_pc_array(np.uint16, self.tri_offset, index_count)
 
+
+
+PcMeshData.init_attributes()

--- a/generated/formats/ms2/compounds/PushConstraint.py
+++ b/generated/formats/ms2/compounds/PushConstraint.py
@@ -22,11 +22,15 @@ class PushConstraint(Constraint):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = Constraint._attribute_list + [
-		('floats', Array, (0, None, (3,), Float), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('floats', Array, (0, None, (3,), Float), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'floats', Array, (0, None, (3,), Float), (False, None)
+
+
+PushConstraint.init_attributes()

--- a/generated/formats/ms2/compounds/RagdollConstraint.py
+++ b/generated/formats/ms2/compounds/RagdollConstraint.py
@@ -29,11 +29,12 @@ class RagdollConstraint(Constraint):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = Constraint._attribute_list + [
-		('loc', Vector3, (0, None), (False, None), None),
-		('floats', Array, (0, None, (5, 3,), Float), (False, None), None),
-		('radians', Array, (0, None, (8,), Float), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('loc', Vector3, (0, None), (False, None), None)
+		yield ('floats', Array, (0, None, (5, 3,), Float), (False, None), None)
+		yield ('radians', Array, (0, None, (8,), Float), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class RagdollConstraint(Constraint):
 		yield 'loc', Vector3, (0, None), (False, None)
 		yield 'floats', Array, (0, None, (5, 3,), Float), (False, None)
 		yield 'radians', Array, (0, None, (8,), Float), (False, None)
+
+
+RagdollConstraint.init_attributes()

--- a/generated/formats/ms2/compounds/RigidBody.py
+++ b/generated/formats/ms2/compounds/RigidBody.py
@@ -42,17 +42,18 @@ class RigidBody(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('flag', Uint, (0, None), (False, None), None),
-		('loc', Vector3, (0, None), (False, None), None),
-		('mass', Float, (0, None), (False, None), None),
-		('static_friction', Float, (0, None), (False, None), None),
-		('unk_1', Float, (0, None), (False, None), None),
-		('unk_2', Float, (0, None), (False, None), None),
-		('unknown_friction', Float, (0, None), (False, None), None),
-		('unk_4', Float, (0, None), (False, None), None),
-		('dynamic_friction', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('flag', Uint, (0, None), (False, None), None)
+		yield ('loc', Vector3, (0, None), (False, None), None)
+		yield ('mass', Float, (0, None), (False, None), None)
+		yield ('static_friction', Float, (0, None), (False, None), None)
+		yield ('unk_1', Float, (0, None), (False, None), None)
+		yield ('unk_2', Float, (0, None), (False, None), None)
+		yield ('unknown_friction', Float, (0, None), (False, None), None)
+		yield ('unk_4', Float, (0, None), (False, None), None)
+		yield ('dynamic_friction', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -66,3 +67,6 @@ class RigidBody(BaseStruct):
 		yield 'unknown_friction', Float, (0, None), (False, None)
 		yield 'unk_4', Float, (0, None), (False, None)
 		yield 'dynamic_friction', Float, (0, None), (False, None)
+
+
+RigidBody.init_attributes()

--- a/generated/formats/ms2/compounds/RotationRange.py
+++ b/generated/formats/ms2/compounds/RotationRange.py
@@ -19,13 +19,17 @@ class RotationRange(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('min', Float, (0, None), (False, None), None),
-		('max', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('min', Float, (0, None), (False, None), None)
+		yield ('max', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'min', Float, (0, None), (False, None)
 		yield 'max', Float, (0, None), (False, None)
+
+
+RotationRange.init_attributes()

--- a/generated/formats/ms2/compounds/Sphere.py
+++ b/generated/formats/ms2/compounds/Sphere.py
@@ -24,11 +24,12 @@ class Sphere(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('center', Vector3, (0, None), (False, None), None),
-		('radius', Float, (0, None), (False, None), None),
-		('zero', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('center', Vector3, (0, None), (False, None), None)
+		yield ('radius', Float, (0, None), (False, None), None)
+		yield ('zero', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class Sphere(BaseStruct):
 		yield 'center', Vector3, (0, None), (False, None)
 		yield 'radius', Float, (0, None), (False, None)
 		yield 'zero', Uint, (0, None), (False, None)
+
+
+Sphere.init_attributes()

--- a/generated/formats/ms2/compounds/StreamDebugger.py
+++ b/generated/formats/ms2/compounds/StreamDebugger.py
@@ -16,9 +16,13 @@ class StreamDebugger(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
+
+
+StreamDebugger.init_attributes()

--- a/generated/formats/ms2/compounds/StreamsZTHeader.py
+++ b/generated/formats/ms2/compounds/StreamsZTHeader.py
@@ -26,13 +26,17 @@ class StreamsZTHeader(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('weird_padding', SmartPadding, (0, None), (False, None), None),
-		('unks', Array, (0, None, (None,), InfoZTMemPool), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('weird_padding', SmartPadding, (0, None), (False, None), None)
+		yield ('unks', Array, (0, None, (None,), InfoZTMemPool), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'weird_padding', SmartPadding, (0, None), (False, None)
 		yield 'unks', Array, (0, None, (instance.arg.static_buffer_index,), InfoZTMemPool), (False, None)
+
+
+StreamsZTHeader.init_attributes()

--- a/generated/formats/ms2/compounds/StretchConstraint.py
+++ b/generated/formats/ms2/compounds/StretchConstraint.py
@@ -31,12 +31,13 @@ class StretchConstraint(Constraint):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = Constraint._attribute_list + [
-		('loc', Vector3, (0, None), (False, None), None),
-		('direction', Vector3, (0, None), (False, None), None),
-		('min', Float, (0, None), (False, None), None),
-		('max', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('loc', Vector3, (0, None), (False, None), None)
+		yield ('direction', Vector3, (0, None), (False, None), None)
+		yield ('min', Float, (0, None), (False, None), None)
+		yield ('max', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -45,3 +46,6 @@ class StretchConstraint(Constraint):
 		yield 'direction', Vector3, (0, None), (False, None)
 		yield 'min', Float, (0, None), (False, None)
 		yield 'max', Float, (0, None), (False, None)
+
+
+StretchConstraint.init_attributes()

--- a/generated/formats/ms2/compounds/SubA.py
+++ b/generated/formats/ms2/compounds/SubA.py
@@ -25,12 +25,13 @@ class SubA(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('index', Ubyte, (0, None), (False, None), None),
-		('a', Ubyte, (0, None), (False, 240), None),
-		('b', Ubyte, (0, None), (False, 237), None),
-		('c', Ubyte, (0, None), (False, 254), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('index', Ubyte, (0, None), (False, None), None)
+		yield ('a', Ubyte, (0, None), (False, 240), None)
+		yield ('b', Ubyte, (0, None), (False, 237), None)
+		yield ('c', Ubyte, (0, None), (False, 254), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -39,3 +40,6 @@ class SubA(BaseStruct):
 		yield 'a', Ubyte, (0, None), (False, 240)
 		yield 'b', Ubyte, (0, None), (False, 237)
 		yield 'c', Ubyte, (0, None), (False, 254)
+
+
+SubA.init_attributes()

--- a/generated/formats/ms2/compounds/SubCollChunk.py
+++ b/generated/formats/ms2/compounds/SubCollChunk.py
@@ -36,14 +36,15 @@ class SubCollChunk(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('bounds_min_repeat', Vector3, (0, None), (False, None), None),
-		('bounds_max_repeat', Vector3, (0, None), (False, None), None),
-		('tri_flags_count', Uint, (0, None), (False, None), None),
-		('count_bits', Ushort, (0, None), (False, None), None),
-		('stuff', Array, (0, None, (9,), Ushort), (False, None), None),
-		('collision_bits', Array, (0, None, (None,), MeshCollisionBit), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('bounds_min_repeat', Vector3, (0, None), (False, None), None)
+		yield ('bounds_max_repeat', Vector3, (0, None), (False, None), None)
+		yield ('tri_flags_count', Uint, (0, None), (False, None), None)
+		yield ('count_bits', Ushort, (0, None), (False, None), None)
+		yield ('stuff', Array, (0, None, (9,), Ushort), (False, None), None)
+		yield ('collision_bits', Array, (0, None, (None,), MeshCollisionBit), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -54,3 +55,6 @@ class SubCollChunk(BaseStruct):
 		yield 'count_bits', Ushort, (0, None), (False, None)
 		yield 'stuff', Array, (0, None, (9,), Ushort), (False, None)
 		yield 'collision_bits', Array, (0, None, (instance.count_bits,), MeshCollisionBit), (False, None)
+
+
+SubCollChunk.init_attributes()

--- a/generated/formats/ms2/compounds/TriChunk.py
+++ b/generated/formats/ms2/compounds/TriChunk.py
@@ -37,17 +37,18 @@ class TriChunk(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('bounds_min', Vector3, (0, None), (False, None), None),
-		('material_index', Ushort, (0, None), (False, None), None),
-		('tris_count', Ushort, (0, None), (False, None), None),
-		('bounds_max', Vector3, (0, None), (False, None), None),
-		('tris_offset', Uint, (0, None), (False, None), None),
-		('loc', Vector3, (0, None), (False, None), None),
-		('rot', AxisAngle, (0, None), (False, None), None),
-		('shell_index', Ushort, (0, None), (False, None), None),
-		('shell_count', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('bounds_min', Vector3, (0, None), (False, None), None)
+		yield ('material_index', Ushort, (0, None), (False, None), None)
+		yield ('tris_count', Ushort, (0, None), (False, None), None)
+		yield ('bounds_max', Vector3, (0, None), (False, None), None)
+		yield ('tris_offset', Uint, (0, None), (False, None), None)
+		yield ('loc', Vector3, (0, None), (False, None), None)
+		yield ('rot', AxisAngle, (0, None), (False, None), None)
+		yield ('shell_index', Ushort, (0, None), (False, None), None)
+		yield ('shell_count', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -61,3 +62,6 @@ class TriChunk(BaseStruct):
 		yield 'rot', AxisAngle, (0, None), (False, None)
 		yield 'shell_index', Ushort, (0, None), (False, None)
 		yield 'shell_count', Ushort, (0, None), (False, None)
+
+
+TriChunk.init_attributes()

--- a/generated/formats/ms2/compounds/UACJoint.py
+++ b/generated/formats/ms2/compounds/UACJoint.py
@@ -26,13 +26,17 @@ class UACJoint(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('unk', Array, (0, None, (6,), Ushort), (False, None), None),
-		('floats', Array, (0, None, (6,), Float), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk', Array, (0, None, (6,), Ushort), (False, None), None)
+		yield ('floats', Array, (0, None, (6,), Float), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'unk', Array, (0, None, (6,), Ushort), (False, None)
 		yield 'floats', Array, (0, None, (6,), Float), (False, None)
+
+
+UACJoint.init_attributes()

--- a/generated/formats/ms2/compounds/UACJointFF.py
+++ b/generated/formats/ms2/compounds/UACJointFF.py
@@ -28,13 +28,14 @@ class UACJointFF(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('eleven', Uint, (0, None), (False, None), None),
-		('f_fs', Array, (0, None, (4,), Int), (False, None), None),
-		('name', OffsetString, (None, None), (False, None), None),
-		('hitcheck_count', Uint, (0, None), (False, None), None),
-		('zeros', Array, (0, None, (3,), Uint), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('eleven', Uint, (0, None), (False, None), None)
+		yield ('f_fs', Array, (0, None, (4,), Int), (False, None), None)
+		yield ('name', OffsetString, (None, None), (False, None), None)
+		yield ('hitcheck_count', Uint, (0, None), (False, None), None)
+		yield ('zeros', Array, (0, None, (3,), Uint), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -44,3 +45,6 @@ class UACJointFF(BaseStruct):
 		yield 'name', OffsetString, (instance.arg, None), (False, None)
 		yield 'hitcheck_count', Uint, (0, None), (False, None)
 		yield 'zeros', Array, (0, None, (3,), Uint), (False, None)
+
+
+UACJointFF.init_attributes()

--- a/generated/formats/ms2/compounds/Vector3.py
+++ b/generated/formats/ms2/compounds/Vector3.py
@@ -26,11 +26,12 @@ class Vector3(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -50,3 +51,6 @@ class Vector3(BaseStruct):
 	def __repr__(self):
 		return f"[ {self.x:6.3f} {self.y:6.3f} {self.z:6.3f} ]"
 
+
+
+Vector3.init_attributes()

--- a/generated/formats/ms2/compounds/Vector4.py
+++ b/generated/formats/ms2/compounds/Vector4.py
@@ -29,12 +29,13 @@ class Vector4(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		('w', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
+		yield ('w', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -47,3 +48,6 @@ class Vector4(BaseStruct):
 	def __repr__(self):
 		return f"[ {self.x:6.3f} {self.y:6.3f} {self.z:6.3f} {self.w:6.3f} ]"
 
+
+
+Vector4.init_attributes()

--- a/generated/formats/ms2/compounds/VertChunk.py
+++ b/generated/formats/ms2/compounds/VertChunk.py
@@ -35,15 +35,16 @@ class VertChunk(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('scale', Float, (0, None), (False, None), None),
-		('pack_base', Float, (0, None), (False, None), None),
-		('vertex_offset', Uint, (0, None), (False, None), None),
-		('vertex_count', Ubyte, (0, None), (False, None), None),
-		('weights_flag', WeightsFlag, (0, None), (False, None), True),
-		('weights_flag', WeightsFlagMalta, (0, None), (False, None), True),
-		('zero', Ubyte, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('scale', Float, (0, None), (False, None), None)
+		yield ('pack_base', Float, (0, None), (False, None), None)
+		yield ('vertex_offset', Uint, (0, None), (False, None), None)
+		yield ('vertex_count', Ubyte, (0, None), (False, None), None)
+		yield ('weights_flag', WeightsFlag, (0, None), (False, None), True)
+		yield ('weights_flag', WeightsFlagMalta, (0, None), (False, None), True)
+		yield ('zero', Ubyte, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -57,3 +58,6 @@ class VertChunk(BaseStruct):
 		if instance.context.version >= 52:
 			yield 'weights_flag', WeightsFlagMalta, (0, None), (False, None)
 		yield 'zero', Ubyte, (0, None), (False, None)
+
+
+VertChunk.init_attributes()

--- a/generated/formats/ms2/compounds/ZTPreBones.py
+++ b/generated/formats/ms2/compounds/ZTPreBones.py
@@ -22,13 +22,14 @@ class ZTPreBones(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('zeros', Array, (0, None, (2,), Uint64), (False, None), None),
-		('unks', Array, (0, None, (8,), Uint), (False, None), None),
-		('unks_2', Array, (0, None, (10,), Uint), (False, None), None),
-		('floats', Array, (0, None, (4,), Float), (False, None), None),
-		('unks_3', Array, (0, None, (2,), Uint), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('zeros', Array, (0, None, (2,), Uint64), (False, None), None)
+		yield ('unks', Array, (0, None, (8,), Uint), (False, None), None)
+		yield ('unks_2', Array, (0, None, (10,), Uint), (False, None), None)
+		yield ('floats', Array, (0, None, (4,), Float), (False, None), None)
+		yield ('unks_3', Array, (0, None, (2,), Uint), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class ZTPreBones(BaseStruct):
 		yield 'unks_2', Array, (0, None, (10,), Uint), (False, None)
 		yield 'floats', Array, (0, None, (4,), Float), (False, None)
 		yield 'unks_3', Array, (0, None, (2,), Uint), (False, None)
+
+
+ZTPreBones.init_attributes()

--- a/generated/formats/ms2/compounds/ZerosPadding.py
+++ b/generated/formats/ms2/compounds/ZerosPadding.py
@@ -24,11 +24,12 @@ class ZerosPadding(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('hier_2_padding_0', Uint64, (0, None), (False, None), None),
-		('hier_2_padding_1', Uint64, (0, None), (False, None), True),
-		('hier_2_padding_2', Uint64, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('hier_2_padding_0', Uint64, (0, None), (False, None), None)
+		yield ('hier_2_padding_1', Uint64, (0, None), (False, None), True)
+		yield ('hier_2_padding_2', Uint64, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class ZerosPadding(BaseStruct):
 			yield 'hier_2_padding_1', Uint64, (0, None), (False, None)
 		if 128 < instance.arg:
 			yield 'hier_2_padding_2', Uint64, (0, None), (False, None)
+
+
+ZerosPadding.init_attributes()

--- a/generated/formats/ms2/compounds/ZtMeshData.py
+++ b/generated/formats/ms2/compounds/ZtMeshData.py
@@ -60,23 +60,24 @@ class ZtMeshData(MeshData):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MeshData._attribute_list + [
-		('tri_index_count', Uint, (0, None), (False, None), None),
-		('vertex_count', Uint, (0, None), (False, None), None),
-		('tri_info_offset', Uint, (0, None), (False, None), None),
-		('vert_info_offset', Uint, (0, None), (False, None), None),
-		('known_ff_0', Int, (0, None), (False, None), None),
-		('tri_offset', Uint, (0, None), (False, None), None),
-		('uv_offset', Uint, (0, None), (False, None), None),
-		('vertex_offset', Uint, (0, None), (False, None), None),
-		('unk_index', Short, (0, None), (False, None), None),
-		('one_0', Ushort, (0, None), (False, None), None),
-		('one_1', Ushort, (0, None), (False, None), None),
-		('poweroftwo', Ushort, (0, None), (False, None), None),
-		('flag', ModelFlagDLA, (0, None), (False, None), True),
-		('flag', ModelFlagZT, (0, None), (False, None), True),
-		('zero_uac', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('tri_index_count', Uint, (0, None), (False, None), None)
+		yield ('vertex_count', Uint, (0, None), (False, None), None)
+		yield ('tri_info_offset', Uint, (0, None), (False, None), None)
+		yield ('vert_info_offset', Uint, (0, None), (False, None), None)
+		yield ('known_ff_0', Int, (0, None), (False, None), None)
+		yield ('tri_offset', Uint, (0, None), (False, None), None)
+		yield ('uv_offset', Uint, (0, None), (False, None), None)
+		yield ('vertex_offset', Uint, (0, None), (False, None), None)
+		yield ('unk_index', Short, (0, None), (False, None), None)
+		yield ('one_0', Ushort, (0, None), (False, None), None)
+		yield ('one_1', Ushort, (0, None), (False, None), None)
+		yield ('poweroftwo', Ushort, (0, None), (False, None), None)
+		yield ('flag', ModelFlagDLA, (0, None), (False, None), True)
+		yield ('flag', ModelFlagZT, (0, None), (False, None), True)
+		yield ('zero_uac', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -223,3 +224,6 @@ class ZtMeshData(MeshData):
 		# self.get_static_weights(self.verts_data["bone index"], self.use_blended_weights)
 
 
+
+
+ZtMeshData.init_attributes()

--- a/generated/formats/ms2/compounds/ZtTriBlockInfo.py
+++ b/generated/formats/ms2/compounds/ZtTriBlockInfo.py
@@ -21,11 +21,12 @@ class ZtTriBlockInfo(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('tri_index_count', Uint, (0, None), (False, None), None),
-		('a', Short, (0, None), (False, None), None),
-		('unk_index', Short, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('tri_index_count', Uint, (0, None), (False, None), None)
+		yield ('a', Short, (0, None), (False, None), None)
+		yield ('unk_index', Short, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -33,3 +34,6 @@ class ZtTriBlockInfo(BaseStruct):
 		yield 'tri_index_count', Uint, (0, None), (False, None)
 		yield 'a', Short, (0, None), (False, None)
 		yield 'unk_index', Short, (0, None), (False, None)
+
+
+ZtTriBlockInfo.init_attributes()

--- a/generated/formats/ms2/compounds/ZtVertBlockInfo.py
+++ b/generated/formats/ms2/compounds/ZtVertBlockInfo.py
@@ -23,11 +23,12 @@ class ZtVertBlockInfo(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('vertex_count', Uint, (0, None), (False, None), None),
-		('flags', Array, (0, None, (8,), Ubyte), (False, None), None),
-		('zero', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('vertex_count', Uint, (0, None), (False, None), None)
+		yield ('flags', Array, (0, None, (8,), Ubyte), (False, None), None)
+		yield ('zero', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -35,3 +36,6 @@ class ZtVertBlockInfo(BaseStruct):
 		yield 'vertex_count', Uint, (0, None), (False, None)
 		yield 'flags', Array, (0, None, (8,), Ubyte), (False, None)
 		yield 'zero', Uint, (0, None), (False, None)
+
+
+ZtVertBlockInfo.init_attributes()

--- a/generated/formats/ovl/compounds/ArchiveEntry.py
+++ b/generated/formats/ovl/compounds/ArchiveEntry.py
@@ -67,25 +67,26 @@ class ArchiveEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('name', OffsetString, (None, None), (False, None), None),
-		('pools_offset', Uint, (0, None), (False, None), None),
-		('stream_files_offset', Uint, (0, None), (False, None), None),
-		('num_pools', Uint, (0, None), (False, None), None),
-		('num_datas', Ushort, (0, None), (False, None), None),
-		('num_pool_groups', Ushort, (0, None), (False, None), None),
-		('num_buffer_groups', Uint, (0, None), (False, None), None),
-		('num_buffers', Uint, (0, None), (False, None), None),
-		('num_fragments', Uint, (0, None), (False, None), None),
-		('num_root_entries', Uint, (0, None), (False, None), None),
-		('read_start', Uint, (0, None), (False, None), None),
-		('set_data_size', Uint, (0, None), (False, None), None),
-		('compressed_size', Uint, (0, None), (False, None), None),
-		('uncompressed_size', Uint64, (0, None), (False, None), None),
-		('pools_start', Uint, (0, None), (False, None), None),
-		('pools_end', Uint, (0, None), (False, None), None),
-		('ovs_offset', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('name', OffsetString, (None, None), (False, None), None)
+		yield ('pools_offset', Uint, (0, None), (False, None), None)
+		yield ('stream_files_offset', Uint, (0, None), (False, None), None)
+		yield ('num_pools', Uint, (0, None), (False, None), None)
+		yield ('num_datas', Ushort, (0, None), (False, None), None)
+		yield ('num_pool_groups', Ushort, (0, None), (False, None), None)
+		yield ('num_buffer_groups', Uint, (0, None), (False, None), None)
+		yield ('num_buffers', Uint, (0, None), (False, None), None)
+		yield ('num_fragments', Uint, (0, None), (False, None), None)
+		yield ('num_root_entries', Uint, (0, None), (False, None), None)
+		yield ('read_start', Uint, (0, None), (False, None), None)
+		yield ('set_data_size', Uint, (0, None), (False, None), None)
+		yield ('compressed_size', Uint, (0, None), (False, None), None)
+		yield ('uncompressed_size', Uint64, (0, None), (False, None), None)
+		yield ('pools_start', Uint, (0, None), (False, None), None)
+		yield ('pools_end', Uint, (0, None), (False, None), None)
+		yield ('ovs_offset', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -107,3 +108,6 @@ class ArchiveEntry(BaseStruct):
 		yield 'pools_start', Uint, (0, None), (False, None)
 		yield 'pools_end', Uint, (0, None), (False, None)
 		yield 'ovs_offset', Uint, (0, None), (False, None)
+
+
+ArchiveEntry.init_attributes()

--- a/generated/formats/ovl/compounds/ArchiveMeta.py
+++ b/generated/formats/ovl/compounds/ArchiveMeta.py
@@ -24,13 +24,17 @@ class ArchiveMeta(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('unk_0', Uint, (0, None), (False, None), None),
-		('unk_1', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_0', Uint, (0, None), (False, None), None)
+		yield ('unk_1', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'unk_0', Uint, (0, None), (False, None)
 		yield 'unk_1', Uint, (0, None), (False, None)
+
+
+ArchiveMeta.init_attributes()

--- a/generated/formats/ovl/compounds/AssetEntry.py
+++ b/generated/formats/ovl/compounds/AssetEntry.py
@@ -24,11 +24,12 @@ class AssetEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('file_hash', Uint64, (0, None), (False, None), None),
-		('ext_hash', Uint64, (0, None), (False, None), True),
-		('root_index', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('file_hash', Uint64, (0, None), (False, None), None)
+		yield ('ext_hash', Uint64, (0, None), (False, None), True)
+		yield ('root_index', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -37,3 +38,6 @@ class AssetEntry(BaseStruct):
 		if instance.context.version >= 19:
 			yield 'ext_hash', Uint64, (0, None), (False, None)
 		yield 'root_index', Uint64, (0, None), (False, None)
+
+
+AssetEntry.init_attributes()

--- a/generated/formats/ovl/compounds/AuxEntry.py
+++ b/generated/formats/ovl/compounds/AuxEntry.py
@@ -26,11 +26,12 @@ class AuxEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('file_index', Uint, (0, None), (False, None), None),
-		('basename', OffsetString, (None, None), (False, None), None),
-		('size', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('file_index', Uint, (0, None), (False, None), None)
+		yield ('basename', OffsetString, (None, None), (False, None), None)
+		yield ('size', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class AuxEntry(BaseStruct):
 		yield 'file_index', Uint, (0, None), (False, None)
 		yield 'basename', OffsetString, (instance.context.names, None), (False, None)
 		yield 'size', Uint, (0, None), (False, None)
+
+
+AuxEntry.init_attributes()

--- a/generated/formats/ovl/compounds/BufferEntry.py
+++ b/generated/formats/ovl/compounds/BufferEntry.py
@@ -29,11 +29,12 @@ class BufferEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('index', Uint, (0, None), (False, None), True),
-		('size', Uint, (0, None), (False, None), None),
-		('file_hash', Uint, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('index', Uint, (0, None), (False, None), True)
+		yield ('size', Uint, (0, None), (False, None), None)
+		yield ('file_hash', Uint, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -64,3 +65,6 @@ class BufferEntry(BaseStruct):
 				same = False
 		return same
 
+
+
+BufferEntry.init_attributes()

--- a/generated/formats/ovl/compounds/BufferGroup.py
+++ b/generated/formats/ovl/compounds/BufferGroup.py
@@ -39,15 +39,16 @@ class BufferGroup(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('buffer_offset', Uint, (0, None), (False, None), None),
-		('buffer_count', Uint, (0, None), (False, None), None),
-		('ext_index', Uint, (0, None), (False, None), None),
-		('buffer_index', Uint, (0, None), (False, None), None),
-		('size', Uint64, (0, None), (False, None), None),
-		('data_offset', Uint, (0, None), (False, None), None),
-		('data_count', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('buffer_offset', Uint, (0, None), (False, None), None)
+		yield ('buffer_count', Uint, (0, None), (False, None), None)
+		yield ('ext_index', Uint, (0, None), (False, None), None)
+		yield ('buffer_index', Uint, (0, None), (False, None), None)
+		yield ('size', Uint64, (0, None), (False, None), None)
+		yield ('data_offset', Uint, (0, None), (False, None), None)
+		yield ('data_count', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -59,3 +60,6 @@ class BufferGroup(BaseStruct):
 		yield 'size', Uint64, (0, None), (False, None)
 		yield 'data_offset', Uint, (0, None), (False, None)
 		yield 'data_count', Uint, (0, None), (False, None)
+
+
+BufferGroup.init_attributes()

--- a/generated/formats/ovl/compounds/DataEntry.py
+++ b/generated/formats/ovl/compounds/DataEntry.py
@@ -41,15 +41,16 @@ class DataEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('file_hash', Uint, (0, None), (False, None), None),
-		('ext_hash', Uint, (0, None), (False, None), True),
-		('set_index', Ushort, (0, None), (False, None), None),
-		('buffer_count', Ushort, (0, None), (False, None), None),
-		('zero', Uint, (0, None), (False, None), True),
-		('size_1', Uint64, (0, None), (False, None), None),
-		('size_2', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('file_hash', Uint, (0, None), (False, None), None)
+		yield ('ext_hash', Uint, (0, None), (False, None), True)
+		yield ('set_index', Ushort, (0, None), (False, None), None)
+		yield ('buffer_count', Ushort, (0, None), (False, None), None)
+		yield ('zero', Uint, (0, None), (False, None), True)
+		yield ('size_1', Uint64, (0, None), (False, None), None)
+		yield ('size_2', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -106,3 +107,6 @@ class DataEntry(BaseStruct):
 				same = False
 		return same
 
+
+
+DataEntry.init_attributes()

--- a/generated/formats/ovl/compounds/DependencyEntry.py
+++ b/generated/formats/ovl/compounds/DependencyEntry.py
@@ -34,12 +34,13 @@ class DependencyEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('file_hash', Uint, (0, None), (False, None), None),
-		('ext_raw', OffsetString, (None, None), (False, None), None),
-		('file_index', Uint, (0, None), (False, None), None),
-		('link_ptr', HeaderPointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('file_hash', Uint, (0, None), (False, None), None)
+		yield ('ext_raw', OffsetString, (None, None), (False, None), None)
+		yield ('file_index', Uint, (0, None), (False, None), None)
+		yield ('link_ptr', HeaderPointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -61,3 +62,6 @@ class DependencyEntry(BaseStruct):
 		# name is already set at this point
 		self.link_ptr.add_link(self.name, pools)
 
+
+
+DependencyEntry.init_attributes()

--- a/generated/formats/ovl/compounds/FileEntry.py
+++ b/generated/formats/ovl/compounds/FileEntry.py
@@ -34,13 +34,14 @@ class FileEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('basename', OffsetString, (None, None), (False, None), None),
-		('file_hash', Uint, (0, None), (False, None), None),
-		('pool_type', Byte, (0, None), (False, None), None),
-		('set_pool_type', Byte, (0, None), (False, None), None),
-		('extension', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('basename', OffsetString, (None, None), (False, None), None)
+		yield ('file_hash', Uint, (0, None), (False, None), None)
+		yield ('pool_type', Byte, (0, None), (False, None), None)
+		yield ('set_pool_type', Byte, (0, None), (False, None), None)
+		yield ('extension', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -56,3 +57,6 @@ class FileEntry(BaseStruct):
 		self.pool_type = ovl.get_mime(self.ext, "pool")
 		self.set_pool_type = ovl.get_mime(self.ext, "set_pool")
 
+
+
+FileEntry.init_attributes()

--- a/generated/formats/ovl/compounds/Fragment.py
+++ b/generated/formats/ovl/compounds/Fragment.py
@@ -26,10 +26,11 @@ class Fragment(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('link_ptr', HeaderPointer, (0, None), (False, None), None),
-		('struct_ptr', HeaderPointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('link_ptr', HeaderPointer, (0, None), (False, None), None)
+		yield ('struct_ptr', HeaderPointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -50,3 +51,6 @@ class Fragment(BaseStruct):
 		target_pool = pools[self.struct_ptr.pool_index]
 		self.link_ptr.add_link((target_pool, self.struct_ptr.data_offset), pools)
 
+
+
+Fragment.init_attributes()

--- a/generated/formats/ovl/compounds/Header.py
+++ b/generated/formats/ovl/compounds/Header.py
@@ -119,46 +119,47 @@ class Header(GenericHeader):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = GenericHeader._attribute_list + [
-		('lod_depth', Uint, (0, None), (False, None), None),
-		('len_names', Uint, (0, None), (False, None), None),
-		('zero_2', Uint, (0, None), (False, None), None),
-		('num_aux_entries', Uint, (0, None), (False, None), None),
-		('num_included_ovls', Ushort, (0, None), (False, None), None),
-		('num_mimes', Ushort, (0, None), (False, None), None),
-		('num_files', Uint, (0, None), (False, None), None),
-		('num_files_2', Uint, (0, None), (False, None), None),
-		('num_dependencies', Uint, (0, None), (False, None), None),
-		('num_archives', Uint, (0, None), (False, None), None),
-		('num_pool_groups', Uint, (0, None), (False, None), None),
-		('num_pools', Uint, (0, None), (False, None), None),
-		('num_datas', Uint, (0, None), (False, None), None),
-		('num_buffers', Uint, (0, None), (False, None), None),
-		('num_stream_files', Uint, (0, None), (False, None), None),
-		('ztuac_unk_0', Uint, (0, None), (False, None), None),
-		('ztuac_unk_1', Uint, (0, None), (False, None), None),
-		('ztuac_unk_2', Uint, (0, None), (False, None), None),
-		('len_archive_names', Uint, (0, None), (False, None), None),
-		('num_files_3', Uint, (0, None), (False, None), None),
-		('len_type_names', Uint, (0, None), (False, None), None),
-		('num_triplets', Uint, (0, None), (False, None), None),
-		('reserved', Array, (0, None, (12,), Uint), (False, None), None),
-		('names', ZStringBuffer, (None, None), (False, None), None),
-		('names_pad', Array, (0, None, (None,), Ubyte), (False, None), True),
-		('mimes', Array, (0, None, (None,), MimeEntry), (False, None), None),
-		('triplets_ref', Empty, (0, None), (False, None), None),
-		('triplets', Array, (0, None, (None,), Triplet), (False, None), True),
-		('triplets_pad', PadAlign, (4, None), (False, None), True),
-		('files', Array, (0, None, (None,), FileEntry), (False, None), None),
-		('archive_names', ZStringBuffer, (None, None), (False, None), None),
-		('archives', Array, (0, None, (None,), ArchiveEntry), (False, None), None),
-		('included_ovls', Array, (0, None, (None,), IncludedOvl), (False, None), None),
-		('dependencies', Array, (0, None, (None,), DependencyEntry), (False, None), True),
-		('aux_entries', Array, (0, None, (None,), AuxEntry), (False, None), None),
-		('dependencies', Array, (0, None, (None,), DependencyEntry), (False, None), True),
-		('stream_files', Array, (0, None, (None,), StreamEntry), (False, None), None),
-		('archives_meta', Array, (0, None, (None,), ArchiveMeta), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('lod_depth', Uint, (0, None), (False, None), None)
+		yield ('len_names', Uint, (0, None), (False, None), None)
+		yield ('zero_2', Uint, (0, None), (False, None), None)
+		yield ('num_aux_entries', Uint, (0, None), (False, None), None)
+		yield ('num_included_ovls', Ushort, (0, None), (False, None), None)
+		yield ('num_mimes', Ushort, (0, None), (False, None), None)
+		yield ('num_files', Uint, (0, None), (False, None), None)
+		yield ('num_files_2', Uint, (0, None), (False, None), None)
+		yield ('num_dependencies', Uint, (0, None), (False, None), None)
+		yield ('num_archives', Uint, (0, None), (False, None), None)
+		yield ('num_pool_groups', Uint, (0, None), (False, None), None)
+		yield ('num_pools', Uint, (0, None), (False, None), None)
+		yield ('num_datas', Uint, (0, None), (False, None), None)
+		yield ('num_buffers', Uint, (0, None), (False, None), None)
+		yield ('num_stream_files', Uint, (0, None), (False, None), None)
+		yield ('ztuac_unk_0', Uint, (0, None), (False, None), None)
+		yield ('ztuac_unk_1', Uint, (0, None), (False, None), None)
+		yield ('ztuac_unk_2', Uint, (0, None), (False, None), None)
+		yield ('len_archive_names', Uint, (0, None), (False, None), None)
+		yield ('num_files_3', Uint, (0, None), (False, None), None)
+		yield ('len_type_names', Uint, (0, None), (False, None), None)
+		yield ('num_triplets', Uint, (0, None), (False, None), None)
+		yield ('reserved', Array, (0, None, (12,), Uint), (False, None), None)
+		yield ('names', ZStringBuffer, (None, None), (False, None), None)
+		yield ('names_pad', Array, (0, None, (None,), Ubyte), (False, None), True)
+		yield ('mimes', Array, (0, None, (None,), MimeEntry), (False, None), None)
+		yield ('triplets_ref', Empty, (0, None), (False, None), None)
+		yield ('triplets', Array, (0, None, (None,), Triplet), (False, None), True)
+		yield ('triplets_pad', PadAlign, (4, None), (False, None), True)
+		yield ('files', Array, (0, None, (None,), FileEntry), (False, None), None)
+		yield ('archive_names', ZStringBuffer, (None, None), (False, None), None)
+		yield ('archives', Array, (0, None, (None,), ArchiveEntry), (False, None), None)
+		yield ('included_ovls', Array, (0, None, (None,), IncludedOvl), (False, None), None)
+		yield ('dependencies', Array, (0, None, (None,), DependencyEntry), (False, None), True)
+		yield ('aux_entries', Array, (0, None, (None,), AuxEntry), (False, None), None)
+		yield ('dependencies', Array, (0, None, (None,), DependencyEntry), (False, None), True)
+		yield ('stream_files', Array, (0, None, (None,), StreamEntry), (False, None), None)
+		yield ('archives_meta', Array, (0, None, (None,), ArchiveMeta), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -205,3 +206,6 @@ class Header(GenericHeader):
 			yield 'dependencies', Array, (0, None, (instance.num_dependencies,), DependencyEntry), (False, None)
 		yield 'stream_files', Array, (0, None, (instance.num_stream_files,), StreamEntry), (False, None)
 		yield 'archives_meta', Array, (0, None, (instance.num_archives,), ArchiveMeta), (False, None)
+
+
+Header.init_attributes()

--- a/generated/formats/ovl/compounds/HeaderPointer.py
+++ b/generated/formats/ovl/compounds/HeaderPointer.py
@@ -25,13 +25,17 @@ class HeaderPointer(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('pool_index', Int, (0, None), (False, -1), None),
-		('data_offset', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('pool_index', Int, (0, None), (False, -1), None)
+		yield ('data_offset', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'pool_index', Int, (0, None), (False, -1)
 		yield 'data_offset', Uint, (0, None), (False, None)
+
+
+HeaderPointer.init_attributes()

--- a/generated/formats/ovl/compounds/IncludedOvl.py
+++ b/generated/formats/ovl/compounds/IncludedOvl.py
@@ -21,11 +21,15 @@ class IncludedOvl(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('basename', OffsetString, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('basename', OffsetString, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'basename', OffsetString, (instance.context.names, None), (False, None)
+
+
+IncludedOvl.init_attributes()

--- a/generated/formats/ovl/compounds/MemPool.py
+++ b/generated/formats/ovl/compounds/MemPool.py
@@ -46,17 +46,18 @@ class MemPool(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('zero_1', Uint64, (0, None), (False, None), True),
-		('size', Uint, (0, None), (False, None), None),
-		('offset', Uint, (0, None), (False, None), None),
-		('zero_2', Uint64, (0, None), (False, None), True),
-		('file_hash', Uint, (0, None), (False, None), None),
-		('num_files', Ushort, (0, None), (False, None), True),
-		('num_datas', Ushort, (0, None), (False, None), True),
-		('ext_hash', Uint, (0, None), (False, None), True),
-		('zero_3', Uint, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('zero_1', Uint64, (0, None), (False, None), True)
+		yield ('size', Uint, (0, None), (False, None), None)
+		yield ('offset', Uint, (0, None), (False, None), None)
+		yield ('zero_2', Uint64, (0, None), (False, None), True)
+		yield ('file_hash', Uint, (0, None), (False, None), None)
+		yield ('num_files', Ushort, (0, None), (False, None), True)
+		yield ('num_datas', Ushort, (0, None), (False, None), True)
+		yield ('ext_hash', Uint, (0, None), (False, None), True)
+		yield ('zero_3', Uint, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -168,3 +169,6 @@ class MemPool(BaseStruct):
 		# return True
 
 
+
+
+MemPool.init_attributes()

--- a/generated/formats/ovl/compounds/MimeEntry.py
+++ b/generated/formats/ovl/compounds/MimeEntry.py
@@ -44,17 +44,18 @@ class MimeEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('name', OffsetString, (None, None), (False, None), None),
-		('zero_0', Uint, (0, None), (False, 0), None),
-		('mime_hash', Uint, (0, None), (False, None), True),
-		('mime_version', Uint, (0, None), (False, None), None),
-		('file_index_offset', Uint, (0, None), (False, None), None),
-		('file_count', Uint, (0, None), (False, None), None),
-		('zero_1', Uint, (0, None), (False, None), True),
-		('triplet_count', Uint, (0, None), (False, None), True),
-		('triplet_offset', Uint, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('name', OffsetString, (None, None), (False, None), None)
+		yield ('zero_0', Uint, (0, None), (False, 0), None)
+		yield ('mime_hash', Uint, (0, None), (False, None), True)
+		yield ('mime_version', Uint, (0, None), (False, None), None)
+		yield ('file_index_offset', Uint, (0, None), (False, None), None)
+		yield ('file_count', Uint, (0, None), (False, None), None)
+		yield ('zero_1', Uint, (0, None), (False, None), True)
+		yield ('triplet_count', Uint, (0, None), (False, None), True)
+		yield ('triplet_offset', Uint, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -85,3 +86,6 @@ class MimeEntry(BaseStruct):
 			trip.a, trip.b, trip.c = triplet
 			ovl.triplets.append(trip)
 
+
+
+MimeEntry.init_attributes()

--- a/generated/formats/ovl/compounds/NamedEntry.py
+++ b/generated/formats/ovl/compounds/NamedEntry.py
@@ -18,8 +18,9 @@ class NamedEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -33,3 +34,6 @@ class NamedEntry(BaseStruct):
 	def name(self, n):
 		self.basename, self.ext = os.path.splitext(n)
 
+
+
+NamedEntry.init_attributes()

--- a/generated/formats/ovl/compounds/OvsHeader.py
+++ b/generated/formats/ovl/compounds/OvsHeader.py
@@ -33,16 +33,17 @@ class OvsHeader(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('pool_groups', Array, (0, None, (None,), PoolGroup), (False, None), None),
-		('pools', Array, (0, None, (None,), MemPool), (False, None), None),
-		('data_entries', Array, (0, None, (None,), DataEntry), (False, None), None),
-		('buffer_entries', Array, (0, None, (None,), BufferEntry), (False, None), None),
-		('buffer_groups', Array, (0, None, (None,), BufferGroup), (False, None), None),
-		('root_entries', Array, (0, None, (None,), RootEntry), (False, None), None),
-		('fragments', Array, (0, None, (None,), Fragment), (False, None), None),
-		('set_header', SetHeader, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('pool_groups', Array, (0, None, (None,), PoolGroup), (False, None), None)
+		yield ('pools', Array, (0, None, (None,), MemPool), (False, None), None)
+		yield ('data_entries', Array, (0, None, (None,), DataEntry), (False, None), None)
+		yield ('buffer_entries', Array, (0, None, (None,), BufferEntry), (False, None), None)
+		yield ('buffer_groups', Array, (0, None, (None,), BufferGroup), (False, None), None)
+		yield ('root_entries', Array, (0, None, (None,), RootEntry), (False, None), None)
+		yield ('fragments', Array, (0, None, (None,), Fragment), (False, None), None)
+		yield ('set_header', SetHeader, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -55,3 +56,6 @@ class OvsHeader(BaseStruct):
 		yield 'root_entries', Array, (0, None, (instance.arg.num_root_entries,), RootEntry), (False, None)
 		yield 'fragments', Array, (0, None, (instance.arg.num_fragments,), Fragment), (False, None)
 		yield 'set_header', SetHeader, (0, None), (False, None)
+
+
+OvsHeader.init_attributes()

--- a/generated/formats/ovl/compounds/PoolGroup.py
+++ b/generated/formats/ovl/compounds/PoolGroup.py
@@ -23,13 +23,17 @@ class PoolGroup(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('type', Ushort, (0, None), (False, None), None),
-		('num_pools', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('type', Ushort, (0, None), (False, None), None)
+		yield ('num_pools', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'type', Ushort, (0, None), (False, None)
 		yield 'num_pools', Ushort, (0, None), (False, None)
+
+
+PoolGroup.init_attributes()

--- a/generated/formats/ovl/compounds/RootEntry.py
+++ b/generated/formats/ovl/compounds/RootEntry.py
@@ -28,11 +28,12 @@ class RootEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('file_hash', Uint, (0, None), (False, None), None),
-		('ext_hash', Uint, (0, None), (False, None), True),
-		('struct_ptr', HeaderPointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('file_hash', Uint, (0, None), (False, None), None)
+		yield ('ext_hash', Uint, (0, None), (False, None), True)
+		yield ('struct_ptr', HeaderPointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class RootEntry(BaseStruct):
 		if instance.context.version >= 19:
 			yield 'ext_hash', Uint, (0, None), (False, None)
 		yield 'struct_ptr', HeaderPointer, (0, None), (False, None)
+
+
+RootEntry.init_attributes()

--- a/generated/formats/ovl/compounds/SetEntry.py
+++ b/generated/formats/ovl/compounds/SetEntry.py
@@ -23,11 +23,12 @@ class SetEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('file_hash', Uint, (0, None), (False, None), None),
-		('ext_hash', Uint, (0, None), (False, None), True),
-		('start', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('file_hash', Uint, (0, None), (False, None), None)
+		yield ('ext_hash', Uint, (0, None), (False, None), True)
+		yield ('start', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class SetEntry(BaseStruct):
 		if instance.context.version >= 19:
 			yield 'ext_hash', Uint, (0, None), (False, None)
 		yield 'start', Uint, (0, None), (False, None)
+
+
+SetEntry.init_attributes()

--- a/generated/formats/ovl/compounds/SetHeader.py
+++ b/generated/formats/ovl/compounds/SetHeader.py
@@ -30,14 +30,15 @@ class SetHeader(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('set_count', Uint, (0, None), (False, None), None),
-		('asset_count', Uint, (0, None), (False, None), None),
-		('sig_a', Uint, (0, None), (False, 1065336831), None),
-		('sig_b', Uint, (0, None), (False, 16909320), None),
-		('sets', Array, (0, None, (None,), SetEntry), (False, None), None),
-		('assets', Array, (0, None, (None,), AssetEntry), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('set_count', Uint, (0, None), (False, None), None)
+		yield ('asset_count', Uint, (0, None), (False, None), None)
+		yield ('sig_a', Uint, (0, None), (False, 1065336831), None)
+		yield ('sig_b', Uint, (0, None), (False, 16909320), None)
+		yield ('sets', Array, (0, None, (None,), SetEntry), (False, None), None)
+		yield ('assets', Array, (0, None, (None,), AssetEntry), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -48,3 +49,6 @@ class SetHeader(BaseStruct):
 		yield 'sig_b', Uint, (0, None), (False, 16909320)
 		yield 'sets', Array, (0, None, (instance.set_count,), SetEntry), (False, None)
 		yield 'assets', Array, (0, None, (instance.asset_count,), AssetEntry), (False, None)
+
+
+SetHeader.init_attributes()

--- a/generated/formats/ovl/compounds/StreamEntry.py
+++ b/generated/formats/ovl/compounds/StreamEntry.py
@@ -29,11 +29,12 @@ class StreamEntry(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('stream_offset', Uint, (0, None), (False, None), None),
-		('file_offset', Uint, (0, None), (False, None), None),
-		('zero', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('stream_offset', Uint, (0, None), (False, None), None)
+		yield ('file_offset', Uint, (0, None), (False, None), None)
+		yield ('zero', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class StreamEntry(BaseStruct):
 		yield 'stream_offset', Uint, (0, None), (False, None)
 		yield 'file_offset', Uint, (0, None), (False, None)
 		yield 'zero', Uint, (0, None), (False, None)
+
+
+StreamEntry.init_attributes()

--- a/generated/formats/ovl/compounds/Triplet.py
+++ b/generated/formats/ovl/compounds/Triplet.py
@@ -27,11 +27,12 @@ class Triplet(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('a', Ubyte, (0, None), (False, None), None),
-		('b', Ubyte, (0, None), (False, None), None),
-		('c', Ubyte, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('a', Ubyte, (0, None), (False, None), None)
+		yield ('b', Ubyte, (0, None), (False, None), None)
+		yield ('c', Ubyte, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -44,3 +45,6 @@ class Triplet(BaseStruct):
 		if isinstance(other, Triplet):
 			return self.a == other.a and self.b == other.b and self.c == other.c
 
+
+
+Triplet.init_attributes()

--- a/generated/formats/ovl_base/compounds/ArrayPointer.py
+++ b/generated/formats/ovl_base/compounds/ArrayPointer.py
@@ -18,8 +18,9 @@ class ArrayPointer(Pointer):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = Pointer._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -54,3 +55,6 @@ class ArrayPointer(Pointer):
 		instance.data = Array._from_xml(arr, elem)
 		return instance
 
+
+
+ArrayPointer.init_attributes()

--- a/generated/formats/ovl_base/compounds/Empty.py
+++ b/generated/formats/ovl_base/compounds/Empty.py
@@ -16,9 +16,13 @@ class Empty(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
+
+
+Empty.init_attributes()

--- a/generated/formats/ovl_base/compounds/ForEachPointer.py
+++ b/generated/formats/ovl_base/compounds/ForEachPointer.py
@@ -24,8 +24,9 @@ class ForEachPointer(Pointer):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = Pointer._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -86,3 +87,6 @@ class ForEachPointer(Pointer):
 		return instance
 
 
+
+
+ForEachPointer.init_attributes()

--- a/generated/formats/ovl_base/compounds/GenericHeader.py
+++ b/generated/formats/ovl_base/compounds/GenericHeader.py
@@ -37,14 +37,15 @@ class GenericHeader(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('magic', FixedString, (4, None), (False, None), None),
-		('version_flag', Byte, (0, None), (False, None), None),
-		('version', Byte, (0, None), (False, None), None),
-		('bitswap', Byte, (0, None), (False, None), None),
-		('seventh_byte', Byte, (0, None), (False, 1), None),
-		('user_version', VersionInfo, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('magic', FixedString, (4, None), (False, None), None)
+		yield ('version_flag', Byte, (0, None), (False, None), None)
+		yield ('version', Byte, (0, None), (False, None), None)
+		yield ('bitswap', Byte, (0, None), (False, None), None)
+		yield ('seventh_byte', Byte, (0, None), (False, 1), None)
+		yield ('user_version', VersionInfo, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -55,3 +56,6 @@ class GenericHeader(BaseStruct):
 		yield 'bitswap', Byte, (0, None), (False, None)
 		yield 'seventh_byte', Byte, (0, None), (False, 1)
 		yield 'user_version', VersionInfo, (0, None), (False, None)
+
+
+GenericHeader.init_attributes()

--- a/generated/formats/ovl_base/compounds/MemStruct.py
+++ b/generated/formats/ovl_base/compounds/MemStruct.py
@@ -26,8 +26,9 @@ class MemStruct(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -116,3 +117,6 @@ class MemStruct(BaseStruct):
 		return None
 
 
+
+
+MemStruct.init_attributes()

--- a/generated/formats/ovl_base/compounds/Pointer.py
+++ b/generated/formats/ovl_base/compounds/Pointer.py
@@ -32,10 +32,11 @@ class Pointer(BaseStruct):
 
 	_import_key = 'ovl_base.compounds.Pointer'
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('pool_index', Int, (0, None), (False, -1), None),
-		('data_offset', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('pool_index', Int, (0, None), (False, -1), None)
+		yield ('data_offset', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -213,3 +214,6 @@ class Pointer(BaseStruct):
 			logging.exception(f"Error on ptr {elem} {elem.attrib}")
 			# raise
 
+
+
+Pointer.init_attributes()

--- a/generated/formats/ovl_base/compounds/SmartPadding.py
+++ b/generated/formats/ovl_base/compounds/SmartPadding.py
@@ -16,8 +16,9 @@ class SmartPadding(BaseStruct):
 
 	_import_key = 'ovl_base.compounds.SmartPadding'
 
-	_attribute_list = BaseStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -59,3 +60,6 @@ class SmartPadding(BaseStruct):
 		stream.write(instance.data)
 
 
+
+
+SmartPadding.init_attributes()

--- a/generated/formats/particleatlas/compounds/ParticleAtlasRoot.py
+++ b/generated/formats/particleatlas/compounds/ParticleAtlasRoot.py
@@ -24,13 +24,14 @@ class ParticleAtlasRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('tex_name', Pointer, (0, ZString), (False, None), None),
-		('gfr_name', Pointer, (0, ZString), (False, None), None),
-		('id', Uint, (0, None), (False, None), None),
-		('zero', Uint, (0, None), (False, None), None),
-		('dependency_name', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('tex_name', Pointer, (0, ZString), (False, None), None)
+		yield ('gfr_name', Pointer, (0, ZString), (False, None), None)
+		yield ('id', Uint, (0, None), (False, None), None)
+		yield ('zero', Uint, (0, None), (False, None), None)
+		yield ('dependency_name', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -40,3 +41,6 @@ class ParticleAtlasRoot(MemStruct):
 		yield 'id', Uint, (0, None), (False, None)
 		yield 'zero', Uint, (0, None), (False, None)
 		yield 'dependency_name', Pointer, (0, None), (False, None)
+
+
+ParticleAtlasRoot.init_attributes()

--- a/generated/formats/particleeffect/compounds/LastRow.py
+++ b/generated/formats/particleeffect/compounds/LastRow.py
@@ -25,20 +25,21 @@ class LastRow(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk_01', Ushort, (0, None), (False, None), None),
-		('unk_02', Ushort, (0, None), (False, None), None),
-		('unk_03', Ushort, (0, None), (False, None), None),
-		('unk_04', Ushort, (0, None), (False, None), None),
-		('unk_05', Ushort, (0, None), (False, None), None),
-		('unk_06', Ushort, (0, None), (False, None), None),
-		('unk_07', Ushort, (0, None), (False, None), None),
-		('unk_08', Ushort, (0, None), (False, None), None),
-		('unk_09', Ushort, (0, None), (False, None), None),
-		('unk_10', Ushort, (0, None), (False, None), None),
-		('unk_11', Ushort, (0, None), (False, None), None),
-		('unk_12', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_01', Ushort, (0, None), (False, None), None)
+		yield ('unk_02', Ushort, (0, None), (False, None), None)
+		yield ('unk_03', Ushort, (0, None), (False, None), None)
+		yield ('unk_04', Ushort, (0, None), (False, None), None)
+		yield ('unk_05', Ushort, (0, None), (False, None), None)
+		yield ('unk_06', Ushort, (0, None), (False, None), None)
+		yield ('unk_07', Ushort, (0, None), (False, None), None)
+		yield ('unk_08', Ushort, (0, None), (False, None), None)
+		yield ('unk_09', Ushort, (0, None), (False, None), None)
+		yield ('unk_10', Ushort, (0, None), (False, None), None)
+		yield ('unk_11', Ushort, (0, None), (False, None), None)
+		yield ('unk_12', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -55,3 +56,6 @@ class LastRow(MemStruct):
 		yield 'unk_10', Ushort, (0, None), (False, None)
 		yield 'unk_11', Ushort, (0, None), (False, None)
 		yield 'unk_12', Ushort, (0, None), (False, None)
+
+
+LastRow.init_attributes()

--- a/generated/formats/particleeffect/compounds/NextRow1.py
+++ b/generated/formats/particleeffect/compounds/NextRow1.py
@@ -19,12 +19,13 @@ class NextRow1(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk', Uint64, (0, None), (False, None), None),
-		('garbage', Uint, (0, None), (False, None), None),
-		('value_1', Ushort, (0, None), (False, None), None),
-		('value_2', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk', Uint64, (0, None), (False, None), None)
+		yield ('garbage', Uint, (0, None), (False, None), None)
+		yield ('value_1', Ushort, (0, None), (False, None), None)
+		yield ('value_2', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -33,3 +34,6 @@ class NextRow1(MemStruct):
 		yield 'garbage', Uint, (0, None), (False, None)
 		yield 'value_1', Ushort, (0, None), (False, None)
 		yield 'value_2', Ushort, (0, None), (False, None)
+
+
+NextRow1.init_attributes()

--- a/generated/formats/particleeffect/compounds/NextRow2.py
+++ b/generated/formats/particleeffect/compounds/NextRow2.py
@@ -29,24 +29,25 @@ class NextRow2(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk_01', Ushort, (0, None), (False, None), None),
-		('unk_02', Ushort, (0, None), (False, None), None),
-		('unk_03', Ushort, (0, None), (False, None), None),
-		('unk_04', Ushort, (0, None), (False, None), None),
-		('unk_05', Ushort, (0, None), (False, None), None),
-		('unk_06', Ushort, (0, None), (False, None), None),
-		('unk_07', Ushort, (0, None), (False, None), None),
-		('unk_08', Ushort, (0, None), (False, None), None),
-		('unk_09', Ushort, (0, None), (False, None), None),
-		('unk_10', Ushort, (0, None), (False, None), None),
-		('unk_11', Ushort, (0, None), (False, None), None),
-		('unk_12', Ushort, (0, None), (False, None), None),
-		('unk_13', Ushort, (0, None), (False, None), None),
-		('unk_14', Ushort, (0, None), (False, None), None),
-		('unk_15', Ushort, (0, None), (False, None), None),
-		('unk_16', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_01', Ushort, (0, None), (False, None), None)
+		yield ('unk_02', Ushort, (0, None), (False, None), None)
+		yield ('unk_03', Ushort, (0, None), (False, None), None)
+		yield ('unk_04', Ushort, (0, None), (False, None), None)
+		yield ('unk_05', Ushort, (0, None), (False, None), None)
+		yield ('unk_06', Ushort, (0, None), (False, None), None)
+		yield ('unk_07', Ushort, (0, None), (False, None), None)
+		yield ('unk_08', Ushort, (0, None), (False, None), None)
+		yield ('unk_09', Ushort, (0, None), (False, None), None)
+		yield ('unk_10', Ushort, (0, None), (False, None), None)
+		yield ('unk_11', Ushort, (0, None), (False, None), None)
+		yield ('unk_12', Ushort, (0, None), (False, None), None)
+		yield ('unk_13', Ushort, (0, None), (False, None), None)
+		yield ('unk_14', Ushort, (0, None), (False, None), None)
+		yield ('unk_15', Ushort, (0, None), (False, None), None)
+		yield ('unk_16', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -67,3 +68,6 @@ class NextRow2(MemStruct):
 		yield 'unk_14', Ushort, (0, None), (False, None)
 		yield 'unk_15', Ushort, (0, None), (False, None)
 		yield 'unk_16', Ushort, (0, None), (False, None)
+
+
+NextRow2.init_attributes()

--- a/generated/formats/particleeffect/compounds/ParticleEffectRoot.py
+++ b/generated/formats/particleeffect/compounds/ParticleEffectRoot.py
@@ -40,29 +40,30 @@ class ParticleEffectRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk_64_1', Uint64, (0, None), (False, None), None),
-		('unk_64_2', Uint64, (0, None), (False, None), None),
-		('unk_64_3', Uint64, (0, None), (False, None), None),
-		('unk_64_4', Uint64, (0, None), (False, None), None),
-		('unk_64_5', Uint64, (0, None), (False, None), None),
-		('unk_64_6', Uint64, (0, None), (False, None), None),
-		('unk_32_1', Uint, (0, None), (False, None), None),
-		('unk_32_2_neg', Int, (0, None), (False, None), None),
-		('unk_32_3', Uint, (0, None), (False, None), None),
-		('unk_32_4', Uint, (0, None), (False, None), None),
-		('a_unk_32_1', Uint, (0, None), (False, None), None),
-		('a_unk_32_2', Uint, (0, None), (False, None), None),
-		('a_unk_32_3_1', Uint, (0, None), (False, None), None),
-		('a_unk_32_4', Uint, (0, None), (False, None), None),
-		('atlasinfo_count', Uint64, (0, None), (False, None), None),
-		('name_foreach_textures', ArrayPointer, (None, None), (False, None), None),
-		('next_row_1', NextRow1, (0, None), (False, None), None),
-		('next_row_2', NextRow2, (0, None), (False, None), None),
-		('next_row_3', NextRow2, (0, None), (False, None), None),
-		('next_row_4', NextRow2, (0, None), (False, None), None),
-		('next_row_5', LastRow, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_64_1', Uint64, (0, None), (False, None), None)
+		yield ('unk_64_2', Uint64, (0, None), (False, None), None)
+		yield ('unk_64_3', Uint64, (0, None), (False, None), None)
+		yield ('unk_64_4', Uint64, (0, None), (False, None), None)
+		yield ('unk_64_5', Uint64, (0, None), (False, None), None)
+		yield ('unk_64_6', Uint64, (0, None), (False, None), None)
+		yield ('unk_32_1', Uint, (0, None), (False, None), None)
+		yield ('unk_32_2_neg', Int, (0, None), (False, None), None)
+		yield ('unk_32_3', Uint, (0, None), (False, None), None)
+		yield ('unk_32_4', Uint, (0, None), (False, None), None)
+		yield ('a_unk_32_1', Uint, (0, None), (False, None), None)
+		yield ('a_unk_32_2', Uint, (0, None), (False, None), None)
+		yield ('a_unk_32_3_1', Uint, (0, None), (False, None), None)
+		yield ('a_unk_32_4', Uint, (0, None), (False, None), None)
+		yield ('atlasinfo_count', Uint64, (0, None), (False, None), None)
+		yield ('name_foreach_textures', ArrayPointer, (None, None), (False, None), None)
+		yield ('next_row_1', NextRow1, (0, None), (False, None), None)
+		yield ('next_row_2', NextRow2, (0, None), (False, None), None)
+		yield ('next_row_3', NextRow2, (0, None), (False, None), None)
+		yield ('next_row_4', NextRow2, (0, None), (False, None), None)
+		yield ('next_row_5', LastRow, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -88,3 +89,6 @@ class ParticleEffectRoot(MemStruct):
 		yield 'next_row_3', NextRow2, (0, None), (False, None)
 		yield 'next_row_4', NextRow2, (0, None), (False, None)
 		yield 'next_row_5', LastRow, (0, None), (False, None)
+
+
+ParticleEffectRoot.init_attributes()

--- a/generated/formats/particleeffect/compounds/TextureData.py
+++ b/generated/formats/particleeffect/compounds/TextureData.py
@@ -16,11 +16,15 @@ class TextureData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('dependency_name', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('dependency_name', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'dependency_name', Pointer, (0, None), (False, None)
+
+
+TextureData.init_attributes()

--- a/generated/formats/particleeffect/compounds/TextureInfo.py
+++ b/generated/formats/particleeffect/compounds/TextureInfo.py
@@ -12,9 +12,13 @@ class TextureInfo(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
+
+
+TextureInfo.init_attributes()

--- a/generated/formats/path/compounds/BrokeStruct.py
+++ b/generated/formats/path/compounds/BrokeStruct.py
@@ -20,13 +20,14 @@ class BrokeStruct(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('support', Pointer, (0, ZString), (False, None), None),
-		('fallen_support', Pointer, (0, ZString), (False, None), None),
-		('head', Pointer, (0, ZString), (False, None), None),
-		('unk_vector_1', Vector3, (0, None), (False, None), None),
-		('unk_vector_2', Vector3, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('support', Pointer, (0, ZString), (False, None), None)
+		yield ('fallen_support', Pointer, (0, ZString), (False, None), None)
+		yield ('head', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_vector_1', Vector3, (0, None), (False, None), None)
+		yield ('unk_vector_2', Vector3, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class BrokeStruct(MemStruct):
 		yield 'head', Pointer, (0, ZString), (False, None)
 		yield 'unk_vector_1', Vector3, (0, None), (False, None)
 		yield 'unk_vector_2', Vector3, (0, None), (False, None)
+
+
+BrokeStruct.init_attributes()

--- a/generated/formats/path/compounds/Connector.py
+++ b/generated/formats/path/compounds/Connector.py
@@ -18,11 +18,12 @@ class Connector(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('model_name', Pointer, (0, ZString), (False, None), None),
-		('joint_name', Pointer, (0, ZString), (False, None), None),
-		('unk_vector', Vector2, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('model_name', Pointer, (0, ZString), (False, None), None)
+		yield ('joint_name', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_vector', Vector2, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -30,3 +31,6 @@ class Connector(MemStruct):
 		yield 'model_name', Pointer, (0, ZString), (False, None)
 		yield 'joint_name', Pointer, (0, ZString), (False, None)
 		yield 'unk_vector', Vector2, (0, None), (False, None)
+
+
+Connector.init_attributes()

--- a/generated/formats/path/compounds/ConnectorMultiJoint.py
+++ b/generated/formats/path/compounds/ConnectorMultiJoint.py
@@ -25,15 +25,16 @@ class ConnectorMultiJoint(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('model_name', Pointer, (0, ZString), (False, None), None),
-		('padding', Uint64, (0, None), (False, 0), None),
-		('joints', ArrayPointer, (None, None), (False, None), None),
-		('num_joints', Uint, (0, None), (False, None), None),
-		('unk_float_1', Float, (0, None), (False, None), None),
-		('unk_float_2', Float, (0, None), (False, None), None),
-		('unk_int_1', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('model_name', Pointer, (0, ZString), (False, None), None)
+		yield ('padding', Uint64, (0, None), (False, 0), None)
+		yield ('joints', ArrayPointer, (None, None), (False, None), None)
+		yield ('num_joints', Uint, (0, None), (False, None), None)
+		yield ('unk_float_1', Float, (0, None), (False, None), None)
+		yield ('unk_float_2', Float, (0, None), (False, None), None)
+		yield ('unk_int_1', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -45,3 +46,6 @@ class ConnectorMultiJoint(MemStruct):
 		yield 'unk_float_1', Float, (0, None), (False, None)
 		yield 'unk_float_2', Float, (0, None), (False, None)
 		yield 'unk_int_1', Uint, (0, None), (False, None)
+
+
+ConnectorMultiJoint.init_attributes()

--- a/generated/formats/path/compounds/Footer.py
+++ b/generated/formats/path/compounds/Footer.py
@@ -22,12 +22,13 @@ class Footer(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('footer_piece', Pointer, (0, ZString), (False, None), None),
-		('unk_int', Uint64, (0, None), (False, None), None),
-		('joint', Pointer, (0, ZString), (False, None), None),
-		('unk_floats', Array, (0, None, (2,), Float), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('footer_piece', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_int', Uint64, (0, None), (False, None), None)
+		yield ('joint', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_floats', Array, (0, None, (2,), Float), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class Footer(MemStruct):
 		yield 'unk_int', Uint64, (0, None), (False, None)
 		yield 'joint', Pointer, (0, ZString), (False, None)
 		yield 'unk_floats', Array, (0, None, (2,), Float), (False, None)
+
+
+Footer.init_attributes()

--- a/generated/formats/path/compounds/Joint.py
+++ b/generated/formats/path/compounds/Joint.py
@@ -24,15 +24,16 @@ class Joint(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('joint_1', Pointer, (0, ZString), (False, None), None),
-		('joint_2', Pointer, (0, ZString), (False, None), None),
-		('joint_3', Pointer, (0, ZString), (False, None), None),
-		('joint_4', Pointer, (0, ZString), (False, None), None),
-		('unk_float', Float, (0, None), (False, None), None),
-		('unk_int', Uint, (0, None), (False, None), None),
-		('unk_int_2', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('joint_1', Pointer, (0, ZString), (False, None), None)
+		yield ('joint_2', Pointer, (0, ZString), (False, None), None)
+		yield ('joint_3', Pointer, (0, ZString), (False, None), None)
+		yield ('joint_4', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_float', Float, (0, None), (False, None), None)
+		yield ('unk_int', Uint, (0, None), (False, None), None)
+		yield ('unk_int_2', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -44,3 +45,6 @@ class Joint(MemStruct):
 		yield 'unk_float', Float, (0, None), (False, None)
 		yield 'unk_int', Uint, (0, None), (False, None)
 		yield 'unk_int_2', Uint64, (0, None), (False, None)
+
+
+Joint.init_attributes()

--- a/generated/formats/path/compounds/PathExtrusion.py
+++ b/generated/formats/path/compounds/PathExtrusion.py
@@ -23,15 +23,16 @@ class PathExtrusion(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('model', Pointer, (0, ZString), (False, None), None),
-		('post_model', Pointer, (0, ZString), (False, None), None),
-		('endcap_model', Pointer, (0, ZString), (False, None), None),
-		('unk_float_1', Float, (0, None), (False, None), None),
-		('unk_float_2', Float, (0, None), (False, None), None),
-		('is_kerb', Bool, (0, None), (False, None), None),
-		('is_not_ground', Bool, (0, None), (False, True), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('model', Pointer, (0, ZString), (False, None), None)
+		yield ('post_model', Pointer, (0, ZString), (False, None), None)
+		yield ('endcap_model', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_float_1', Float, (0, None), (False, None), None)
+		yield ('unk_float_2', Float, (0, None), (False, None), None)
+		yield ('is_kerb', Bool, (0, None), (False, None), None)
+		yield ('is_not_ground', Bool, (0, None), (False, True), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -43,3 +44,6 @@ class PathExtrusion(MemStruct):
 		yield 'unk_float_2', Float, (0, None), (False, None)
 		yield 'is_kerb', Bool, (0, None), (False, None)
 		yield 'is_not_ground', Bool, (0, None), (False, True)
+
+
+PathExtrusion.init_attributes()

--- a/generated/formats/path/compounds/PathJoinPartResource.py
+++ b/generated/formats/path/compounds/PathJoinPartResource.py
@@ -34,24 +34,25 @@ class PathJoinPartResource(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk_points_1', Pointer, (None, None), (False, None), None),
-		('unk_points_2', Pointer, (None, None), (False, None), None),
-		('unk_vector', ArrayPointer, (1, None), (False, None), None),
-		('unk_shorts', ArrayPointer, (8, Ushort), (False, None), None),
-		('unk_points_3', Pointer, (None, None), (False, None), None),
-		('padding_1', Uint64, (0, None), (True, 0), None),
-		('pathresource', Pointer, (0, ZString), (False, None), None),
-		('unk_byte_1', Byte, (0, None), (False, None), None),
-		('unk_byte_2', Byte, (0, None), (False, None), None),
-		('unk_byte_3', Byte, (0, None), (False, None), None),
-		('num_points_1', Byte, (0, None), (False, None), None),
-		('num_points_1_copy', Byte, (0, None), (False, None), None),
-		('num_points_2', Byte, (0, None), (False, None), None),
-		('num_points_2_copy', Byte, (0, None), (False, None), None),
-		('num_points_3', Byte, (0, None), (False, None), None),
-		('padding_2', Uint64, (0, None), (True, 0), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_points_1', Pointer, (None, None), (False, None), None)
+		yield ('unk_points_2', Pointer, (None, None), (False, None), None)
+		yield ('unk_vector', ArrayPointer, (1, None), (False, None), None)
+		yield ('unk_shorts', ArrayPointer, (8, Ushort), (False, None), None)
+		yield ('unk_points_3', Pointer, (None, None), (False, None), None)
+		yield ('padding_1', Uint64, (0, None), (True, 0), None)
+		yield ('pathresource', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_byte_1', Byte, (0, None), (False, None), None)
+		yield ('unk_byte_2', Byte, (0, None), (False, None), None)
+		yield ('unk_byte_3', Byte, (0, None), (False, None), None)
+		yield ('num_points_1', Byte, (0, None), (False, None), None)
+		yield ('num_points_1_copy', Byte, (0, None), (False, None), None)
+		yield ('num_points_2', Byte, (0, None), (False, None), None)
+		yield ('num_points_2_copy', Byte, (0, None), (False, None), None)
+		yield ('num_points_3', Byte, (0, None), (False, None), None)
+		yield ('padding_2', Uint64, (0, None), (True, 0), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -72,3 +73,6 @@ class PathJoinPartResource(MemStruct):
 		yield 'num_points_2_copy', Byte, (0, None), (False, None)
 		yield 'num_points_3', Byte, (0, None), (False, None)
 		yield 'padding_2', Uint64, (0, None), (True, 0)
+
+
+PathJoinPartResource.init_attributes()

--- a/generated/formats/path/compounds/PathJoinPartResourceList.py
+++ b/generated/formats/path/compounds/PathJoinPartResourceList.py
@@ -15,11 +15,15 @@ class PathJoinPartResourceList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('resources', Array, (0, None, (None,), PathJoinPartResource), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('resources', Array, (0, None, (None,), PathJoinPartResource), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'resources', Array, (0, None, (instance.arg,), PathJoinPartResource), (False, None)
+
+
+PathJoinPartResourceList.init_attributes()

--- a/generated/formats/path/compounds/PathJoinPartResourceRoot.py
+++ b/generated/formats/path/compounds/PathJoinPartResourceRoot.py
@@ -16,13 +16,17 @@ class PathJoinPartResourceRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('resources_list', Pointer, (None, None), (False, None), None),
-		('num_res', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('resources_list', Pointer, (None, None), (False, None), None)
+		yield ('num_res', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'resources_list', Pointer, (instance.num_res, PathJoinPartResourceRoot._import_map["path.compounds.PathJoinPartResourceList"]), (False, None)
 		yield 'num_res', Uint64, (0, None), (False, None)
+
+
+PathJoinPartResourceRoot.init_attributes()

--- a/generated/formats/path/compounds/PathMaterial.py
+++ b/generated/formats/path/compounds/PathMaterial.py
@@ -29,21 +29,22 @@ class PathMaterial(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('elevated_mat', Pointer, (0, ZString), (False, None), None),
-		('elevated_mat_valid', Pointer, (0, ZString), (False, None), None),
-		('elevated_mat_invalid', Pointer, (0, ZString), (False, None), None),
-		('terrain_mat', Pointer, (0, ZString), (False, None), None),
-		('terrain_mat_valid', Pointer, (0, ZString), (False, None), None),
-		('terrain_mat_invalid', Pointer, (0, ZString), (False, None), None),
-		('underside_mat_1', Pointer, (0, ZString), (False, None), None),
-		('underside_mat_2', Pointer, (0, ZString), (False, None), None),
-		('stairs_mat_1', Pointer, (0, ZString), (False, None), None),
-		('stairs_mat_2', Pointer, (0, ZString), (False, None), None),
-		('path_sub_type', Uint64, (0, None), (False, None), None),
-		('mat_data', ArrayPointer, (None, None), (False, None), None),
-		('num_data', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('elevated_mat', Pointer, (0, ZString), (False, None), None)
+		yield ('elevated_mat_valid', Pointer, (0, ZString), (False, None), None)
+		yield ('elevated_mat_invalid', Pointer, (0, ZString), (False, None), None)
+		yield ('terrain_mat', Pointer, (0, ZString), (False, None), None)
+		yield ('terrain_mat_valid', Pointer, (0, ZString), (False, None), None)
+		yield ('terrain_mat_invalid', Pointer, (0, ZString), (False, None), None)
+		yield ('underside_mat_1', Pointer, (0, ZString), (False, None), None)
+		yield ('underside_mat_2', Pointer, (0, ZString), (False, None), None)
+		yield ('stairs_mat_1', Pointer, (0, ZString), (False, None), None)
+		yield ('stairs_mat_2', Pointer, (0, ZString), (False, None), None)
+		yield ('path_sub_type', Uint64, (0, None), (False, None), None)
+		yield ('mat_data', ArrayPointer, (None, None), (False, None), None)
+		yield ('num_data', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -61,3 +62,6 @@ class PathMaterial(MemStruct):
 		yield 'path_sub_type', Uint64, (0, None), (False, None)
 		yield 'mat_data', ArrayPointer, (instance.num_data, PathMaterial._import_map["path.compounds.PathMaterialData"]), (False, None)
 		yield 'num_data', Uint64, (0, None), (False, None)
+
+
+PathMaterial.init_attributes()

--- a/generated/formats/path/compounds/PathMaterialData.py
+++ b/generated/formats/path/compounds/PathMaterialData.py
@@ -18,12 +18,13 @@ class PathMaterialData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk_int_1', Uint, (0, None), (False, None), None),
-		('unk_float_1', Float, (0, None), (False, None), None),
-		('unk_int_2', Uint, (0, None), (False, None), None),
-		('unk_int_3', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_int_1', Uint, (0, None), (False, None), None)
+		yield ('unk_float_1', Float, (0, None), (False, None), None)
+		yield ('unk_int_2', Uint, (0, None), (False, None), None)
+		yield ('unk_int_3', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -32,3 +33,6 @@ class PathMaterialData(MemStruct):
 		yield 'unk_float_1', Float, (0, None), (False, None)
 		yield 'unk_int_2', Uint, (0, None), (False, None)
 		yield 'unk_int_3', Uint, (0, None), (False, None)
+
+
+PathMaterialData.init_attributes()

--- a/generated/formats/path/compounds/PathResource.py
+++ b/generated/formats/path/compounds/PathResource.py
@@ -24,17 +24,18 @@ class PathResource(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('pathmaterial', Pointer, (0, ZString), (False, None), None),
-		('pathextrusion_kerb', Pointer, (0, ZString), (False, None), None),
-		('pathextrusion_railing', Pointer, (0, ZString), (False, None), None),
-		('pathextrusion_ground', Pointer, (0, ZString), (False, None), None),
-		('pathsupport', Pointer, (0, ZString), (False, None), None),
-		('path_type', Byte, (0, None), (False, None), None),
-		('path_sub_type', Byte, (0, None), (False, None), None),
-		('unk_byte_1', Byte, (0, None), (False, 1), None),
-		('unk_byte_2', Byte, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('pathmaterial', Pointer, (0, ZString), (False, None), None)
+		yield ('pathextrusion_kerb', Pointer, (0, ZString), (False, None), None)
+		yield ('pathextrusion_railing', Pointer, (0, ZString), (False, None), None)
+		yield ('pathextrusion_ground', Pointer, (0, ZString), (False, None), None)
+		yield ('pathsupport', Pointer, (0, ZString), (False, None), None)
+		yield ('path_type', Byte, (0, None), (False, None), None)
+		yield ('path_sub_type', Byte, (0, None), (False, None), None)
+		yield ('unk_byte_1', Byte, (0, None), (False, 1), None)
+		yield ('unk_byte_2', Byte, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -48,3 +49,6 @@ class PathResource(MemStruct):
 		yield 'path_sub_type', Byte, (0, None), (False, None)
 		yield 'unk_byte_1', Byte, (0, None), (False, 1)
 		yield 'unk_byte_2', Byte, (0, None), (False, None)
+
+
+PathResource.init_attributes()

--- a/generated/formats/path/compounds/PathSupport.py
+++ b/generated/formats/path/compounds/PathSupport.py
@@ -19,11 +19,12 @@ class PathSupport(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('support', Pointer, (0, ZString), (False, None), None),
-		('distance', Float, (0, None), (False, 10.0), None),
-		('_unk_int_1', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('support', Pointer, (0, ZString), (False, None), None)
+		yield ('distance', Float, (0, None), (False, 10.0), None)
+		yield ('_unk_int_1', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -31,3 +32,6 @@ class PathSupport(MemStruct):
 		yield 'support', Pointer, (0, ZString), (False, None)
 		yield 'distance', Float, (0, None), (False, 10.0)
 		yield '_unk_int_1', Uint, (0, None), (False, None)
+
+
+PathSupport.init_attributes()

--- a/generated/formats/path/compounds/PathType.py
+++ b/generated/formats/path/compounds/PathType.py
@@ -18,12 +18,13 @@ class PathType(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('enum_value', Uint, (0, None), (False, None), None),
-		('min_width', Float, (0, None), (False, 4.0), None),
-		('max_width', Float, (0, None), (False, 10.0), None),
-		('_unk_int_2', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('enum_value', Uint, (0, None), (False, None), None)
+		yield ('min_width', Float, (0, None), (False, 4.0), None)
+		yield ('max_width', Float, (0, None), (False, 10.0), None)
+		yield ('_unk_int_2', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -32,3 +33,6 @@ class PathType(MemStruct):
 		yield 'min_width', Float, (0, None), (False, 4.0)
 		yield 'max_width', Float, (0, None), (False, 10.0)
 		yield '_unk_int_2', Uint, (0, None), (False, None)
+
+
+PathType.init_attributes()

--- a/generated/formats/path/compounds/Pillar.py
+++ b/generated/formats/path/compounds/Pillar.py
@@ -23,13 +23,14 @@ class Pillar(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('support', Pointer, (0, ZString), (False, None), None),
-		('cap', Pointer, (0, ZString), (False, None), None),
-		('unk_int', Uint64, (0, None), (False, None), None),
-		('unk_floats', Array, (0, None, (2,), Float), (False, None), None),
-		('unk_int_2', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('support', Pointer, (0, ZString), (False, None), None)
+		yield ('cap', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_int', Uint64, (0, None), (False, None), None)
+		yield ('unk_floats', Array, (0, None, (2,), Float), (False, None), None)
+		yield ('unk_int_2', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -39,3 +40,6 @@ class Pillar(MemStruct):
 		yield 'unk_int', Uint64, (0, None), (False, None)
 		yield 'unk_floats', Array, (0, None, (2,), Float), (False, None)
 		yield 'unk_int_2', Uint64, (0, None), (False, None)
+
+
+Pillar.init_attributes()

--- a/generated/formats/path/compounds/PointsList.py
+++ b/generated/formats/path/compounds/PointsList.py
@@ -15,11 +15,15 @@ class PointsList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('points', Array, (0, None, (None,), Vector3), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('points', Array, (0, None, (None,), Vector3), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'points', Array, (0, None, (instance.arg,), Vector3), (False, None)
+
+
+PointsList.init_attributes()

--- a/generated/formats/path/compounds/SubBraceStruct.py
+++ b/generated/formats/path/compounds/SubBraceStruct.py
@@ -17,13 +17,17 @@ class SubBraceStruct(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('sub_brace_name', Pointer, (0, ZString), (False, None), None),
-		('padding', Uint64, (0, None), (False, 0), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('sub_brace_name', Pointer, (0, ZString), (False, None), None)
+		yield ('padding', Uint64, (0, None), (False, 0), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'sub_brace_name', Pointer, (0, ZString), (False, None)
 		yield 'padding', Uint64, (0, None), (False, 0)
+
+
+SubBraceStruct.init_attributes()

--- a/generated/formats/path/compounds/SupportSetData.py
+++ b/generated/formats/path/compounds/SupportSetData.py
@@ -18,12 +18,13 @@ class SupportSetData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk_index', Uint, (0, None), (False, None), None),
-		('unk_int_1', Uint, (0, None), (False, None), None),
-		('unk_int_2', Uint, (0, None), (False, None), None),
-		('unk_float_1', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_index', Uint, (0, None), (False, None), None)
+		yield ('unk_int_1', Uint, (0, None), (False, None), None)
+		yield ('unk_int_2', Uint, (0, None), (False, None), None)
+		yield ('unk_float_1', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -32,3 +33,6 @@ class SupportSetData(MemStruct):
 		yield 'unk_int_1', Uint, (0, None), (False, None)
 		yield 'unk_int_2', Uint, (0, None), (False, None)
 		yield 'unk_float_1', Float, (0, None), (False, None)
+
+
+SupportSetData.init_attributes()

--- a/generated/formats/path/compounds/SupportSetRoot.py
+++ b/generated/formats/path/compounds/SupportSetRoot.py
@@ -38,27 +38,28 @@ class SupportSetRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('connector_1', ArrayPointer, (None, None), (False, None), None),
-		('connector_2', ArrayPointer, (None, None), (False, None), None),
-		('pillar', ArrayPointer, (None, None), (False, None), None),
-		('footer', ArrayPointer, (None, None), (False, None), None),
-		('sub_braces', ArrayPointer, (None, None), (False, None), None),
-		('unk_vector_1', Vector3, (0, None), (False, None), None),
-		('unk_vector_2', Vector2, (0, None), (False, None), None),
-		('unk_vector_3', Vector3, (0, None), (False, None), None),
-		('unk_int_1', Uint, (0, None), (False, None), None),
-		('num_connector_1', Uint, (0, None), (False, None), None),
-		('num_connector_2', Uint, (0, None), (False, None), None),
-		('num_pillar', Uint, (0, None), (False, None), None),
-		('num_subbrace', Uint, (0, None), (False, None), None),
-		('num_broken_support', Uint, (0, None), (False, None), None),
-		('unk_floats', Array, (0, None, (4,), Float), (False, None), None),
-		('broken_supports', ArrayPointer, (None, None), (False, None), None),
-		('data', ArrayPointer, (None, None), (False, None), None),
-		('num_data', Uint, (0, None), (False, None), None),
-		('zeros', Array, (0, None, (3,), Uint), (False, 0), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('connector_1', ArrayPointer, (None, None), (False, None), None)
+		yield ('connector_2', ArrayPointer, (None, None), (False, None), None)
+		yield ('pillar', ArrayPointer, (None, None), (False, None), None)
+		yield ('footer', ArrayPointer, (None, None), (False, None), None)
+		yield ('sub_braces', ArrayPointer, (None, None), (False, None), None)
+		yield ('unk_vector_1', Vector3, (0, None), (False, None), None)
+		yield ('unk_vector_2', Vector2, (0, None), (False, None), None)
+		yield ('unk_vector_3', Vector3, (0, None), (False, None), None)
+		yield ('unk_int_1', Uint, (0, None), (False, None), None)
+		yield ('num_connector_1', Uint, (0, None), (False, None), None)
+		yield ('num_connector_2', Uint, (0, None), (False, None), None)
+		yield ('num_pillar', Uint, (0, None), (False, None), None)
+		yield ('num_subbrace', Uint, (0, None), (False, None), None)
+		yield ('num_broken_support', Uint, (0, None), (False, None), None)
+		yield ('unk_floats', Array, (0, None, (4,), Float), (False, None), None)
+		yield ('broken_supports', ArrayPointer, (None, None), (False, None), None)
+		yield ('data', ArrayPointer, (None, None), (False, None), None)
+		yield ('num_data', Uint, (0, None), (False, None), None)
+		yield ('zeros', Array, (0, None, (3,), Uint), (False, 0), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -82,3 +83,6 @@ class SupportSetRoot(MemStruct):
 		yield 'data', ArrayPointer, (instance.num_data, SupportSetRoot._import_map["path.compounds.SupportSetData"]), (False, None)
 		yield 'num_data', Uint, (0, None), (False, None)
 		yield 'zeros', Array, (0, None, (3,), Uint), (False, 0)
+
+
+SupportSetRoot.init_attributes()

--- a/generated/formats/path/compounds/Vector2.py
+++ b/generated/formats/path/compounds/Vector2.py
@@ -23,13 +23,17 @@ class Vector2(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
+
+
+Vector2.init_attributes()

--- a/generated/formats/path/compounds/Vector3.py
+++ b/generated/formats/path/compounds/Vector3.py
@@ -26,11 +26,12 @@ class Vector3(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class Vector3(MemStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+Vector3.init_attributes()

--- a/generated/formats/path/compounds/Vector4.py
+++ b/generated/formats/path/compounds/Vector4.py
@@ -29,12 +29,13 @@ class Vector4(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		('w', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
+		yield ('w', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -43,3 +44,6 @@ class Vector4(MemStruct):
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
 		yield 'w', Float, (0, None), (False, None)
+
+
+Vector4.init_attributes()

--- a/generated/formats/physicssurfacesxmlres/compounds/EmptyStruct.py
+++ b/generated/formats/physicssurfacesxmlres/compounds/EmptyStruct.py
@@ -12,9 +12,13 @@ class EmptyStruct(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
+
+
+EmptyStruct.init_attributes()

--- a/generated/formats/physicssurfacesxmlres/compounds/PhysicsSurfaceXMLResRoot.py
+++ b/generated/formats/physicssurfacesxmlres/compounds/PhysicsSurfaceXMLResRoot.py
@@ -43,28 +43,29 @@ class PhysicsSurfaceXMLResRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('default_surface_name', Pointer, (0, ZString), (False, None), None),
-		('float_1', Float, (0, None), (False, None), None),
-		('float_2', Float, (0, None), (False, None), None),
-		('float_3', Float, (0, None), (False, None), None),
-		('float_4', Float, (0, None), (False, None), None),
-		('unk_64_1', Uint64, (0, None), (False, None), None),
-		('name_1', Pointer, (0, ZString), (False, None), None),
-		('name_2', Pointer, (0, ZString), (False, None), None),
-		('ptr_1', Pointer, (0, None), (False, None), None),
-		('ptr_2', ArrayPointer, (None, None), (False, None), None),
-		('count', Ushort, (0, None), (False, None), None),
-		('short_2', Ushort, (0, None), (False, None), None),
-		('unk_32_1', Uint, (0, None), (False, None), None),
-		('unk_64_4', Uint64, (0, None), (False, None), None),
-		('unk_64_5', Uint64, (0, None), (False, None), None),
-		('unk_64_6', Uint64, (0, None), (False, None), None),
-		('unk_64_7', Uint64, (0, None), (False, None), None),
-		('unk_64_8', Uint64, (0, None), (False, None), None),
-		('unk_64_9', Uint64, (0, None), (False, None), None),
-		('unk_64_10', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('default_surface_name', Pointer, (0, ZString), (False, None), None)
+		yield ('float_1', Float, (0, None), (False, None), None)
+		yield ('float_2', Float, (0, None), (False, None), None)
+		yield ('float_3', Float, (0, None), (False, None), None)
+		yield ('float_4', Float, (0, None), (False, None), None)
+		yield ('unk_64_1', Uint64, (0, None), (False, None), None)
+		yield ('name_1', Pointer, (0, ZString), (False, None), None)
+		yield ('name_2', Pointer, (0, ZString), (False, None), None)
+		yield ('ptr_1', Pointer, (0, None), (False, None), None)
+		yield ('ptr_2', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Ushort, (0, None), (False, None), None)
+		yield ('short_2', Ushort, (0, None), (False, None), None)
+		yield ('unk_32_1', Uint, (0, None), (False, None), None)
+		yield ('unk_64_4', Uint64, (0, None), (False, None), None)
+		yield ('unk_64_5', Uint64, (0, None), (False, None), None)
+		yield ('unk_64_6', Uint64, (0, None), (False, None), None)
+		yield ('unk_64_7', Uint64, (0, None), (False, None), None)
+		yield ('unk_64_8', Uint64, (0, None), (False, None), None)
+		yield ('unk_64_9', Uint64, (0, None), (False, None), None)
+		yield ('unk_64_10', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -89,3 +90,6 @@ class PhysicsSurfaceXMLResRoot(MemStruct):
 		yield 'unk_64_8', Uint64, (0, None), (False, None)
 		yield 'unk_64_9', Uint64, (0, None), (False, None)
 		yield 'unk_64_10', Uint64, (0, None), (False, None)
+
+
+PhysicsSurfaceXMLResRoot.init_attributes()

--- a/generated/formats/physicssurfacesxmlres/compounds/SurfacePhysicsInfo.py
+++ b/generated/formats/physicssurfacesxmlres/compounds/SurfacePhysicsInfo.py
@@ -29,17 +29,18 @@ class SurfacePhysicsInfo(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('surface_name', Pointer, (0, ZString), (False, None), None),
-		('float_1', Float, (0, None), (False, None), None),
-		('float_2', Float, (0, None), (False, None), None),
-		('float_3', Float, (0, None), (False, None), None),
-		('float_4', Float, (0, None), (False, None), None),
-		('unk_64_1', Uint64, (0, None), (False, None), None),
-		('name_1', Pointer, (0, ZString), (False, None), None),
-		('name_2', Pointer, (0, ZString), (False, None), None),
-		('ptr_1', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('surface_name', Pointer, (0, ZString), (False, None), None)
+		yield ('float_1', Float, (0, None), (False, None), None)
+		yield ('float_2', Float, (0, None), (False, None), None)
+		yield ('float_3', Float, (0, None), (False, None), None)
+		yield ('float_4', Float, (0, None), (False, None), None)
+		yield ('unk_64_1', Uint64, (0, None), (False, None), None)
+		yield ('name_1', Pointer, (0, ZString), (False, None), None)
+		yield ('name_2', Pointer, (0, ZString), (False, None), None)
+		yield ('ptr_1', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -53,3 +54,6 @@ class SurfacePhysicsInfo(MemStruct):
 		yield 'name_1', Pointer, (0, ZString), (False, None)
 		yield 'name_2', Pointer, (0, ZString), (False, None)
 		yield 'ptr_1', Pointer, (0, SurfacePhysicsInfo._import_map["physicssurfacesxmlres.compounds.EmptyStruct"]), (False, None)
+
+
+SurfacePhysicsInfo.init_attributes()

--- a/generated/formats/posedriverdef/compounds/Data.py
+++ b/generated/formats/posedriverdef/compounds/Data.py
@@ -16,11 +16,15 @@ class Data(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('floats', Array, (0, None, (16,), Float), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('floats', Array, (0, None, (16,), Float), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'floats', Array, (0, None, (16,), Float), (False, None)
+
+
+Data.init_attributes()

--- a/generated/formats/posedriverdef/compounds/Driver.py
+++ b/generated/formats/posedriverdef/compounds/Driver.py
@@ -31,17 +31,18 @@ class Driver(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('joint_name', Pointer, (0, ZString), (False, None), None),
-		('a', Ubyte, (0, None), (False, None), None),
-		('b', Ubyte, (0, None), (False, None), None),
-		('c', Ushort, (0, None), (False, None), None),
-		('d', Uint, (0, None), (False, None), None),
-		('driven_joint_name', Pointer, (0, ZString), (False, None), None),
-		('unk_1', Uint64, (0, None), (False, None), None),
-		('data', Pointer, (0, None), (False, None), None),
-		('unk_2', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('joint_name', Pointer, (0, ZString), (False, None), None)
+		yield ('a', Ubyte, (0, None), (False, None), None)
+		yield ('b', Ubyte, (0, None), (False, None), None)
+		yield ('c', Ushort, (0, None), (False, None), None)
+		yield ('d', Uint, (0, None), (False, None), None)
+		yield ('driven_joint_name', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_1', Uint64, (0, None), (False, None), None)
+		yield ('data', Pointer, (0, None), (False, None), None)
+		yield ('unk_2', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -55,3 +56,6 @@ class Driver(MemStruct):
 		yield 'unk_1', Uint64, (0, None), (False, None)
 		yield 'data', Pointer, (0, Driver._import_map["posedriverdef.compounds.Data"]), (False, None)
 		yield 'unk_2', Uint64, (0, None), (False, None)
+
+
+Driver.init_attributes()

--- a/generated/formats/posedriverdef/compounds/PoseDriverDefRoot.py
+++ b/generated/formats/posedriverdef/compounds/PoseDriverDefRoot.py
@@ -16,13 +16,17 @@ class PoseDriverDefRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('drivers', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('drivers', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'drivers', ArrayPointer, (instance.count, PoseDriverDefRoot._import_map["posedriverdef.compounds.Driver"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
+
+
+PoseDriverDefRoot.init_attributes()

--- a/generated/formats/pscollection/compounds/Arg.py
+++ b/generated/formats/pscollection/compounds/Arg.py
@@ -24,15 +24,16 @@ class Arg(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('u_0', Ubyte, (0, None), (True, 0), None),
-		('arg_type', Ubyte, (0, None), (False, None), None),
-		('arg_index', Ubyte, (0, None), (False, None), None),
-		('u_1', Ubyte, (0, None), (True, 0), None),
-		('u_2', Uint, (0, None), (True, 0), None),
-		('u_3', Uint64, (0, None), (True, 0), None),
-		('u_4', Uint64, (0, None), (True, 0), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('u_0', Ubyte, (0, None), (True, 0), None)
+		yield ('arg_type', Ubyte, (0, None), (False, None), None)
+		yield ('arg_index', Ubyte, (0, None), (False, None), None)
+		yield ('u_1', Ubyte, (0, None), (True, 0), None)
+		yield ('u_2', Uint, (0, None), (True, 0), None)
+		yield ('u_3', Uint64, (0, None), (True, 0), None)
+		yield ('u_4', Uint64, (0, None), (True, 0), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -44,3 +45,6 @@ class Arg(MemStruct):
 		yield 'u_2', Uint, (0, None), (True, 0)
 		yield 'u_3', Uint64, (0, None), (True, 0)
 		yield 'u_4', Uint64, (0, None), (True, 0)
+
+
+Arg.init_attributes()

--- a/generated/formats/pscollection/compounds/PreparedStatement.py
+++ b/generated/formats/pscollection/compounds/PreparedStatement.py
@@ -20,12 +20,13 @@ class PreparedStatement(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('args', ArrayPointer, (None, None), (False, None), None),
-		('arg_count', Uint64, (0, None), (True, 0), None),
-		('statement_name', Pointer, (0, ZString), (False, None), None),
-		('sql_query', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('args', ArrayPointer, (None, None), (False, None), None)
+		yield ('arg_count', Uint64, (0, None), (True, 0), None)
+		yield ('statement_name', Pointer, (0, ZString), (False, None), None)
+		yield ('sql_query', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -34,3 +35,6 @@ class PreparedStatement(MemStruct):
 		yield 'arg_count', Uint64, (0, None), (True, 0)
 		yield 'statement_name', Pointer, (0, ZString), (False, None)
 		yield 'sql_query', Pointer, (0, ZString), (False, None)
+
+
+PreparedStatement.init_attributes()

--- a/generated/formats/pscollection/compounds/PscollectionRoot.py
+++ b/generated/formats/pscollection/compounds/PscollectionRoot.py
@@ -16,13 +16,17 @@ class PscollectionRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('prepared_statements', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('prepared_statements', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'prepared_statements', ArrayPointer, (instance.count, PscollectionRoot._import_map["pscollection.compounds.PreparedStatement"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
+
+
+PscollectionRoot.init_attributes()

--- a/generated/formats/renderfeaturecollection/compounds/RenderFeatureCollectionRoot.py
+++ b/generated/formats/renderfeaturecollection/compounds/RenderFeatureCollectionRoot.py
@@ -16,13 +16,17 @@ class RenderFeatureCollectionRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('item_list', ArrayPointer, (None, None), (False, None), None),
-		('item_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('item_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('item_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'item_list', ArrayPointer, (instance.item_count, RenderFeatureCollectionRoot._import_map["renderfeaturecollection.compounds.RenderFeatureItem"]), (False, None)
 		yield 'item_count', Uint64, (0, None), (False, None)
+
+
+RenderFeatureCollectionRoot.init_attributes()

--- a/generated/formats/renderfeaturecollection/compounds/RenderFeatureItem.py
+++ b/generated/formats/renderfeaturecollection/compounds/RenderFeatureItem.py
@@ -19,11 +19,12 @@ class RenderFeatureItem(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('item_name', Pointer, (0, ZString), (False, None), None),
-		('item_data', ArrayPointer, (None, None), (False, None), None),
-		('item_data_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('item_name', Pointer, (0, ZString), (False, None), None)
+		yield ('item_data', ArrayPointer, (None, None), (False, None), None)
+		yield ('item_data_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -31,3 +32,6 @@ class RenderFeatureItem(MemStruct):
 		yield 'item_name', Pointer, (0, ZString), (False, None)
 		yield 'item_data', ArrayPointer, (instance.item_data_count, RenderFeatureItem._import_map["renderfeaturecollection.compounds.RenderFeatureSubItem"]), (False, None)
 		yield 'item_data_count', Uint64, (0, None), (False, None)
+
+
+RenderFeatureItem.init_attributes()

--- a/generated/formats/renderfeaturecollection/compounds/RenderFeatureSubItem.py
+++ b/generated/formats/renderfeaturecollection/compounds/RenderFeatureSubItem.py
@@ -17,13 +17,17 @@ class RenderFeatureSubItem(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('sub_item_name', Pointer, (0, ZString), (False, None), None),
-		('sub_item_value_or_flags', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('sub_item_name', Pointer, (0, ZString), (False, None), None)
+		yield ('sub_item_value_or_flags', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'sub_item_name', Pointer, (0, ZString), (False, None)
 		yield 'sub_item_value_or_flags', Uint64, (0, None), (False, None)
+
+
+RenderFeatureSubItem.init_attributes()

--- a/generated/formats/renderparameters/compounds/CurveList.py
+++ b/generated/formats/renderparameters/compounds/CurveList.py
@@ -19,11 +19,15 @@ class CurveList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, None, (None,), Pointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, None, (None,), Pointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, CurveList._import_map["renderparameters.compounds.KeyPoint"], (instance.arg,), Pointer), (False, None)
+
+
+CurveList.init_attributes()

--- a/generated/formats/renderparameters/compounds/CurveParam.py
+++ b/generated/formats/renderparameters/compounds/CurveParam.py
@@ -24,13 +24,14 @@ class CurveParam(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('attribute_name', Pointer, (0, ZString), (False, None), None),
-		('dtype', Int, (0, None), (False, None), None),
-		('do_interpolation', Uint, (0, None), (False, None), None),
-		('curve_entries', Pointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('attribute_name', Pointer, (0, ZString), (False, None), None)
+		yield ('dtype', Int, (0, None), (False, None), None)
+		yield ('do_interpolation', Uint, (0, None), (False, None), None)
+		yield ('curve_entries', Pointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -40,3 +41,6 @@ class CurveParam(MemStruct):
 		yield 'do_interpolation', Uint, (0, None), (False, None)
 		yield 'curve_entries', Pointer, (instance.count, CurveParam._import_map["renderparameters.compounds.CurveList"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
+
+
+CurveParam.init_attributes()

--- a/generated/formats/renderparameters/compounds/CurveParamList.py
+++ b/generated/formats/renderparameters/compounds/CurveParamList.py
@@ -19,11 +19,15 @@ class CurveParamList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, None, (None,), Pointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, None, (None,), Pointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, CurveParamList._import_map["renderparameters.compounds.CurveParam"], (instance.arg,), Pointer), (False, None)
+
+
+CurveParamList.init_attributes()

--- a/generated/formats/renderparameters/compounds/KeyPoint.py
+++ b/generated/formats/renderparameters/compounds/KeyPoint.py
@@ -17,12 +17,13 @@ class KeyPoint(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('time', Float, (0, None), (False, None), None),
-		('value', Float, (0, None), (False, None), None),
-		('tangent_before', Float, (0, None), (False, None), None),
-		('tangent_after', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('time', Float, (0, None), (False, None), None)
+		yield ('value', Float, (0, None), (False, None), None)
+		yield ('tangent_before', Float, (0, None), (False, None), None)
+		yield ('tangent_after', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -31,3 +32,6 @@ class KeyPoint(MemStruct):
 		yield 'value', Float, (0, None), (False, None)
 		yield 'tangent_before', Float, (0, None), (False, None)
 		yield 'tangent_after', Float, (0, None), (False, None)
+
+
+KeyPoint.init_attributes()

--- a/generated/formats/renderparameters/compounds/Param.py
+++ b/generated/formats/renderparameters/compounds/Param.py
@@ -23,11 +23,12 @@ class Param(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('attribute_name', Pointer, (0, ZString), (False, None), None),
-		('dtype', RenderParameterType, (0, None), (False, None), None),
-		('data', ParamData, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('attribute_name', Pointer, (0, ZString), (False, None), None)
+		yield ('dtype', RenderParameterType, (0, None), (False, None), None)
+		yield ('data', ParamData, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -35,3 +36,6 @@ class Param(MemStruct):
 		yield 'attribute_name', Pointer, (0, ZString), (False, None)
 		yield 'dtype', RenderParameterType, (0, None), (False, None)
 		yield 'data', ParamData, (instance.dtype, None), (False, None)
+
+
+Param.init_attributes()

--- a/generated/formats/renderparameters/compounds/ParamData.py
+++ b/generated/formats/renderparameters/compounds/ParamData.py
@@ -25,18 +25,19 @@ class ParamData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('data', Array, (0, None, (1,), Bool), (False, None), True),
-		('data', Array, (0, None, (1,), Float), (False, None), True),
-		('data', Array, (0, None, (1,), Int), (False, None), True),
-		('data', Array, (0, None, (1,), Uint), (False, None), True),
-		('data', Array, (0, None, (2,), Float), (False, None), True),
-		('data', Array, (0, None, (3,), Float), (False, None), True),
-		('data', Array, (0, None, (4,), Float), (False, None), True),
-		('data', Array, (0, None, (4,), Ubyte), (False, None), True),
-		('data', Array, (0, None, (4,), Float), (False, None), True),
-		('data', Array, (0, None, (1,), ZStrPtr), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('data', Array, (0, None, (1,), Bool), (False, None), True)
+		yield ('data', Array, (0, None, (1,), Float), (False, None), True)
+		yield ('data', Array, (0, None, (1,), Int), (False, None), True)
+		yield ('data', Array, (0, None, (1,), Uint), (False, None), True)
+		yield ('data', Array, (0, None, (2,), Float), (False, None), True)
+		yield ('data', Array, (0, None, (3,), Float), (False, None), True)
+		yield ('data', Array, (0, None, (4,), Float), (False, None), True)
+		yield ('data', Array, (0, None, (4,), Ubyte), (False, None), True)
+		yield ('data', Array, (0, None, (4,), Float), (False, None), True)
+		yield ('data', Array, (0, None, (1,), ZStrPtr), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -61,3 +62,6 @@ class ParamData(MemStruct):
 			yield 'data', Array, (0, None, (4,), Float), (False, None)
 		if instance.arg == 9:
 			yield 'data', Array, (0, None, (1,), ZStrPtr), (False, None)
+
+
+ParamData.init_attributes()

--- a/generated/formats/renderparameters/compounds/ParamList.py
+++ b/generated/formats/renderparameters/compounds/ParamList.py
@@ -19,11 +19,15 @@ class ParamList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, None, (None,), Pointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, None, (None,), Pointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, ParamList._import_map["renderparameters.compounds.Param"], (instance.arg,), Pointer), (False, None)
+
+
+ParamList.init_attributes()

--- a/generated/formats/renderparameters/compounds/RenderParameterCurvesRoot.py
+++ b/generated/formats/renderparameters/compounds/RenderParameterCurvesRoot.py
@@ -23,12 +23,13 @@ class RenderParameterCurvesRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('param_name', Pointer, (0, ZStringObfuscated), (False, None), None),
-		('params', Pointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		('unk', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('param_name', Pointer, (0, ZStringObfuscated), (False, None), None)
+		yield ('params', Pointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
+		yield ('unk', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -37,3 +38,6 @@ class RenderParameterCurvesRoot(MemStruct):
 		yield 'params', Pointer, (instance.count, RenderParameterCurvesRoot._import_map["renderparameters.compounds.CurveParamList"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
 		yield 'unk', Uint64, (0, None), (False, None)
+
+
+RenderParameterCurvesRoot.init_attributes()

--- a/generated/formats/renderparameters/compounds/RenderParametersRoot.py
+++ b/generated/formats/renderparameters/compounds/RenderParametersRoot.py
@@ -23,12 +23,13 @@ class RenderParametersRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('param_name', Pointer, (0, ZStringObfuscated), (False, None), None),
-		('params', Pointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		('unk', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('param_name', Pointer, (0, ZStringObfuscated), (False, None), None)
+		yield ('params', Pointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
+		yield ('unk', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -37,3 +38,6 @@ class RenderParametersRoot(MemStruct):
 		yield 'params', Pointer, (instance.count, RenderParametersRoot._import_map["renderparameters.compounds.ParamList"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
 		yield 'unk', Uint64, (0, None), (False, None)
+
+
+RenderParametersRoot.init_attributes()

--- a/generated/formats/renderparameters/compounds/ZStrPtr.py
+++ b/generated/formats/renderparameters/compounds/ZStrPtr.py
@@ -19,11 +19,15 @@ class ZStrPtr(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('string', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('string', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'string', Pointer, (0, ZString), (False, None)
+
+
+ZStrPtr.init_attributes()

--- a/generated/formats/restaurantsettings/compounds/Perk.py
+++ b/generated/formats/restaurantsettings/compounds/Perk.py
@@ -29,21 +29,22 @@ class Perk(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk_0', Uint64, (0, None), (False, None), None),
-		('building_cost', Uint64, (0, None), (False, None), None),
-		('running_cost_base', Uint64, (0, None), (False, None), None),
-		('running_cost_per_extension', Uint64, (0, None), (False, None), None),
-		('unk_4', Float, (0, None), (False, None), None),
-		('unk_5', Float, (0, None), (False, None), None),
-		('label', Pointer, (0, ZString), (False, None), None),
-		('desc', Pointer, (0, ZString), (False, None), None),
-		('icon', Pointer, (0, ZString), (False, None), None),
-		('unk_6', Float, (0, None), (False, None), None),
-		('appeal_adults', Float, (0, None), (False, None), None),
-		('appeal_families', Float, (0, None), (False, None), None),
-		('appeal_teenagers', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_0', Uint64, (0, None), (False, None), None)
+		yield ('building_cost', Uint64, (0, None), (False, None), None)
+		yield ('running_cost_base', Uint64, (0, None), (False, None), None)
+		yield ('running_cost_per_extension', Uint64, (0, None), (False, None), None)
+		yield ('unk_4', Float, (0, None), (False, None), None)
+		yield ('unk_5', Float, (0, None), (False, None), None)
+		yield ('label', Pointer, (0, ZString), (False, None), None)
+		yield ('desc', Pointer, (0, ZString), (False, None), None)
+		yield ('icon', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_6', Float, (0, None), (False, None), None)
+		yield ('appeal_adults', Float, (0, None), (False, None), None)
+		yield ('appeal_families', Float, (0, None), (False, None), None)
+		yield ('appeal_teenagers', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -61,3 +62,6 @@ class Perk(MemStruct):
 		yield 'appeal_adults', Float, (0, None), (False, None)
 		yield 'appeal_families', Float, (0, None), (False, None)
 		yield 'appeal_teenagers', Float, (0, None), (False, None)
+
+
+Perk.init_attributes()

--- a/generated/formats/restaurantsettings/compounds/RestaurantSettingsRoot.py
+++ b/generated/formats/restaurantsettings/compounds/RestaurantSettingsRoot.py
@@ -28,20 +28,21 @@ class RestaurantSettingsRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('running_cost_base', Uint64, (0, None), (False, None), None),
-		('unk_1', Uint, (0, None), (False, None), None),
-		('unk_2', Float, (0, None), (False, None), None),
-		('unk_3', Float, (0, None), (False, None), None),
-		('unk_4', Float, (0, None), (False, None), None),
-		('unk_5', Float, (0, None), (False, None), None),
-		('unk_6', Float, (0, None), (False, None), None),
-		('running_cost_per_extension', Uint64, (0, None), (False, None), None),
-		('unk_8', Uint, (0, None), (False, None), None),
-		('unk_9', Float, (0, None), (False, None), None),
-		('perks', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('running_cost_base', Uint64, (0, None), (False, None), None)
+		yield ('unk_1', Uint, (0, None), (False, None), None)
+		yield ('unk_2', Float, (0, None), (False, None), None)
+		yield ('unk_3', Float, (0, None), (False, None), None)
+		yield ('unk_4', Float, (0, None), (False, None), None)
+		yield ('unk_5', Float, (0, None), (False, None), None)
+		yield ('unk_6', Float, (0, None), (False, None), None)
+		yield ('running_cost_per_extension', Uint64, (0, None), (False, None), None)
+		yield ('unk_8', Uint, (0, None), (False, None), None)
+		yield ('unk_9', Float, (0, None), (False, None), None)
+		yield ('perks', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -58,3 +59,6 @@ class RestaurantSettingsRoot(MemStruct):
 		yield 'unk_9', Float, (0, None), (False, None)
 		yield 'perks', ArrayPointer, (instance.count, RestaurantSettingsRoot._import_map["restaurantsettings.compounds.Perk"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
+
+
+RestaurantSettingsRoot.init_attributes()

--- a/generated/formats/ridesettings/compounds/Pair.py
+++ b/generated/formats/ridesettings/compounds/Pair.py
@@ -16,13 +16,17 @@ class Pair(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('value_0', Uint, (0, None), (False, None), None),
-		('value_1', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('value_0', Uint, (0, None), (False, None), None)
+		yield ('value_1', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'value_0', Uint, (0, None), (False, None)
 		yield 'value_1', Float, (0, None), (False, None)
+
+
+Pair.init_attributes()

--- a/generated/formats/ridesettings/compounds/RideSettingsRoot.py
+++ b/generated/formats/ridesettings/compounds/RideSettingsRoot.py
@@ -22,15 +22,16 @@ class RideSettingsRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk_0', Float, (0, None), (False, None), None),
-		('unk_1', Uint, (0, None), (False, None), None),
-		('array_1', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint, (0, None), (False, None), None),
-		('pad_0', Uint, (0, None), (False, None), None),
-		('pad_1', Uint, (0, None), (False, None), None),
-		('pad_2', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_0', Float, (0, None), (False, None), None)
+		yield ('unk_1', Uint, (0, None), (False, None), None)
+		yield ('array_1', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint, (0, None), (False, None), None)
+		yield ('pad_0', Uint, (0, None), (False, None), None)
+		yield ('pad_1', Uint, (0, None), (False, None), None)
+		yield ('pad_2', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -42,3 +43,6 @@ class RideSettingsRoot(MemStruct):
 		yield 'pad_0', Uint, (0, None), (False, None)
 		yield 'pad_1', Uint, (0, None), (False, None)
 		yield 'pad_2', Uint, (0, None), (False, None)
+
+
+RideSettingsRoot.init_attributes()

--- a/generated/formats/scaleformlanguagedata/compounds/FontInfo.py
+++ b/generated/formats/scaleformlanguagedata/compounds/FontInfo.py
@@ -22,11 +22,12 @@ class FontInfo(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('style_name', Pointer, (0, ZString), (False, None), None),
-		('font_file', Pointer, (0, ZString), (False, None), None),
-		('flag_or_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('style_name', Pointer, (0, ZString), (False, None), None)
+		yield ('font_file', Pointer, (0, ZString), (False, None), None)
+		yield ('flag_or_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -34,3 +35,6 @@ class FontInfo(MemStruct):
 		yield 'style_name', Pointer, (0, ZString), (False, None)
 		yield 'font_file', Pointer, (0, ZString), (False, None)
 		yield 'flag_or_count', Uint64, (0, None), (False, None)
+
+
+FontInfo.init_attributes()

--- a/generated/formats/scaleformlanguagedata/compounds/ScaleformlanguagedataRoot.py
+++ b/generated/formats/scaleformlanguagedata/compounds/ScaleformlanguagedataRoot.py
@@ -25,14 +25,15 @@ class ScaleformlanguagedataRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('zero_0', Uint64, (0, None), (False, None), None),
-		('zero_1', Uint64, (0, None), (False, None), None),
-		('fonts', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		('zero_2', Uint64, (0, None), (False, None), None),
-		('zero_3', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('zero_0', Uint64, (0, None), (False, None), None)
+		yield ('zero_1', Uint64, (0, None), (False, None), None)
+		yield ('fonts', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
+		yield ('zero_2', Uint64, (0, None), (False, None), None)
+		yield ('zero_3', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -43,3 +44,6 @@ class ScaleformlanguagedataRoot(MemStruct):
 		yield 'count', Uint64, (0, None), (False, None)
 		yield 'zero_2', Uint64, (0, None), (False, None)
 		yield 'zero_3', Uint64, (0, None), (False, None)
+
+
+ScaleformlanguagedataRoot.init_attributes()

--- a/generated/formats/semanticflexicolours/compounds/Colourname.py
+++ b/generated/formats/semanticflexicolours/compounds/Colourname.py
@@ -15,11 +15,15 @@ class Colourname(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('colour_name', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('colour_name', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'colour_name', Pointer, (0, ZString), (False, None)
+
+
+Colourname.init_attributes()

--- a/generated/formats/semanticflexicolours/compounds/SemanticFlexiColoursRoot.py
+++ b/generated/formats/semanticflexicolours/compounds/SemanticFlexiColoursRoot.py
@@ -16,13 +16,17 @@ class SemanticFlexiColoursRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('name_list', ArrayPointer, (None, None), (False, None), None),
-		('name_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('name_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('name_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'name_list', ArrayPointer, (instance.name_count, SemanticFlexiColoursRoot._import_map["semanticflexicolours.compounds.Colourname"]), (False, None)
 		yield 'name_count', Uint64, (0, None), (False, None)
+
+
+SemanticFlexiColoursRoot.init_attributes()

--- a/generated/formats/specdef/compounds/ArrayData.py
+++ b/generated/formats/specdef/compounds/ArrayData.py
@@ -22,11 +22,12 @@ class ArrayData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('item', Pointer, (None, None), (False, None), None),
-		('dtype', SpecdefDtype, (0, None), (False, None), None),
-		('unused', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('item', Pointer, (None, None), (False, None), None)
+		yield ('dtype', SpecdefDtype, (0, None), (False, None), None)
+		yield ('unused', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -34,3 +35,6 @@ class ArrayData(MemStruct):
 		yield 'item', Pointer, (instance.dtype, ArrayData._import_map["specdef.compounds.Data"]), (False, None)
 		yield 'dtype', SpecdefDtype, (0, None), (False, None)
 		yield 'unused', Uint, (0, None), (False, None)
+
+
+ArrayData.init_attributes()

--- a/generated/formats/specdef/compounds/BooleanData.py
+++ b/generated/formats/specdef/compounds/BooleanData.py
@@ -22,11 +22,12 @@ class BooleanData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('value', Ubyte, (0, None), (False, None), None),
-		('default', Ubyte, (0, None), (False, None), None),
-		('unused', Array, (0, None, (6,), Ubyte), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('value', Ubyte, (0, None), (False, None), None)
+		yield ('default', Ubyte, (0, None), (False, None), None)
+		yield ('unused', Array, (0, None, (6,), Ubyte), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -34,3 +35,6 @@ class BooleanData(MemStruct):
 		yield 'value', Ubyte, (0, None), (False, None)
 		yield 'default', Ubyte, (0, None), (False, None)
 		yield 'unused', Array, (0, None, (6,), Ubyte), (False, None)
+
+
+BooleanData.init_attributes()

--- a/generated/formats/specdef/compounds/ChildSpecData.py
+++ b/generated/formats/specdef/compounds/ChildSpecData.py
@@ -20,11 +20,15 @@ class ChildSpecData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('specdef', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('specdef', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'specdef', Pointer, (0, ChildSpecData._import_map["specdef.compounds.SpecdefRoot"]), (False, None)
+
+
+ChildSpecData.init_attributes()

--- a/generated/formats/specdef/compounds/Data.py
+++ b/generated/formats/specdef/compounds/Data.py
@@ -34,24 +34,25 @@ class Data(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('dtype', BooleanData, (0, None), (False, None), True),
-		('dtype', Int8Data, (0, None), (False, None), True),
-		('dtype', Int16Data, (0, None), (False, None), True),
-		('dtype', Int32Data, (0, None), (False, None), True),
-		('dtype', Int64Data, (0, None), (False, None), True),
-		('dtype', Uint8Data, (0, None), (False, None), True),
-		('dtype', Uint16Data, (0, None), (False, None), True),
-		('dtype', Uint32Data, (0, None), (False, None), True),
-		('dtype', Uint64Data, (0, None), (False, None), True),
-		('dtype', FloatData, (0, None), (False, None), True),
-		('dtype', StringData, (0, None), (False, None), True),
-		('dtype', Vector2, (0, None), (False, None), True),
-		('dtype', Vector3, (0, None), (False, None), True),
-		('dtype', ArrayData, (0, None), (False, None), True),
-		('dtype', ChildSpecData, (0, None), (False, None), True),
-		('dtype', ReferenceToObjectData, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('dtype', BooleanData, (0, None), (False, None), True)
+		yield ('dtype', Int8Data, (0, None), (False, None), True)
+		yield ('dtype', Int16Data, (0, None), (False, None), True)
+		yield ('dtype', Int32Data, (0, None), (False, None), True)
+		yield ('dtype', Int64Data, (0, None), (False, None), True)
+		yield ('dtype', Uint8Data, (0, None), (False, None), True)
+		yield ('dtype', Uint16Data, (0, None), (False, None), True)
+		yield ('dtype', Uint32Data, (0, None), (False, None), True)
+		yield ('dtype', Uint64Data, (0, None), (False, None), True)
+		yield ('dtype', FloatData, (0, None), (False, None), True)
+		yield ('dtype', StringData, (0, None), (False, None), True)
+		yield ('dtype', Vector2, (0, None), (False, None), True)
+		yield ('dtype', Vector3, (0, None), (False, None), True)
+		yield ('dtype', ArrayData, (0, None), (False, None), True)
+		yield ('dtype', ChildSpecData, (0, None), (False, None), True)
+		yield ('dtype', ReferenceToObjectData, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -88,3 +89,6 @@ class Data(MemStruct):
 			yield 'dtype', ChildSpecData, (0, None), (False, None)
 		if instance.arg == 15:
 			yield 'dtype', ReferenceToObjectData, (0, None), (False, None)
+
+
+Data.init_attributes()

--- a/generated/formats/specdef/compounds/DataPtr.py
+++ b/generated/formats/specdef/compounds/DataPtr.py
@@ -18,11 +18,15 @@ class DataPtr(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('data_ptr', Pointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('data_ptr', Pointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'data_ptr', Pointer, (instance.arg.dtype, DataPtr._import_map["specdef.compounds.Data"]), (False, None)
+
+
+DataPtr.init_attributes()

--- a/generated/formats/specdef/compounds/FloatData.py
+++ b/generated/formats/specdef/compounds/FloatData.py
@@ -22,12 +22,13 @@ class FloatData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('imin', Float, (0, None), (False, None), None),
-		('imax', Float, (0, None), (False, None), None),
-		('ivalue', Float, (0, None), (False, None), None),
-		('ioptional', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('imin', Float, (0, None), (False, None), None)
+		yield ('imax', Float, (0, None), (False, None), None)
+		yield ('ivalue', Float, (0, None), (False, None), None)
+		yield ('ioptional', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class FloatData(MemStruct):
 		yield 'imax', Float, (0, None), (False, None)
 		yield 'ivalue', Float, (0, None), (False, None)
 		yield 'ioptional', Uint, (0, None), (False, None)
+
+
+FloatData.init_attributes()

--- a/generated/formats/specdef/compounds/Int16Data.py
+++ b/generated/formats/specdef/compounds/Int16Data.py
@@ -23,13 +23,14 @@ class Int16Data(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('imin', Short, (0, None), (False, None), None),
-		('imax', Short, (0, None), (False, None), None),
-		('ivalue', Short, (0, None), (False, None), None),
-		('ioptional', Short, (0, None), (False, None), None),
-		('enum', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('imin', Short, (0, None), (False, None), None)
+		yield ('imax', Short, (0, None), (False, None), None)
+		yield ('ivalue', Short, (0, None), (False, None), None)
+		yield ('ioptional', Short, (0, None), (False, None), None)
+		yield ('enum', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -39,3 +40,6 @@ class Int16Data(MemStruct):
 		yield 'ivalue', Short, (0, None), (False, None)
 		yield 'ioptional', Short, (0, None), (False, None)
 		yield 'enum', Pointer, (0, None), (False, None)
+
+
+Int16Data.init_attributes()

--- a/generated/formats/specdef/compounds/Int32Data.py
+++ b/generated/formats/specdef/compounds/Int32Data.py
@@ -23,13 +23,14 @@ class Int32Data(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('imin', Int, (0, None), (False, None), None),
-		('imax', Int, (0, None), (False, None), None),
-		('ivalue', Int, (0, None), (False, None), None),
-		('ioptional', Int, (0, None), (False, None), None),
-		('enum', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('imin', Int, (0, None), (False, None), None)
+		yield ('imax', Int, (0, None), (False, None), None)
+		yield ('ivalue', Int, (0, None), (False, None), None)
+		yield ('ioptional', Int, (0, None), (False, None), None)
+		yield ('enum', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -39,3 +40,6 @@ class Int32Data(MemStruct):
 		yield 'ivalue', Int, (0, None), (False, None)
 		yield 'ioptional', Int, (0, None), (False, None)
 		yield 'enum', Pointer, (0, None), (False, None)
+
+
+Int32Data.init_attributes()

--- a/generated/formats/specdef/compounds/Int64Data.py
+++ b/generated/formats/specdef/compounds/Int64Data.py
@@ -23,13 +23,14 @@ class Int64Data(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('imin', Int64, (0, None), (False, None), None),
-		('imax', Int64, (0, None), (False, None), None),
-		('ivalue', Int64, (0, None), (False, None), None),
-		('ioptional', Int64, (0, None), (False, None), None),
-		('enum', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('imin', Int64, (0, None), (False, None), None)
+		yield ('imax', Int64, (0, None), (False, None), None)
+		yield ('ivalue', Int64, (0, None), (False, None), None)
+		yield ('ioptional', Int64, (0, None), (False, None), None)
+		yield ('enum', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -39,3 +40,6 @@ class Int64Data(MemStruct):
 		yield 'ivalue', Int64, (0, None), (False, None)
 		yield 'ioptional', Int64, (0, None), (False, None)
 		yield 'enum', Pointer, (0, None), (False, None)
+
+
+Int64Data.init_attributes()

--- a/generated/formats/specdef/compounds/Int8Data.py
+++ b/generated/formats/specdef/compounds/Int8Data.py
@@ -27,14 +27,15 @@ class Int8Data(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('imin', Byte, (0, None), (False, None), None),
-		('imax', Byte, (0, None), (False, None), None),
-		('ivalue', Byte, (0, None), (False, None), None),
-		('ioptional', Byte, (0, None), (False, None), None),
-		('unused', Array, (0, None, (4,), Ubyte), (False, None), None),
-		('enum', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('imin', Byte, (0, None), (False, None), None)
+		yield ('imax', Byte, (0, None), (False, None), None)
+		yield ('ivalue', Byte, (0, None), (False, None), None)
+		yield ('ioptional', Byte, (0, None), (False, None), None)
+		yield ('unused', Array, (0, None, (4,), Ubyte), (False, None), None)
+		yield ('enum', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -45,3 +46,6 @@ class Int8Data(MemStruct):
 		yield 'ioptional', Byte, (0, None), (False, None)
 		yield 'unused', Array, (0, None, (4,), Ubyte), (False, None)
 		yield 'enum', Pointer, (0, None), (False, None)
+
+
+Int8Data.init_attributes()

--- a/generated/formats/specdef/compounds/NamePtr.py
+++ b/generated/formats/specdef/compounds/NamePtr.py
@@ -15,11 +15,15 @@ class NamePtr(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('name_ptr', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('name_ptr', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'name_ptr', Pointer, (0, ZString), (False, None)
+
+
+NamePtr.init_attributes()

--- a/generated/formats/specdef/compounds/PtrList.py
+++ b/generated/formats/specdef/compounds/PtrList.py
@@ -16,11 +16,15 @@ class PtrList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, ZString, (instance.arg,), Pointer), (False, None)
+
+
+PtrList.init_attributes()

--- a/generated/formats/specdef/compounds/ReferenceToObjectData.py
+++ b/generated/formats/specdef/compounds/ReferenceToObjectData.py
@@ -21,13 +21,17 @@ class ReferenceToObjectData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('obj_name', Pointer, (0, ZString), (False, None), None),
-		('ioptional', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('obj_name', Pointer, (0, ZString), (False, None), None)
+		yield ('ioptional', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'obj_name', Pointer, (0, ZString), (False, None)
 		yield 'ioptional', Uint, (0, None), (False, None)
+
+
+ReferenceToObjectData.init_attributes()

--- a/generated/formats/specdef/compounds/Spec.py
+++ b/generated/formats/specdef/compounds/Spec.py
@@ -14,11 +14,15 @@ class Spec(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('dtype', SpecdefDtype, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('dtype', SpecdefDtype, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'dtype', SpecdefDtype, (0, None), (False, None)
+
+
+Spec.init_attributes()

--- a/generated/formats/specdef/compounds/SpecdefRoot.py
+++ b/generated/formats/specdef/compounds/SpecdefRoot.py
@@ -30,21 +30,22 @@ class SpecdefRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('attrib_count', Ushort, (0, None), (False, None), None),
-		('flags', Ushort, (0, None), (False, None), None),
-		('name_count', Ubyte, (0, None), (False, None), None),
-		('childspec_count', Ubyte, (0, None), (False, None), None),
-		('manager_count', Ubyte, (0, None), (False, None), None),
-		('script_count', Ubyte, (0, None), (False, None), None),
-		('attribs', ArrayPointer, (None, None), (False, None), None),
-		('name_foreach_attribs', ForEachPointer, (None, None), (False, None), None),
-		('data_foreach_attribs', ForEachPointer, (None, None), (False, None), None),
-		('names', Pointer, (None, None), (False, None), None),
-		('childspecs', Pointer, (None, None), (False, None), None),
-		('managers', Pointer, (None, None), (False, None), None),
-		('scripts', Pointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('attrib_count', Ushort, (0, None), (False, None), None)
+		yield ('flags', Ushort, (0, None), (False, None), None)
+		yield ('name_count', Ubyte, (0, None), (False, None), None)
+		yield ('childspec_count', Ubyte, (0, None), (False, None), None)
+		yield ('manager_count', Ubyte, (0, None), (False, None), None)
+		yield ('script_count', Ubyte, (0, None), (False, None), None)
+		yield ('attribs', ArrayPointer, (None, None), (False, None), None)
+		yield ('name_foreach_attribs', ForEachPointer, (None, None), (False, None), None)
+		yield ('data_foreach_attribs', ForEachPointer, (None, None), (False, None), None)
+		yield ('names', Pointer, (None, None), (False, None), None)
+		yield ('childspecs', Pointer, (None, None), (False, None), None)
+		yield ('managers', Pointer, (None, None), (False, None), None)
+		yield ('scripts', Pointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -62,3 +63,6 @@ class SpecdefRoot(MemStruct):
 		yield 'childspecs', Pointer, (instance.childspec_count, SpecdefRoot._import_map["specdef.compounds.PtrList"]), (False, None)
 		yield 'managers', Pointer, (instance.manager_count, SpecdefRoot._import_map["specdef.compounds.PtrList"]), (False, None)
 		yield 'scripts', Pointer, (instance.script_count, SpecdefRoot._import_map["specdef.compounds.PtrList"]), (False, None)
+
+
+SpecdefRoot.init_attributes()

--- a/generated/formats/specdef/compounds/StringData.py
+++ b/generated/formats/specdef/compounds/StringData.py
@@ -21,13 +21,17 @@ class StringData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('str_name', Pointer, (0, ZString), (False, None), None),
-		('ioptional', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('str_name', Pointer, (0, ZString), (False, None), None)
+		yield ('ioptional', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'str_name', Pointer, (0, ZString), (False, None)
 		yield 'ioptional', Uint, (0, None), (False, None)
+
+
+StringData.init_attributes()

--- a/generated/formats/specdef/compounds/Uint16Data.py
+++ b/generated/formats/specdef/compounds/Uint16Data.py
@@ -23,13 +23,14 @@ class Uint16Data(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('imin', Ushort, (0, None), (False, None), None),
-		('imax', Ushort, (0, None), (False, None), None),
-		('ivalue', Ushort, (0, None), (False, None), None),
-		('ioptional', Ushort, (0, None), (False, None), None),
-		('enum', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('imin', Ushort, (0, None), (False, None), None)
+		yield ('imax', Ushort, (0, None), (False, None), None)
+		yield ('ivalue', Ushort, (0, None), (False, None), None)
+		yield ('ioptional', Ushort, (0, None), (False, None), None)
+		yield ('enum', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -39,3 +40,6 @@ class Uint16Data(MemStruct):
 		yield 'ivalue', Ushort, (0, None), (False, None)
 		yield 'ioptional', Ushort, (0, None), (False, None)
 		yield 'enum', Pointer, (0, None), (False, None)
+
+
+Uint16Data.init_attributes()

--- a/generated/formats/specdef/compounds/Uint32Data.py
+++ b/generated/formats/specdef/compounds/Uint32Data.py
@@ -23,13 +23,14 @@ class Uint32Data(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('imin', Uint, (0, None), (False, None), None),
-		('imax', Uint, (0, None), (False, None), None),
-		('ivalue', Uint, (0, None), (False, None), None),
-		('ioptional', Uint, (0, None), (False, None), None),
-		('enum', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('imin', Uint, (0, None), (False, None), None)
+		yield ('imax', Uint, (0, None), (False, None), None)
+		yield ('ivalue', Uint, (0, None), (False, None), None)
+		yield ('ioptional', Uint, (0, None), (False, None), None)
+		yield ('enum', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -39,3 +40,6 @@ class Uint32Data(MemStruct):
 		yield 'ivalue', Uint, (0, None), (False, None)
 		yield 'ioptional', Uint, (0, None), (False, None)
 		yield 'enum', Pointer, (0, None), (False, None)
+
+
+Uint32Data.init_attributes()

--- a/generated/formats/specdef/compounds/Uint64Data.py
+++ b/generated/formats/specdef/compounds/Uint64Data.py
@@ -23,13 +23,14 @@ class Uint64Data(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('imin', Uint64, (0, None), (False, None), None),
-		('imax', Uint64, (0, None), (False, None), None),
-		('ivalue', Uint64, (0, None), (False, None), None),
-		('ioptional', Uint64, (0, None), (False, None), None),
-		('enum', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('imin', Uint64, (0, None), (False, None), None)
+		yield ('imax', Uint64, (0, None), (False, None), None)
+		yield ('ivalue', Uint64, (0, None), (False, None), None)
+		yield ('ioptional', Uint64, (0, None), (False, None), None)
+		yield ('enum', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -39,3 +40,6 @@ class Uint64Data(MemStruct):
 		yield 'ivalue', Uint64, (0, None), (False, None)
 		yield 'ioptional', Uint64, (0, None), (False, None)
 		yield 'enum', Pointer, (0, None), (False, None)
+
+
+Uint64Data.init_attributes()

--- a/generated/formats/specdef/compounds/Uint8Data.py
+++ b/generated/formats/specdef/compounds/Uint8Data.py
@@ -26,14 +26,15 @@ class Uint8Data(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('imin', Ubyte, (0, None), (False, None), None),
-		('imax', Ubyte, (0, None), (False, None), None),
-		('ivalue', Ubyte, (0, None), (False, None), None),
-		('ioptional', Ubyte, (0, None), (False, None), None),
-		('unused', Array, (0, None, (4,), Ubyte), (False, None), None),
-		('enum', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('imin', Ubyte, (0, None), (False, None), None)
+		yield ('imax', Ubyte, (0, None), (False, None), None)
+		yield ('ivalue', Ubyte, (0, None), (False, None), None)
+		yield ('ioptional', Ubyte, (0, None), (False, None), None)
+		yield ('unused', Array, (0, None, (4,), Ubyte), (False, None), None)
+		yield ('enum', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -44,3 +45,6 @@ class Uint8Data(MemStruct):
 		yield 'ioptional', Ubyte, (0, None), (False, None)
 		yield 'unused', Array, (0, None, (4,), Ubyte), (False, None)
 		yield 'enum', Pointer, (0, None), (False, None)
+
+
+Uint8Data.init_attributes()

--- a/generated/formats/specdef/compounds/Vector2.py
+++ b/generated/formats/specdef/compounds/Vector2.py
@@ -22,12 +22,13 @@ class Vector2(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('ioptional', Uint, (0, None), (False, None), None),
-		('unused', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('ioptional', Uint, (0, None), (False, None), None)
+		yield ('unused', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class Vector2(MemStruct):
 		yield 'y', Float, (0, None), (False, None)
 		yield 'ioptional', Uint, (0, None), (False, None)
 		yield 'unused', Uint, (0, None), (False, None)
+
+
+Vector2.init_attributes()

--- a/generated/formats/specdef/compounds/Vector3.py
+++ b/generated/formats/specdef/compounds/Vector3.py
@@ -22,12 +22,13 @@ class Vector3(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		('ioptional', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
+		yield ('ioptional', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class Vector3(MemStruct):
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
 		yield 'ioptional', Uint, (0, None), (False, None)
+
+
+Vector3.init_attributes()

--- a/generated/formats/spl/compounds/ByteVector3.py
+++ b/generated/formats/spl/compounds/ByteVector3.py
@@ -26,11 +26,12 @@ class ByteVector3(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Byte, (0, None), (False, None), None),
-		('y', Byte, (0, None), (False, None), None),
-		('z', Byte, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Byte, (0, None), (False, None), None)
+		yield ('y', Byte, (0, None), (False, None), None)
+		yield ('z', Byte, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class ByteVector3(MemStruct):
 		yield 'x', Byte, (0, None), (False, None)
 		yield 'y', Byte, (0, None), (False, None)
 		yield 'z', Byte, (0, None), (False, None)
+
+
+ByteVector3.init_attributes()

--- a/generated/formats/spl/compounds/Key.py
+++ b/generated/formats/spl/compounds/Key.py
@@ -23,12 +23,13 @@ class Key(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('pos', ShortVector3, (0, None), (False, None), None),
-		('handle_left', ByteVector3, (0, None), (False, None), None),
-		('handle_right', ByteVector3, (0, None), (False, None), None),
-		('handle_scale', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('pos', ShortVector3, (0, None), (False, None), None)
+		yield ('handle_left', ByteVector3, (0, None), (False, None), None)
+		yield ('handle_right', ByteVector3, (0, None), (False, None), None)
+		yield ('handle_scale', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -37,3 +38,6 @@ class Key(MemStruct):
 		yield 'handle_left', ByteVector3, (0, None), (False, None)
 		yield 'handle_right', ByteVector3, (0, None), (False, None)
 		yield 'handle_scale', Float, (0, None), (False, None)
+
+
+Key.init_attributes()

--- a/generated/formats/spl/compounds/ShortVector3.py
+++ b/generated/formats/spl/compounds/ShortVector3.py
@@ -26,11 +26,12 @@ class ShortVector3(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Short, (0, None), (False, None), None),
-		('y', Short, (0, None), (False, None), None),
-		('z', Short, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Short, (0, None), (False, None), None)
+		yield ('y', Short, (0, None), (False, None), None)
+		yield ('z', Short, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class ShortVector3(MemStruct):
 		yield 'x', Short, (0, None), (False, None)
 		yield 'y', Short, (0, None), (False, None)
 		yield 'z', Short, (0, None), (False, None)
+
+
+ShortVector3.init_attributes()

--- a/generated/formats/spl/compounds/SplData.py
+++ b/generated/formats/spl/compounds/SplData.py
@@ -23,11 +23,12 @@ class SplData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('offset', Vector3, (0, None), (False, None), None),
-		('scale', Float, (0, None), (False, None), None),
-		('keys', Array, (0, None, (None,), Key), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('offset', Vector3, (0, None), (False, None), None)
+		yield ('scale', Float, (0, None), (False, None), None)
+		yield ('keys', Array, (0, None, (None,), Key), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -35,3 +36,6 @@ class SplData(MemStruct):
 		yield 'offset', Vector3, (0, None), (False, None)
 		yield 'scale', Float, (0, None), (False, None)
 		yield 'keys', Array, (0, None, (instance.arg,), Key), (False, None)
+
+
+SplData.init_attributes()

--- a/generated/formats/spl/compounds/SplRoot.py
+++ b/generated/formats/spl/compounds/SplRoot.py
@@ -27,13 +27,14 @@ class SplRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('spline_data', Pointer, (None, None), (False, None), None),
-		('count', Ushort, (0, None), (False, None), None),
-		('sixteen', Ubyte, (0, None), (False, 16), None),
-		('one', Ubyte, (0, None), (False, 1), None),
-		('length', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('spline_data', Pointer, (None, None), (False, None), None)
+		yield ('count', Ushort, (0, None), (False, None), None)
+		yield ('sixteen', Ubyte, (0, None), (False, 16), None)
+		yield ('one', Ubyte, (0, None), (False, 1), None)
+		yield ('length', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -43,3 +44,6 @@ class SplRoot(MemStruct):
 		yield 'sixteen', Ubyte, (0, None), (False, 16)
 		yield 'one', Ubyte, (0, None), (False, 1)
 		yield 'length', Float, (0, None), (False, None)
+
+
+SplRoot.init_attributes()

--- a/generated/formats/spl/compounds/Vector3.py
+++ b/generated/formats/spl/compounds/Vector3.py
@@ -26,11 +26,12 @@ class Vector3(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class Vector3(MemStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+Vector3.init_attributes()

--- a/generated/formats/terraindetaillayers/compounds/BrushitemStruct.py
+++ b/generated/formats/terraindetaillayers/compounds/BrushitemStruct.py
@@ -17,13 +17,17 @@ class BrushitemStruct(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('brush_name', Pointer, (0, ZString), (False, None), None),
-		('brush_type', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('brush_name', Pointer, (0, ZString), (False, None), None)
+		yield ('brush_type', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'brush_name', Pointer, (0, ZString), (False, None)
 		yield 'brush_type', Uint64, (0, None), (False, None)
+
+
+BrushitemStruct.init_attributes()

--- a/generated/formats/terraindetaillayers/compounds/DetailStruct.py
+++ b/generated/formats/terraindetaillayers/compounds/DetailStruct.py
@@ -18,12 +18,13 @@ class DetailStruct(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('index', Uint, (0, None), (False, None), None),
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('index', Uint, (0, None), (False, None), None)
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -32,3 +33,6 @@ class DetailStruct(MemStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+DetailStruct.init_attributes()

--- a/generated/formats/terraindetaillayers/compounds/EmptyStruct.py
+++ b/generated/formats/terraindetaillayers/compounds/EmptyStruct.py
@@ -12,9 +12,13 @@ class EmptyStruct(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
+
+
+EmptyStruct.init_attributes()

--- a/generated/formats/terraindetaillayers/compounds/InfoStruct.py
+++ b/generated/formats/terraindetaillayers/compounds/InfoStruct.py
@@ -20,13 +20,14 @@ class InfoStruct(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('brush_list', ArrayPointer, (None, None), (False, None), None),
-		('brush_count', Uint, (0, None), (False, None), None),
-		('brush_flags', Uint, (0, None), (False, None), None),
-		('scale', Float, (0, None), (False, None), None),
-		('unk_1', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('brush_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('brush_count', Uint, (0, None), (False, None), None)
+		yield ('brush_flags', Uint, (0, None), (False, None), None)
+		yield ('scale', Float, (0, None), (False, None), None)
+		yield ('unk_1', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class InfoStruct(MemStruct):
 		yield 'brush_flags', Uint, (0, None), (False, None)
 		yield 'scale', Float, (0, None), (False, None)
 		yield 'unk_1', Float, (0, None), (False, None)
+
+
+InfoStruct.init_attributes()

--- a/generated/formats/terraindetaillayers/compounds/TerrainDetailLayersRoot.py
+++ b/generated/formats/terraindetaillayers/compounds/TerrainDetailLayersRoot.py
@@ -20,13 +20,17 @@ class TerrainDetailLayersRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('layer_list', ArrayPointer, (None, None), (False, None), None),
-		('layer_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('layer_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('layer_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'layer_list', ArrayPointer, (instance.layer_count, TerrainDetailLayersRoot._import_map["terraindetaillayers.compounds.TerrainDetailsLayerItem"]), (False, None)
 		yield 'layer_count', Uint64, (0, None), (False, None)
+
+
+TerrainDetailLayersRoot.init_attributes()

--- a/generated/formats/terraindetaillayers/compounds/TerrainDetailsLayerItem.py
+++ b/generated/formats/terraindetaillayers/compounds/TerrainDetailsLayerItem.py
@@ -52,39 +52,40 @@ class TerrainDetailsLayerItem(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('layer_name', Pointer, (0, ZString), (False, None), None),
-		('info_list', ArrayPointer, (None, None), (False, None), None),
-		('info_count', Uint, (0, None), (False, None), None),
-		('float_1', Float, (0, None), (False, None), None),
-		('float_2', Float, (0, None), (False, None), None),
-		('float_3', Float, (0, None), (False, None), None),
-		('float_4', Float, (0, None), (False, None), None),
-		('float_5', Float, (0, None), (False, None), None),
-		('float_6', Float, (0, None), (False, None), None),
-		('unk_2', Uint, (0, None), (False, None), None),
-		('detail_list', ArrayPointer, (None, None), (False, None), None),
-		('detail_count', Uint, (0, None), (False, None), None),
-		('floata_1', Float, (0, None), (False, None), None),
-		('floata_2', Float, (0, None), (False, None), None),
-		('floata_3', Float, (0, None), (False, None), None),
-		('floata_4', Float, (0, None), (False, None), None),
-		('floata_5', Float, (0, None), (False, None), None),
-		('floata_6', Float, (0, None), (False, None), None),
-		('floata_7', Float, (0, None), (False, None), None),
-		('floata_8', Float, (0, None), (False, None), None),
-		('unk_3_flags', Uint, (0, None), (False, None), None),
-		('unk_4_found_as_1', Uint, (0, None), (False, None), None),
-		('unk_5_as_0', Uint, (0, None), (False, None), None),
-		('unk_6_as_0', Uint, (0, None), (False, None), None),
-		('unk_7_as_0', Uint, (0, None), (False, None), None),
-		('unk_8_as_0', Uint, (0, None), (False, None), None),
-		('unk_9_as_0', Uint, (0, None), (False, None), None),
-		('unk_a_as_0', Uint, (0, None), (False, None), None),
-		('unk_b_as_0', Uint, (0, None), (False, None), None),
-		('floatb_1', Float, (0, None), (False, None), None),
-		('floatb_2', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('layer_name', Pointer, (0, ZString), (False, None), None)
+		yield ('info_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('info_count', Uint, (0, None), (False, None), None)
+		yield ('float_1', Float, (0, None), (False, None), None)
+		yield ('float_2', Float, (0, None), (False, None), None)
+		yield ('float_3', Float, (0, None), (False, None), None)
+		yield ('float_4', Float, (0, None), (False, None), None)
+		yield ('float_5', Float, (0, None), (False, None), None)
+		yield ('float_6', Float, (0, None), (False, None), None)
+		yield ('unk_2', Uint, (0, None), (False, None), None)
+		yield ('detail_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('detail_count', Uint, (0, None), (False, None), None)
+		yield ('floata_1', Float, (0, None), (False, None), None)
+		yield ('floata_2', Float, (0, None), (False, None), None)
+		yield ('floata_3', Float, (0, None), (False, None), None)
+		yield ('floata_4', Float, (0, None), (False, None), None)
+		yield ('floata_5', Float, (0, None), (False, None), None)
+		yield ('floata_6', Float, (0, None), (False, None), None)
+		yield ('floata_7', Float, (0, None), (False, None), None)
+		yield ('floata_8', Float, (0, None), (False, None), None)
+		yield ('unk_3_flags', Uint, (0, None), (False, None), None)
+		yield ('unk_4_found_as_1', Uint, (0, None), (False, None), None)
+		yield ('unk_5_as_0', Uint, (0, None), (False, None), None)
+		yield ('unk_6_as_0', Uint, (0, None), (False, None), None)
+		yield ('unk_7_as_0', Uint, (0, None), (False, None), None)
+		yield ('unk_8_as_0', Uint, (0, None), (False, None), None)
+		yield ('unk_9_as_0', Uint, (0, None), (False, None), None)
+		yield ('unk_a_as_0', Uint, (0, None), (False, None), None)
+		yield ('unk_b_as_0', Uint, (0, None), (False, None), None)
+		yield ('floatb_1', Float, (0, None), (False, None), None)
+		yield ('floatb_2', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -120,3 +121,6 @@ class TerrainDetailsLayerItem(MemStruct):
 		yield 'unk_b_as_0', Uint, (0, None), (False, None)
 		yield 'floatb_1', Float, (0, None), (False, None)
 		yield 'floatb_2', Float, (0, None), (False, None)
+
+
+TerrainDetailsLayerItem.init_attributes()

--- a/generated/formats/terrainindexeddetaillayers/compounds/BrushitemStruct.py
+++ b/generated/formats/terrainindexeddetaillayers/compounds/BrushitemStruct.py
@@ -16,13 +16,17 @@ class BrushitemStruct(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('layer_name', Pointer, (0, ZString), (False, None), None),
-		('brush_name', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('layer_name', Pointer, (0, ZString), (False, None), None)
+		yield ('brush_name', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'layer_name', Pointer, (0, ZString), (False, None)
 		yield 'brush_name', Pointer, (0, ZString), (False, None)
+
+
+BrushitemStruct.init_attributes()

--- a/generated/formats/terrainindexeddetaillayers/compounds/TerrainDetailsLayerItem.py
+++ b/generated/formats/terrainindexeddetaillayers/compounds/TerrainDetailsLayerItem.py
@@ -19,11 +19,12 @@ class TerrainDetailsLayerItem(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('layer_name', Pointer, (0, ZString), (False, None), None),
-		('info_list', ArrayPointer, (None, None), (False, None), None),
-		('info_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('layer_name', Pointer, (0, ZString), (False, None), None)
+		yield ('info_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('info_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -31,3 +32,6 @@ class TerrainDetailsLayerItem(MemStruct):
 		yield 'layer_name', Pointer, (0, ZString), (False, None)
 		yield 'info_list', ArrayPointer, (instance.info_count, TerrainDetailsLayerItem._import_map["terrainindexeddetaillayers.compounds.BrushitemStruct"]), (False, None)
 		yield 'info_count', Uint64, (0, None), (False, None)
+
+
+TerrainDetailsLayerItem.init_attributes()

--- a/generated/formats/terrainindexeddetaillayers/compounds/TerrainIndexedDetailLayersRoot.py
+++ b/generated/formats/terrainindexeddetaillayers/compounds/TerrainIndexedDetailLayersRoot.py
@@ -20,13 +20,17 @@ class TerrainIndexedDetailLayersRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('layer_list', ArrayPointer, (None, None), (False, None), None),
-		('layer_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('layer_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('layer_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'layer_list', ArrayPointer, (instance.layer_count, TerrainIndexedDetailLayersRoot._import_map["terrainindexeddetaillayers.compounds.TerrainDetailsLayerItem"]), (False, None)
 		yield 'layer_count', Uint64, (0, None), (False, None)
+
+
+TerrainIndexedDetailLayersRoot.init_attributes()

--- a/generated/formats/tex/compounds/Mipmap.py
+++ b/generated/formats/tex/compounds/Mipmap.py
@@ -32,13 +32,14 @@ class Mipmap(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('offset', Uint, (0, None), (False, None), None),
-		('size', Uint, (0, None), (False, None), None),
-		('size_array', Uint, (0, None), (False, None), None),
-		('size_scan', Uint, (0, None), (False, None), None),
-		('size_data', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('offset', Uint, (0, None), (False, None), None)
+		yield ('size', Uint, (0, None), (False, None), None)
+		yield ('size_array', Uint, (0, None), (False, None), None)
+		yield ('size_scan', Uint, (0, None), (False, None), None)
+		yield ('size_data', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -48,3 +49,6 @@ class Mipmap(MemStruct):
 		yield 'size_array', Uint, (0, None), (False, None)
 		yield 'size_scan', Uint, (0, None), (False, None)
 		yield 'size_data', Uint, (0, None), (False, None)
+
+
+Mipmap.init_attributes()

--- a/generated/formats/tex/compounds/SizeInfo.py
+++ b/generated/formats/tex/compounds/SizeInfo.py
@@ -18,11 +18,12 @@ class SizeInfo(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('data', SizeInfoRaw, (0, None), (False, None), None),
-		('padding', Array, (0, None, (None,), Ubyte), (False, None), True),
-		('padding', Array, (0, None, (None,), Ubyte), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('data', SizeInfoRaw, (0, None), (False, None), None)
+		yield ('padding', Array, (0, None, (None,), Ubyte), (False, None), True)
+		yield ('padding', Array, (0, None, (None,), Ubyte), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -32,3 +33,6 @@ class SizeInfo(MemStruct):
 			yield 'padding', Array, (0, None, (320 - instance.data.io_size,), Ubyte), (False, None)
 		if instance.context.user_version.use_djb and (instance.context.version == 19):
 			yield 'padding', Array, (0, None, (384 - instance.data.io_size,), Ubyte), (False, None)
+
+
+SizeInfo.init_attributes()

--- a/generated/formats/tex/compounds/SizeInfoRaw.py
+++ b/generated/formats/tex/compounds/SizeInfoRaw.py
@@ -45,17 +45,18 @@ class SizeInfoRaw(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('zero', Uint64, (0, None), (True, 0), None),
-		('data_size', Uint, (0, None), (False, None), None),
-		('width', Uint, (0, None), (False, None), None),
-		('height', Uint, (0, None), (False, None), None),
-		('depth', Uint, (0, None), (True, 1), None),
-		('num_tiles', Uint, (0, None), (True, 1), None),
-		('num_mips', Uint, (0, None), (False, None), None),
-		('unk_pz', Uint64, (0, None), (True, 0), True),
-		('mip_maps', Array, (0, None, (None,), Mipmap), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('zero', Uint64, (0, None), (True, 0), None)
+		yield ('data_size', Uint, (0, None), (False, None), None)
+		yield ('width', Uint, (0, None), (False, None), None)
+		yield ('height', Uint, (0, None), (False, None), None)
+		yield ('depth', Uint, (0, None), (True, 1), None)
+		yield ('num_tiles', Uint, (0, None), (True, 1), None)
+		yield ('num_mips', Uint, (0, None), (False, None), None)
+		yield ('unk_pz', Uint64, (0, None), (True, 0), True)
+		yield ('mip_maps', Array, (0, None, (None,), Mipmap), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -70,3 +71,6 @@ class SizeInfoRaw(MemStruct):
 		if instance.context.version >= 20:
 			yield 'unk_pz', Uint64, (0, None), (True, 0)
 		yield 'mip_maps', Array, (0, None, (instance.num_mips,), Mipmap), (False, None)
+
+
+SizeInfoRaw.init_attributes()

--- a/generated/formats/tex/compounds/TexBuffer.py
+++ b/generated/formats/tex/compounds/TexBuffer.py
@@ -35,14 +35,15 @@ class TexBuffer(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('offset', Uint64, (0, None), (False, None), None),
-		('size', Uint64, (0, None), (False, None), None),
-		('first_mip', Ubyte, (0, None), (False, None), None),
-		('mip_count', Ubyte, (0, None), (False, None), None),
-		('padding_0', Short, (0, None), (True, 0), None),
-		('padding_1', Int, (0, None), (True, 0), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('offset', Uint64, (0, None), (False, None), None)
+		yield ('size', Uint64, (0, None), (False, None), None)
+		yield ('first_mip', Ubyte, (0, None), (False, None), None)
+		yield ('mip_count', Ubyte, (0, None), (False, None), None)
+		yield ('padding_0', Short, (0, None), (True, 0), None)
+		yield ('padding_1', Int, (0, None), (True, 0), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -53,3 +54,6 @@ class TexBuffer(MemStruct):
 		yield 'mip_count', Ubyte, (0, None), (False, None)
 		yield 'padding_0', Short, (0, None), (True, 0)
 		yield 'padding_1', Int, (0, None), (True, 0)
+
+
+TexBuffer.init_attributes()

--- a/generated/formats/tex/compounds/TexBufferPc.py
+++ b/generated/formats/tex/compounds/TexBufferPc.py
@@ -25,12 +25,13 @@ class TexBufferPc(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('width', Ushort, (0, None), (False, None), None),
-		('height', Ushort, (0, None), (False, None), None),
-		('num_tiles', Ushort, (0, None), (False, None), True),
-		('num_mips', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('width', Ushort, (0, None), (False, None), None)
+		yield ('height', Ushort, (0, None), (False, None), None)
+		yield ('num_tiles', Ushort, (0, None), (False, None), True)
+		yield ('num_mips', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -40,3 +41,6 @@ class TexBufferPc(MemStruct):
 		if instance.context.version >= 18:
 			yield 'num_tiles', Ushort, (0, None), (False, None)
 		yield 'num_mips', Ushort, (0, None), (False, None)
+
+
+TexBufferPc.init_attributes()

--- a/generated/formats/tex/compounds/TexHeader.py
+++ b/generated/formats/tex/compounds/TexHeader.py
@@ -47,24 +47,25 @@ class TexHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('zero_0', Uint, (0, None), (True, 0), True),
-		('zero_0', Uint64, (0, None), (True, 0), True),
-		('zero_1', Uint64, (0, None), (True, 0), True),
-		('buffer_infos', ArrayPointer, (None, None), (False, None), True),
-		('buffer_infos', ArrayPointer, (None, None), (False, None), True),
-		('size_info', Pointer, (0, None), (False, None), True),
-		('compression_type', DdsTypeCoaster, (0, None), (False, None), True),
-		('compression_type', DdsType, (0, None), (False, None), True),
-		('one_0', Ubyte, (0, None), (False, None), None),
-		('num_mips', Ushort, (0, None), (False, None), True),
-		('width', Ushort, (0, None), (False, None), True),
-		('height', Ushort, (0, None), (False, None), True),
-		('stream_count', Ubyte, (0, None), (False, None), True),
-		('stream_count_repeat', Ubyte, (0, None), (False, None), True),
-		('pad', Uint, (0, None), (True, 0), None),
-		('pad_dla', Uint64, (0, None), (True, 0), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('zero_0', Uint, (0, None), (True, 0), True)
+		yield ('zero_0', Uint64, (0, None), (True, 0), True)
+		yield ('zero_1', Uint64, (0, None), (True, 0), True)
+		yield ('buffer_infos', ArrayPointer, (None, None), (False, None), True)
+		yield ('buffer_infos', ArrayPointer, (None, None), (False, None), True)
+		yield ('size_info', Pointer, (0, None), (False, None), True)
+		yield ('compression_type', DdsTypeCoaster, (0, None), (False, None), True)
+		yield ('compression_type', DdsType, (0, None), (False, None), True)
+		yield ('one_0', Ubyte, (0, None), (False, None), None)
+		yield ('num_mips', Ushort, (0, None), (False, None), True)
+		yield ('width', Ushort, (0, None), (False, None), True)
+		yield ('height', Ushort, (0, None), (False, None), True)
+		yield ('stream_count', Ubyte, (0, None), (False, None), True)
+		yield ('stream_count_repeat', Ubyte, (0, None), (False, None), True)
+		yield ('pad', Uint, (0, None), (True, 0), None)
+		yield ('pad_dla', Uint64, (0, None), (True, 0), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -95,3 +96,6 @@ class TexHeader(MemStruct):
 		yield 'pad', Uint, (0, None), (True, 0)
 		if instance.context.version <= 15:
 			yield 'pad_dla', Uint64, (0, None), (True, 0)
+
+
+TexHeader.init_attributes()

--- a/generated/formats/tex/compounds/TexturestreamHeader.py
+++ b/generated/formats/tex/compounds/TexturestreamHeader.py
@@ -20,10 +20,11 @@ class TexturestreamHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('zero', Uint64, (0, None), (True, 0), None),
-		('lod_index', Uint64, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('zero', Uint64, (0, None), (True, 0), None)
+		yield ('lod_index', Uint64, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -31,3 +32,6 @@ class TexturestreamHeader(MemStruct):
 		yield 'zero', Uint64, (0, None), (True, 0)
 		if instance.context.user_version.use_djb and (instance.context.version == 20):
 			yield 'lod_index', Uint64, (0, None), (False, None)
+
+
+TexturestreamHeader.init_attributes()

--- a/generated/formats/texatlas/compounds/AtlasItem.py
+++ b/generated/formats/texatlas/compounds/AtlasItem.py
@@ -25,16 +25,17 @@ class AtlasItem(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('atlas_name', Pointer, (0, ZString), (False, None), None),
-		('startx', Float, (0, None), (False, None), None),
-		('starty', Float, (0, None), (False, None), None),
-		('endx', Float, (0, None), (False, None), None),
-		('endy', Float, (0, None), (False, None), None),
-		('layer', Uint, (0, None), (False, None), None),
-		('flags_1', Ushort, (0, None), (False, None), None),
-		('flags_2', Ushort, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('atlas_name', Pointer, (0, ZString), (False, None), None)
+		yield ('startx', Float, (0, None), (False, None), None)
+		yield ('starty', Float, (0, None), (False, None), None)
+		yield ('endx', Float, (0, None), (False, None), None)
+		yield ('endy', Float, (0, None), (False, None), None)
+		yield ('layer', Uint, (0, None), (False, None), None)
+		yield ('flags_1', Ushort, (0, None), (False, None), None)
+		yield ('flags_2', Ushort, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -47,3 +48,6 @@ class AtlasItem(MemStruct):
 		yield 'layer', Uint, (0, None), (False, None)
 		yield 'flags_1', Ushort, (0, None), (False, None)
 		yield 'flags_2', Ushort, (0, None), (False, None)
+
+
+AtlasItem.init_attributes()

--- a/generated/formats/texatlas/compounds/TexAtlasRoot.py
+++ b/generated/formats/texatlas/compounds/TexAtlasRoot.py
@@ -18,12 +18,13 @@ class TexAtlasRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('texture_list', ArrayPointer, (None, None), (False, None), None),
-		('texture_count', Uint64, (0, None), (False, None), None),
-		('atlas_list', ArrayPointer, (None, None), (False, None), None),
-		('atlas_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('texture_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('texture_count', Uint64, (0, None), (False, None), None)
+		yield ('atlas_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('atlas_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -32,3 +33,6 @@ class TexAtlasRoot(MemStruct):
 		yield 'texture_count', Uint64, (0, None), (False, None)
 		yield 'atlas_list', ArrayPointer, (instance.atlas_count, TexAtlasRoot._import_map["texatlas.compounds.AtlasItem"]), (False, None)
 		yield 'atlas_count', Uint64, (0, None), (False, None)
+
+
+TexAtlasRoot.init_attributes()

--- a/generated/formats/texatlas/compounds/TextureData.py
+++ b/generated/formats/texatlas/compounds/TextureData.py
@@ -18,13 +18,17 @@ class TextureData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('atlas_name', Pointer, (0, ZString), (False, None), None),
-		('dependency_name', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('atlas_name', Pointer, (0, ZString), (False, None), None)
+		yield ('dependency_name', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'atlas_name', Pointer, (0, ZString), (False, None)
 		yield 'dependency_name', Pointer, (0, None), (False, None)
+
+
+TextureData.init_attributes()

--- a/generated/formats/trackedridecar/compounds/TrackedRideCarRoot.py
+++ b/generated/formats/trackedridecar/compounds/TrackedRideCarRoot.py
@@ -31,15 +31,16 @@ class TrackedRideCarRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('sub', ArrayPointer, (None, None), (False, None), None),
-		('sub_count', Uint, (0, None), (False, None), None),
-		('total_vecs_count', Uint, (0, None), (False, None), None),
-		('vec', Array, (0, None, (3,), Float), (False, None), None),
-		('zero_0', Uint, (0, None), (False, None), None),
-		('some_name', Pointer, (0, ZString), (False, None), None),
-		('zero_1', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('sub', ArrayPointer, (None, None), (False, None), None)
+		yield ('sub_count', Uint, (0, None), (False, None), None)
+		yield ('total_vecs_count', Uint, (0, None), (False, None), None)
+		yield ('vec', Array, (0, None, (3,), Float), (False, None), None)
+		yield ('zero_0', Uint, (0, None), (False, None), None)
+		yield ('some_name', Pointer, (0, ZString), (False, None), None)
+		yield ('zero_1', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -51,3 +52,6 @@ class TrackedRideCarRoot(MemStruct):
 		yield 'zero_0', Uint, (0, None), (False, None)
 		yield 'some_name', Pointer, (0, ZString), (False, None)
 		yield 'zero_1', Uint64, (0, None), (False, None)
+
+
+TrackedRideCarRoot.init_attributes()

--- a/generated/formats/trackedridecar/compounds/TrackedRideCarSub.py
+++ b/generated/formats/trackedridecar/compounds/TrackedRideCarSub.py
@@ -25,13 +25,14 @@ class TrackedRideCarSub(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('float', Float, (0, None), (False, None), None),
-		('u_0', Uint, (0, None), (False, None), None),
-		('vectors', ArrayPointer, (None, None), (False, None), None),
-		('vecs_count', Uint64, (0, None), (False, None), None),
-		('zero_1', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('float', Float, (0, None), (False, None), None)
+		yield ('u_0', Uint, (0, None), (False, None), None)
+		yield ('vectors', ArrayPointer, (None, None), (False, None), None)
+		yield ('vecs_count', Uint64, (0, None), (False, None), None)
+		yield ('zero_1', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -41,3 +42,6 @@ class TrackedRideCarSub(MemStruct):
 		yield 'vectors', ArrayPointer, (instance.vecs_count, TrackedRideCarSub._import_map["trackedridecar.compounds.Vector3"]), (False, None)
 		yield 'vecs_count', Uint64, (0, None), (False, None)
 		yield 'zero_1', Uint64, (0, None), (False, None)
+
+
+TrackedRideCarSub.init_attributes()

--- a/generated/formats/trackedridecar/compounds/Vector3.py
+++ b/generated/formats/trackedridecar/compounds/Vector3.py
@@ -20,11 +20,15 @@ class Vector3(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('floats', Array, (0, None, (3,), Float), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('floats', Array, (0, None, (3,), Float), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'floats', Array, (0, None, (3,), Float), (False, None)
+
+
+Vector3.init_attributes()

--- a/generated/formats/trackelement/compounds/TrackElementData.py
+++ b/generated/formats/trackelement/compounds/TrackElementData.py
@@ -36,21 +36,22 @@ class TrackElementData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('loop_name', Pointer, (0, ZString), (False, None), None),
-		('ovl_name', Pointer, (0, ZString), (False, None), None),
-		('catwalk', Pointer, (0, None), (False, None), True),
-		('unk_0', Uint64, (0, None), (False, None), True),
-		('optional_catwalk', Pointer, (0, ZString), (False, None), None),
-		('unk_1', Uint, (0, None), (False, None), True),
-		('unk_2', Uint, (0, None), (False, None), None),
-		('unk_3', Ushort, (0, None), (False, 0), None),
-		('unk_4', Ushort, (0, None), (False, 32), None),
-		('unk_5', Uint, (0, None), (False, 1024), True),
-		('unk_6', Uint, (0, None), (False, 1), None),
-		('unk_7', Uint, (0, None), (False, 1), None),
-		('pad', Uint64, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('loop_name', Pointer, (0, ZString), (False, None), None)
+		yield ('ovl_name', Pointer, (0, ZString), (False, None), None)
+		yield ('catwalk', Pointer, (0, None), (False, None), True)
+		yield ('unk_0', Uint64, (0, None), (False, None), True)
+		yield ('optional_catwalk', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_1', Uint, (0, None), (False, None), True)
+		yield ('unk_2', Uint, (0, None), (False, None), None)
+		yield ('unk_3', Ushort, (0, None), (False, 0), None)
+		yield ('unk_4', Ushort, (0, None), (False, 32), None)
+		yield ('unk_5', Uint, (0, None), (False, 1024), True)
+		yield ('unk_6', Uint, (0, None), (False, 1), None)
+		yield ('unk_7', Uint, (0, None), (False, 1), None)
+		yield ('pad', Uint64, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -72,3 +73,6 @@ class TrackElementData(MemStruct):
 		yield 'unk_7', Uint, (0, None), (False, 1)
 		if instance.arg < 2:
 			yield 'pad', Uint64, (0, None), (False, None)
+
+
+TrackElementData.init_attributes()

--- a/generated/formats/trackelement/compounds/TrackElementRoot.py
+++ b/generated/formats/trackelement/compounds/TrackElementRoot.py
@@ -24,12 +24,13 @@ class TrackElementRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('track_data', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		('unk_string_1', Pointer, (0, ZString), (False, None), None),
-		('unk_string_2', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('track_data', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
+		yield ('unk_string_1', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_string_2', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class TrackElementRoot(MemStruct):
 		yield 'count', Uint64, (0, None), (False, None)
 		yield 'unk_string_1', Pointer, (0, ZString), (False, None)
 		yield 'unk_string_2', Pointer, (0, ZString), (False, None)
+
+
+TrackElementRoot.init_attributes()

--- a/generated/formats/trackelement/compounds/TrackElementSub.py
+++ b/generated/formats/trackelement/compounds/TrackElementSub.py
@@ -23,12 +23,13 @@ class TrackElementSub(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('catwalk_right_lsm', Pointer, (0, ZString), (False, None), None),
-		('catwalk_left_lsm', Pointer, (0, ZString), (False, None), None),
-		('catwalk_both_lsm', Pointer, (0, ZString), (False, None), None),
-		('unk_0', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('catwalk_right_lsm', Pointer, (0, ZString), (False, None), None)
+		yield ('catwalk_left_lsm', Pointer, (0, ZString), (False, None), None)
+		yield ('catwalk_both_lsm', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_0', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -37,3 +38,6 @@ class TrackElementSub(MemStruct):
 		yield 'catwalk_left_lsm', Pointer, (0, ZString), (False, None)
 		yield 'catwalk_both_lsm', Pointer, (0, ZString), (False, None)
 		yield 'unk_0', Uint64, (0, None), (False, None)
+
+
+TrackElementSub.init_attributes()

--- a/generated/formats/trackmesh/compounds/LastData.py
+++ b/generated/formats/trackmesh/compounds/LastData.py
@@ -34,23 +34,24 @@ class LastData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('some_name', Pointer, (0, ZString), (False, None), None),
-		('p_1', Pointer, (0, None), (False, None), None),
-		('p_1_count', Uint64, (0, None), (False, None), None),
-		('b', Uint64, (0, None), (False, None), None),
-		('c', Uint64, (0, None), (False, None), None),
-		('p_2', Pointer, (0, None), (False, None), None),
-		('p_2_count', Uint64, (0, None), (False, None), None),
-		('p_3', Pointer, (0, None), (False, None), None),
-		('p_3_count', Uint64, (0, None), (False, None), None),
-		('f', Uint64, (0, None), (False, None), None),
-		('g', Uint64, (0, None), (False, None), None),
-		('p_4', Pointer, (0, None), (False, None), None),
-		('p_4_count', Uint64, (0, None), (False, None), None),
-		('p_5', Pointer, (0, None), (False, None), None),
-		('p_5_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('some_name', Pointer, (0, ZString), (False, None), None)
+		yield ('p_1', Pointer, (0, None), (False, None), None)
+		yield ('p_1_count', Uint64, (0, None), (False, None), None)
+		yield ('b', Uint64, (0, None), (False, None), None)
+		yield ('c', Uint64, (0, None), (False, None), None)
+		yield ('p_2', Pointer, (0, None), (False, None), None)
+		yield ('p_2_count', Uint64, (0, None), (False, None), None)
+		yield ('p_3', Pointer, (0, None), (False, None), None)
+		yield ('p_3_count', Uint64, (0, None), (False, None), None)
+		yield ('f', Uint64, (0, None), (False, None), None)
+		yield ('g', Uint64, (0, None), (False, None), None)
+		yield ('p_4', Pointer, (0, None), (False, None), None)
+		yield ('p_4_count', Uint64, (0, None), (False, None), None)
+		yield ('p_5', Pointer, (0, None), (False, None), None)
+		yield ('p_5_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -70,3 +71,6 @@ class LastData(MemStruct):
 		yield 'p_4_count', Uint64, (0, None), (False, None)
 		yield 'p_5', Pointer, (0, None), (False, None)
 		yield 'p_5_count', Uint64, (0, None), (False, None)
+
+
+LastData.init_attributes()

--- a/generated/formats/trackmesh/compounds/Lod.py
+++ b/generated/formats/trackmesh/compounds/Lod.py
@@ -22,12 +22,13 @@ class Lod(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('a', Uint, (0, None), (False, None), None),
-		('b', Uint, (0, None), (False, None), None),
-		('c', Uint, (0, None), (False, None), None),
-		('distance', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('a', Uint, (0, None), (False, None), None)
+		yield ('b', Uint, (0, None), (False, None), None)
+		yield ('c', Uint, (0, None), (False, None), None)
+		yield ('distance', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class Lod(MemStruct):
 		yield 'b', Uint, (0, None), (False, None)
 		yield 'c', Uint, (0, None), (False, None)
 		yield 'distance', Float, (0, None), (False, None)
+
+
+Lod.init_attributes()

--- a/generated/formats/trackmesh/compounds/OffsetData.py
+++ b/generated/formats/trackmesh/compounds/OffsetData.py
@@ -33,19 +33,20 @@ class OffsetData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('offset_id', Pointer, (0, ZString), (False, None), None),
-		('z_0', Uint64, (0, None), (False, None), None),
-		('z_1', Uint64, (0, None), (False, None), None),
-		('relative_offset', Vector3, (0, None), (False, None), None),
-		('spacing', Float, (0, None), (False, None), None),
-		('one', Uint, (0, None), (False, None), None),
-		('z_2', Uint, (0, None), (False, None), None),
-		('z_3', Uint, (0, None), (False, None), None),
-		('count', Uint, (0, None), (False, None), None),
-		('z_4', Uint, (0, None), (False, None), None),
-		('z_5', Uint, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('offset_id', Pointer, (0, ZString), (False, None), None)
+		yield ('z_0', Uint64, (0, None), (False, None), None)
+		yield ('z_1', Uint64, (0, None), (False, None), None)
+		yield ('relative_offset', Vector3, (0, None), (False, None), None)
+		yield ('spacing', Float, (0, None), (False, None), None)
+		yield ('one', Uint, (0, None), (False, None), None)
+		yield ('z_2', Uint, (0, None), (False, None), None)
+		yield ('z_3', Uint, (0, None), (False, None), None)
+		yield ('count', Uint, (0, None), (False, None), None)
+		yield ('z_4', Uint, (0, None), (False, None), None)
+		yield ('z_5', Uint, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -61,3 +62,6 @@ class OffsetData(MemStruct):
 		yield 'count', Uint, (0, None), (False, None)
 		yield 'z_4', Uint, (0, None), (False, None)
 		yield 'z_5', Uint, (0, None), (False, None)
+
+
+OffsetData.init_attributes()

--- a/generated/formats/trackmesh/compounds/TrackData.py
+++ b/generated/formats/trackmesh/compounds/TrackData.py
@@ -27,15 +27,16 @@ class TrackData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('place_id', Pointer, (0, ZString), (False, None), None),
-		('file', Pointer, (0, ZString), (False, None), None),
-		('a', Uint, (0, None), (False, None), None),
-		('b', Uint, (0, None), (False, None), None),
-		('c', Uint64, (0, None), (False, None), None),
-		('offset_id', Pointer, (0, ZString), (False, None), None),
-		('d', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('place_id', Pointer, (0, ZString), (False, None), None)
+		yield ('file', Pointer, (0, ZString), (False, None), None)
+		yield ('a', Uint, (0, None), (False, None), None)
+		yield ('b', Uint, (0, None), (False, None), None)
+		yield ('c', Uint64, (0, None), (False, None), None)
+		yield ('offset_id', Pointer, (0, ZString), (False, None), None)
+		yield ('d', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -47,3 +48,6 @@ class TrackData(MemStruct):
 		yield 'c', Uint64, (0, None), (False, None)
 		yield 'offset_id', Pointer, (0, ZString), (False, None)
 		yield 'd', Uint64, (0, None), (False, None)
+
+
+TrackData.init_attributes()

--- a/generated/formats/trackmesh/compounds/TrackMeshRoot.py
+++ b/generated/formats/trackmesh/compounds/TrackMeshRoot.py
@@ -32,19 +32,20 @@ class TrackMeshRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('a', Uint64, (0, None), (False, None), None),
-		('offset_data', ArrayPointer, (None, None), (False, None), None),
-		('track_data', ArrayPointer, (None, None), (False, None), None),
-		('last', ArrayPointer, (None, None), (False, None), None),
-		('count_0', Uint, (0, None), (False, None), None),
-		('next_count', Uint, (0, None), (False, None), None),
-		('last_count', Uint64, (0, None), (False, None), None),
-		('lods', ArrayPointer, (None, None), (False, None), None),
-		('lod_count', Uint64, (0, None), (False, None), None),
-		('heatmap_name', Pointer, (0, ZString), (False, None), None),
-		('g', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('a', Uint64, (0, None), (False, None), None)
+		yield ('offset_data', ArrayPointer, (None, None), (False, None), None)
+		yield ('track_data', ArrayPointer, (None, None), (False, None), None)
+		yield ('last', ArrayPointer, (None, None), (False, None), None)
+		yield ('count_0', Uint, (0, None), (False, None), None)
+		yield ('next_count', Uint, (0, None), (False, None), None)
+		yield ('last_count', Uint64, (0, None), (False, None), None)
+		yield ('lods', ArrayPointer, (None, None), (False, None), None)
+		yield ('lod_count', Uint64, (0, None), (False, None), None)
+		yield ('heatmap_name', Pointer, (0, ZString), (False, None), None)
+		yield ('g', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -60,3 +61,6 @@ class TrackMeshRoot(MemStruct):
 		yield 'lod_count', Uint64, (0, None), (False, None)
 		yield 'heatmap_name', Pointer, (0, ZString), (False, None)
 		yield 'g', Uint64, (0, None), (False, None)
+
+
+TrackMeshRoot.init_attributes()

--- a/generated/formats/trackmesh/compounds/Vector3.py
+++ b/generated/formats/trackmesh/compounds/Vector3.py
@@ -26,11 +26,12 @@ class Vector3(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class Vector3(MemStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+Vector3.init_attributes()

--- a/generated/formats/trackstation/compounds/CommonChunk.py
+++ b/generated/formats/trackstation/compounds/CommonChunk.py
@@ -33,22 +33,23 @@ class CommonChunk(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('float_1', Float, (0, None), (False, None), None),
-		('float_2', Float, (0, None), (False, None), None),
-		('piece_name_0', Pointer, (0, ZString), (False, None), None),
-		('piece_name_1', Pointer, (0, ZString), (False, None), None),
-		('piece_name_2', Pointer, (0, ZString), (False, None), None),
-		('unk_flags_0', Array, (0, None, (8,), Ubyte), (False, None), None),
-		('piece_name_3', Pointer, (0, ZString), (False, None), None),
-		('piece_name_4', Pointer, (0, ZString), (False, None), None),
-		('piece_name_5', Pointer, (0, ZString), (False, None), None),
-		('unk_flags_1', Array, (0, None, (8,), Ubyte), (False, None), None),
-		('piece_name_6', Pointer, (0, ZString), (False, None), None),
-		('piece_name_7', Pointer, (0, ZString), (False, None), None),
-		('piece_name_8', Pointer, (0, ZString), (False, None), None),
-		('zero', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('float_1', Float, (0, None), (False, None), None)
+		yield ('float_2', Float, (0, None), (False, None), None)
+		yield ('piece_name_0', Pointer, (0, ZString), (False, None), None)
+		yield ('piece_name_1', Pointer, (0, ZString), (False, None), None)
+		yield ('piece_name_2', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_flags_0', Array, (0, None, (8,), Ubyte), (False, None), None)
+		yield ('piece_name_3', Pointer, (0, ZString), (False, None), None)
+		yield ('piece_name_4', Pointer, (0, ZString), (False, None), None)
+		yield ('piece_name_5', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_flags_1', Array, (0, None, (8,), Ubyte), (False, None), None)
+		yield ('piece_name_6', Pointer, (0, ZString), (False, None), None)
+		yield ('piece_name_7', Pointer, (0, ZString), (False, None), None)
+		yield ('piece_name_8', Pointer, (0, ZString), (False, None), None)
+		yield ('zero', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -67,3 +68,6 @@ class CommonChunk(MemStruct):
 		yield 'piece_name_7', Pointer, (0, ZString), (False, None)
 		yield 'piece_name_8', Pointer, (0, ZString), (False, None)
 		yield 'zero', Uint64, (0, None), (False, None)
+
+
+CommonChunk.init_attributes()

--- a/generated/formats/trackstation/compounds/FirstPointersa.py
+++ b/generated/formats/trackstation/compounds/FirstPointersa.py
@@ -22,12 +22,13 @@ class FirstPointersa(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('pointer_stuff_1', CommonChunk, (0, None), (False, None), None),
-		('pointer_stuff_2', CommonChunk, (0, None), (False, None), None),
-		('pointer_stuff_3', CommonChunk, (0, None), (False, None), None),
-		('zero', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('pointer_stuff_1', CommonChunk, (0, None), (False, None), None)
+		yield ('pointer_stuff_2', CommonChunk, (0, None), (False, None), None)
+		yield ('pointer_stuff_3', CommonChunk, (0, None), (False, None), None)
+		yield ('zero', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -36,3 +37,6 @@ class FirstPointersa(MemStruct):
 		yield 'pointer_stuff_2', CommonChunk, (0, None), (False, None)
 		yield 'pointer_stuff_3', CommonChunk, (0, None), (False, None)
 		yield 'zero', Uint64, (0, None), (False, None)
+
+
+FirstPointersa.init_attributes()

--- a/generated/formats/trackstation/compounds/FirstPointersb.py
+++ b/generated/formats/trackstation/compounds/FirstPointersb.py
@@ -20,13 +20,17 @@ class FirstPointersb(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('pointer_stuff', CommonChunk, (0, None), (False, None), None),
-		('zero', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('pointer_stuff', CommonChunk, (0, None), (False, None), None)
+		yield ('zero', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'pointer_stuff', CommonChunk, (0, None), (False, None)
 		yield 'zero', Uint64, (0, None), (False, None)
+
+
+FirstPointersb.init_attributes()

--- a/generated/formats/trackstation/compounds/TrackStationRoot.py
+++ b/generated/formats/trackstation/compounds/TrackStationRoot.py
@@ -37,23 +37,24 @@ class TrackStationRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('unk_floats', Array, (0, None, (2,), Float), (False, None), None),
-		('unk_ints', Array, (0, None, (2,), Uint), (False, None), None),
-		('some_dataa', Pointer, (0, None), (False, None), None),
-		('some_datab', Pointer, (0, None), (False, None), None),
-		('stationpiece_name_0', Pointer, (0, ZString), (False, None), None),
-		('stationpiece_name_1', Pointer, (0, ZString), (False, None), None),
-		('stationpiece_name_2', Pointer, (0, ZString), (False, None), None),
-		('stationpiece_name_3', Pointer, (0, ZString), (False, None), None),
-		('stationpiece_name_4', Pointer, (0, ZString), (False, None), None),
-		('unk_ints_2', Array, (0, None, (2,), Uint), (False, None), None),
-		('stationpiece_name_5', Pointer, (0, ZString), (False, None), None),
-		('stationpiece_name_6', Pointer, (0, ZString), (False, None), None),
-		('stationpiece_name_7', Pointer, (0, ZString), (False, None), None),
-		('unk_floats_2', Array, (0, None, (4,), Float), (False, None), None),
-		('unk_ints_3', Array, (0, None, (2,), Uint), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('unk_floats', Array, (0, None, (2,), Float), (False, None), None)
+		yield ('unk_ints', Array, (0, None, (2,), Uint), (False, None), None)
+		yield ('some_dataa', Pointer, (0, None), (False, None), None)
+		yield ('some_datab', Pointer, (0, None), (False, None), None)
+		yield ('stationpiece_name_0', Pointer, (0, ZString), (False, None), None)
+		yield ('stationpiece_name_1', Pointer, (0, ZString), (False, None), None)
+		yield ('stationpiece_name_2', Pointer, (0, ZString), (False, None), None)
+		yield ('stationpiece_name_3', Pointer, (0, ZString), (False, None), None)
+		yield ('stationpiece_name_4', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_ints_2', Array, (0, None, (2,), Uint), (False, None), None)
+		yield ('stationpiece_name_5', Pointer, (0, ZString), (False, None), None)
+		yield ('stationpiece_name_6', Pointer, (0, ZString), (False, None), None)
+		yield ('stationpiece_name_7', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_floats_2', Array, (0, None, (4,), Float), (False, None), None)
+		yield ('unk_ints_3', Array, (0, None, (2,), Uint), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -73,3 +74,6 @@ class TrackStationRoot(MemStruct):
 		yield 'stationpiece_name_7', Pointer, (0, ZString), (False, None)
 		yield 'unk_floats_2', Array, (0, None, (4,), Float), (False, None)
 		yield 'unk_ints_3', Array, (0, None, (2,), Uint), (False, None)
+
+
+TrackStationRoot.init_attributes()

--- a/generated/formats/trackstation/compounds/Vector3.py
+++ b/generated/formats/trackstation/compounds/Vector3.py
@@ -26,11 +26,12 @@ class Vector3(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class Vector3(MemStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+Vector3.init_attributes()

--- a/generated/formats/uimoviedefinition/compounds/PtrList.py
+++ b/generated/formats/uimoviedefinition/compounds/PtrList.py
@@ -16,11 +16,15 @@ class PtrList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, ZString, (instance.arg,), Pointer), (False, None)
+
+
+PtrList.init_attributes()

--- a/generated/formats/uimoviedefinition/compounds/UiMovieHeader.py
+++ b/generated/formats/uimoviedefinition/compounds/UiMovieHeader.py
@@ -51,38 +51,39 @@ class UiMovieHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('movie_name', Pointer, (0, ZString), (False, None), None),
-		('pkg_name', Pointer, (0, ZString), (False, None), None),
-		('category_name', Pointer, (0, ZString), (False, None), None),
-		('type_name', Pointer, (0, ZString), (False, None), None),
-		('flag_1', Uint, (0, None), (False, None), None),
-		('flag_2', Ushort, (0, None), (False, None), None),
-		('flag_3', Ushort, (0, None), (False, None), None),
-		('floats', Array, (0, None, (3,), Float), (False, None), None),
-		('u_0', Ubyte, (0, None), (False, None), None),
-		('num_ui_triggers', Ubyte, (0, None), (False, None), None),
-		('u_1', Ubyte, (0, None), (False, None), None),
-		('num_ui_names', Ubyte, (0, None), (False, None), None),
-		('num_assetpkgs', Ubyte, (0, None), (False, None), None),
-		('u_2', Ubyte, (0, None), (False, None), None),
-		('num_list_1', Ubyte, (0, None), (False, None), None),
-		('num_list_2', Ubyte, (0, None), (False, None), None),
-		('num_ui_interfaces', Ubyte, (0, None), (False, None), None),
-		('u_3', Ubyte, (0, None), (False, None), None),
-		('u_4', Ubyte, (0, None), (False, None), None),
-		('u_5', Ubyte, (0, None), (False, None), None),
-		('ptr_0', Pointer, (0, None), (False, None), None),
-		('ui_triggers', Pointer, (None, None), (False, None), None),
-		('ptr_1', Pointer, (0, None), (False, None), None),
-		('ui_names', Pointer, (None, None), (False, None), None),
-		('assetpkgs', Pointer, (None, None), (False, None), None),
-		('ptr_2', Pointer, (0, None), (False, None), None),
-		('list_1', ArrayPointer, (None, Uint), (False, None), None),
-		('list_2', ArrayPointer, (None, Uint), (False, None), None),
-		('ui_interfaces', Pointer, (None, None), (False, None), None),
-		('ptr_3', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('movie_name', Pointer, (0, ZString), (False, None), None)
+		yield ('pkg_name', Pointer, (0, ZString), (False, None), None)
+		yield ('category_name', Pointer, (0, ZString), (False, None), None)
+		yield ('type_name', Pointer, (0, ZString), (False, None), None)
+		yield ('flag_1', Uint, (0, None), (False, None), None)
+		yield ('flag_2', Ushort, (0, None), (False, None), None)
+		yield ('flag_3', Ushort, (0, None), (False, None), None)
+		yield ('floats', Array, (0, None, (3,), Float), (False, None), None)
+		yield ('u_0', Ubyte, (0, None), (False, None), None)
+		yield ('num_ui_triggers', Ubyte, (0, None), (False, None), None)
+		yield ('u_1', Ubyte, (0, None), (False, None), None)
+		yield ('num_ui_names', Ubyte, (0, None), (False, None), None)
+		yield ('num_assetpkgs', Ubyte, (0, None), (False, None), None)
+		yield ('u_2', Ubyte, (0, None), (False, None), None)
+		yield ('num_list_1', Ubyte, (0, None), (False, None), None)
+		yield ('num_list_2', Ubyte, (0, None), (False, None), None)
+		yield ('num_ui_interfaces', Ubyte, (0, None), (False, None), None)
+		yield ('u_3', Ubyte, (0, None), (False, None), None)
+		yield ('u_4', Ubyte, (0, None), (False, None), None)
+		yield ('u_5', Ubyte, (0, None), (False, None), None)
+		yield ('ptr_0', Pointer, (0, None), (False, None), None)
+		yield ('ui_triggers', Pointer, (None, None), (False, None), None)
+		yield ('ptr_1', Pointer, (0, None), (False, None), None)
+		yield ('ui_names', Pointer, (None, None), (False, None), None)
+		yield ('assetpkgs', Pointer, (None, None), (False, None), None)
+		yield ('ptr_2', Pointer, (0, None), (False, None), None)
+		yield ('list_1', ArrayPointer, (None, Uint), (False, None), None)
+		yield ('list_2', ArrayPointer, (None, Uint), (False, None), None)
+		yield ('ui_interfaces', Pointer, (None, None), (False, None), None)
+		yield ('ptr_3', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -117,3 +118,6 @@ class UiMovieHeader(MemStruct):
 		yield 'list_2', ArrayPointer, (instance.num_list_2, Uint), (False, None)
 		yield 'ui_interfaces', Pointer, (instance.num_ui_interfaces, UiMovieHeader._import_map["uimoviedefinition.compounds.PtrList"]), (False, None)
 		yield 'ptr_3', Pointer, (0, None), (False, None)
+
+
+UiMovieHeader.init_attributes()

--- a/generated/formats/userinterfaceicondata/compounds/UserinterfaceicondataRoot.py
+++ b/generated/formats/userinterfaceicondata/compounds/UserinterfaceicondataRoot.py
@@ -16,13 +16,17 @@ class UserinterfaceicondataRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('tex_name', Pointer, (0, ZString), (False, None), None),
-		('ovl_name', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('tex_name', Pointer, (0, ZString), (False, None), None)
+		yield ('ovl_name', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'tex_name', Pointer, (0, ZString), (False, None)
 		yield 'ovl_name', Pointer, (0, ZString), (False, None)
+
+
+UserinterfaceicondataRoot.init_attributes()

--- a/generated/formats/voxelskirt/compounds/Area.py
+++ b/generated/formats/voxelskirt/compounds/Area.py
@@ -24,13 +24,14 @@ class Area(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('_id', Uint64, (0, None), (False, None), None),
-		('width_1', Uint64, (0, None), (False, None), None),
-		('height_1', Uint64, (0, None), (False, None), None),
-		('width_2', Uint64, (0, None), (False, None), None),
-		('height_2', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('_id', Uint64, (0, None), (False, None), None)
+		yield ('width_1', Uint64, (0, None), (False, None), None)
+		yield ('height_1', Uint64, (0, None), (False, None), None)
+		yield ('width_2', Uint64, (0, None), (False, None), None)
+		yield ('height_2', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -40,3 +41,6 @@ class Area(BaseStruct):
 		yield 'height_1', Uint64, (0, None), (False, None)
 		yield 'width_2', Uint64, (0, None), (False, None)
 		yield 'height_2', Uint64, (0, None), (False, None)
+
+
+Area.init_attributes()

--- a/generated/formats/voxelskirt/compounds/DataSlot.py
+++ b/generated/formats/voxelskirt/compounds/DataSlot.py
@@ -25,10 +25,11 @@ class DataSlot(BaseStruct):
 
 	_import_key = 'voxelskirt.compounds.DataSlot'
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('_offset', Uint64, (0, None), (False, None), None),
-		('_count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('_offset', Uint64, (0, None), (False, None), None)
+		yield ('_count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -74,3 +75,6 @@ class DataSlot(BaseStruct):
 		instance.data = Array._from_xml(arr, sub)
 		return instance
 
+
+
+DataSlot.init_attributes()

--- a/generated/formats/voxelskirt/compounds/EntityGroup.py
+++ b/generated/formats/voxelskirt/compounds/EntityGroup.py
@@ -24,13 +24,17 @@ class EntityGroup(Material):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = Material._attribute_list + [
-		('ff', Int, (0, None), (False, None), None),
-		('ff_or_zero', Int, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ff', Int, (0, None), (False, None), None)
+		yield ('ff_or_zero', Int, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ff', Int, (0, None), (False, None)
 		yield 'ff_or_zero', Int, (0, None), (False, None)
+
+
+EntityGroup.init_attributes()

--- a/generated/formats/voxelskirt/compounds/EntityInstance.py
+++ b/generated/formats/voxelskirt/compounds/EntityInstance.py
@@ -20,13 +20,17 @@ class EntityInstance(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('loc', Vector3F, (0, None), (False, None), None),
-		('z_rot', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('loc', Vector3F, (0, None), (False, None), None)
+		yield ('z_rot', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'loc', Vector3F, (0, None), (False, None)
 		yield 'z_rot', Float, (0, None), (False, None)
+
+
+EntityInstance.init_attributes()

--- a/generated/formats/voxelskirt/compounds/Layer.py
+++ b/generated/formats/voxelskirt/compounds/Layer.py
@@ -29,12 +29,13 @@ class Layer(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('_id', Uint64, (0, None), (False, None), None),
-		('dtype', VxlDtype, (0, None), (False, None), None),
-		('_offset', Uint64, (0, None), (False, None), None),
-		('_data_size', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('_id', Uint64, (0, None), (False, None), None)
+		yield ('dtype', VxlDtype, (0, None), (False, None), None)
+		yield ('_offset', Uint64, (0, None), (False, None), None)
+		yield ('_data_size', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -43,3 +44,6 @@ class Layer(BaseStruct):
 		yield 'dtype', VxlDtype, (0, None), (False, None)
 		yield '_offset', Uint64, (0, None), (False, None)
 		yield '_data_size', Uint64, (0, None), (False, None)
+
+
+Layer.init_attributes()

--- a/generated/formats/voxelskirt/compounds/Material.py
+++ b/generated/formats/voxelskirt/compounds/Material.py
@@ -22,13 +22,17 @@ class Material(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('entity_instances', DataSlot, (0, None), (False, None), None),
-		('_id', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('entity_instances', DataSlot, (0, None), (False, None), None)
+		yield ('_id', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'entity_instances', DataSlot, (0, Material._import_map["voxelskirt.compounds.EntityInstance"]), (False, None)
 		yield '_id', Uint64, (0, None), (False, None)
+
+
+Material.init_attributes()

--- a/generated/formats/voxelskirt/compounds/Name.py
+++ b/generated/formats/voxelskirt/compounds/Name.py
@@ -16,11 +16,15 @@ class Name(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('_offset', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('_offset', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield '_offset', Uint64, (0, None), (False, None)
+
+
+Name.init_attributes()

--- a/generated/formats/voxelskirt/compounds/Vector3F.py
+++ b/generated/formats/voxelskirt/compounds/Vector3F.py
@@ -16,11 +16,12 @@ class Vector3F(BaseStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = BaseStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -28,3 +29,6 @@ class Vector3F(BaseStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+Vector3F.init_attributes()

--- a/generated/formats/voxelskirt/compounds/VoxelskirtRoot.py
+++ b/generated/formats/voxelskirt/compounds/VoxelskirtRoot.py
@@ -42,21 +42,22 @@ class VoxelskirtRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('zero', Uint64, (0, None), (True, 0), None),
-		('_data_size', Uint64, (0, None), (False, None), None),
-		('x', Uint64, (0, None), (False, None), None),
-		('y', Uint64, (0, None), (False, None), None),
-		('scale', Float, (0, None), (False, None), None),
-		('padding', Uint, (0, None), (True, 0), None),
-		('_height_offset', Uint64, (0, None), (False, None), True),
-		('_weights_offset', Uint64, (0, None), (False, None), True),
-		('layers', DataSlot, (0, None), (False, None), True),
-		('areas', DataSlot, (0, None), (False, None), True),
-		('entity_groups', DataSlot, (0, None), (False, None), None),
-		('materials', DataSlot, (0, None), (False, None), None),
-		('names', DataSlot, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('zero', Uint64, (0, None), (True, 0), None)
+		yield ('_data_size', Uint64, (0, None), (False, None), None)
+		yield ('x', Uint64, (0, None), (False, None), None)
+		yield ('y', Uint64, (0, None), (False, None), None)
+		yield ('scale', Float, (0, None), (False, None), None)
+		yield ('padding', Uint, (0, None), (True, 0), None)
+		yield ('_height_offset', Uint64, (0, None), (False, None), True)
+		yield ('_weights_offset', Uint64, (0, None), (False, None), True)
+		yield ('layers', DataSlot, (0, None), (False, None), True)
+		yield ('areas', DataSlot, (0, None), (False, None), True)
+		yield ('entity_groups', DataSlot, (0, None), (False, None), None)
+		yield ('materials', DataSlot, (0, None), (False, None), None)
+		yield ('names', DataSlot, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -76,3 +77,6 @@ class VoxelskirtRoot(MemStruct):
 		yield 'entity_groups', DataSlot, (0, VoxelskirtRoot._import_map["voxelskirt.compounds.EntityGroup"]), (False, None)
 		yield 'materials', DataSlot, (0, VoxelskirtRoot._import_map["voxelskirt.compounds.Material"]), (False, None)
 		yield 'names', DataSlot, (0, VoxelskirtRoot._import_map["voxelskirt.compounds.Name"]), (False, None)
+
+
+VoxelskirtRoot.init_attributes()

--- a/generated/formats/weatherevents/compounds/WeatherEventData.py
+++ b/generated/formats/weatherevents/compounds/WeatherEventData.py
@@ -57,49 +57,50 @@ class WeatherEventData(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('event_name', Pointer, (0, ZString), (False, None), None),
-		('float_1', Float, (0, None), (False, None), None),
-		('float_2', Float, (0, None), (False, None), None),
-		('float_3', Float, (0, None), (False, None), None),
-		('float_4', Float, (0, None), (False, None), None),
-		('float_5', Float, (0, None), (False, None), None),
-		('float_6', Float, (0, None), (False, None), None),
-		('float_7', Float, (0, None), (False, None), None),
-		('float_8', Float, (0, None), (False, None), None),
-		('float_9', Float, (0, None), (False, None), None),
-		('float_10', Float, (0, None), (False, None), None),
-		('event_curve_name_from_base', Pointer, (0, ZString), (False, None), None),
-		('unk_1_as_1', Uint, (0, None), (False, None), None),
-		('float_11', Float, (0, None), (False, None), None),
-		('float_12', Float, (0, None), (False, None), None),
-		('float_13', Float, (0, None), (False, None), None),
-		('float_14', Float, (0, None), (False, None), None),
-		('float_15', Float, (0, None), (False, None), None),
-		('event_curve_clouds', Pointer, (0, ZString), (False, None), None),
-		('block_1_unk_as_1', Uint, (0, None), (False, None), None),
-		('block_1_float_1', Float, (0, None), (False, None), None),
-		('block_1_float_2', Float, (0, None), (False, None), None),
-		('block_1_float_3', Float, (0, None), (False, None), None),
-		('block_1_float_4', Float, (0, None), (False, None), None),
-		('block_1_float_5', Float, (0, None), (False, None), None),
-		('block_1_float_6', Float, (0, None), (False, None), None),
-		('block_1_float_7', Float, (0, None), (False, None), None),
-		('block_2_unk_as_1', Uint, (0, None), (False, None), None),
-		('block_2_float_1', Float, (0, None), (False, None), None),
-		('block_2_float_2', Float, (0, None), (False, None), None),
-		('block_2_float_3', Float, (0, None), (False, None), None),
-		('block_2_float_4', Float, (0, None), (False, None), None),
-		('block_2_float_5', Float, (0, None), (False, None), None),
-		('block_2_float_6', Float, (0, None), (False, None), None),
-		('block_2_float_7', Float, (0, None), (False, None), None),
-		('block_3_unk_as_1', Uint, (0, None), (False, None), None),
-		('block_3_float_1', Float, (0, None), (False, None), None),
-		('block_3_float_2', Float, (0, None), (False, None), None),
-		('block_3_float_3', Float, (0, None), (False, None), None),
-		('block_3_float_4', Float, (0, None), (False, None), None),
-		('block_3_float_5', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('event_name', Pointer, (0, ZString), (False, None), None)
+		yield ('float_1', Float, (0, None), (False, None), None)
+		yield ('float_2', Float, (0, None), (False, None), None)
+		yield ('float_3', Float, (0, None), (False, None), None)
+		yield ('float_4', Float, (0, None), (False, None), None)
+		yield ('float_5', Float, (0, None), (False, None), None)
+		yield ('float_6', Float, (0, None), (False, None), None)
+		yield ('float_7', Float, (0, None), (False, None), None)
+		yield ('float_8', Float, (0, None), (False, None), None)
+		yield ('float_9', Float, (0, None), (False, None), None)
+		yield ('float_10', Float, (0, None), (False, None), None)
+		yield ('event_curve_name_from_base', Pointer, (0, ZString), (False, None), None)
+		yield ('unk_1_as_1', Uint, (0, None), (False, None), None)
+		yield ('float_11', Float, (0, None), (False, None), None)
+		yield ('float_12', Float, (0, None), (False, None), None)
+		yield ('float_13', Float, (0, None), (False, None), None)
+		yield ('float_14', Float, (0, None), (False, None), None)
+		yield ('float_15', Float, (0, None), (False, None), None)
+		yield ('event_curve_clouds', Pointer, (0, ZString), (False, None), None)
+		yield ('block_1_unk_as_1', Uint, (0, None), (False, None), None)
+		yield ('block_1_float_1', Float, (0, None), (False, None), None)
+		yield ('block_1_float_2', Float, (0, None), (False, None), None)
+		yield ('block_1_float_3', Float, (0, None), (False, None), None)
+		yield ('block_1_float_4', Float, (0, None), (False, None), None)
+		yield ('block_1_float_5', Float, (0, None), (False, None), None)
+		yield ('block_1_float_6', Float, (0, None), (False, None), None)
+		yield ('block_1_float_7', Float, (0, None), (False, None), None)
+		yield ('block_2_unk_as_1', Uint, (0, None), (False, None), None)
+		yield ('block_2_float_1', Float, (0, None), (False, None), None)
+		yield ('block_2_float_2', Float, (0, None), (False, None), None)
+		yield ('block_2_float_3', Float, (0, None), (False, None), None)
+		yield ('block_2_float_4', Float, (0, None), (False, None), None)
+		yield ('block_2_float_5', Float, (0, None), (False, None), None)
+		yield ('block_2_float_6', Float, (0, None), (False, None), None)
+		yield ('block_2_float_7', Float, (0, None), (False, None), None)
+		yield ('block_3_unk_as_1', Uint, (0, None), (False, None), None)
+		yield ('block_3_float_1', Float, (0, None), (False, None), None)
+		yield ('block_3_float_2', Float, (0, None), (False, None), None)
+		yield ('block_3_float_3', Float, (0, None), (False, None), None)
+		yield ('block_3_float_4', Float, (0, None), (False, None), None)
+		yield ('block_3_float_5', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -145,3 +146,6 @@ class WeatherEventData(MemStruct):
 		yield 'block_3_float_3', Float, (0, None), (False, None)
 		yield 'block_3_float_4', Float, (0, None), (False, None)
 		yield 'block_3_float_5', Float, (0, None), (False, None)
+
+
+WeatherEventData.init_attributes()

--- a/generated/formats/weatherevents/compounds/WeatherEventsRoot.py
+++ b/generated/formats/weatherevents/compounds/WeatherEventsRoot.py
@@ -25,15 +25,16 @@ class WeatherEventsRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('resource_name', Pointer, (0, ZStringObfuscated), (False, None), None),
-		('default_event_name', Pointer, (0, ZString), (False, None), None),
-		('transition_time', Float, (0, None), (False, None), None),
-		('unknown_1', Float, (0, None), (False, None), None),
-		('event_list', ArrayPointer, (None, None), (False, None), None),
-		('event_count', Uint64, (0, None), (False, None), None),
-		('unknown_2', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('resource_name', Pointer, (0, ZStringObfuscated), (False, None), None)
+		yield ('default_event_name', Pointer, (0, ZString), (False, None), None)
+		yield ('transition_time', Float, (0, None), (False, None), None)
+		yield ('unknown_1', Float, (0, None), (False, None), None)
+		yield ('event_list', ArrayPointer, (None, None), (False, None), None)
+		yield ('event_count', Uint64, (0, None), (False, None), None)
+		yield ('unknown_2', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -45,3 +46,6 @@ class WeatherEventsRoot(MemStruct):
 		yield 'event_list', ArrayPointer, (instance.event_count, WeatherEventsRoot._import_map["weatherevents.compounds.WeatherEventData"]), (False, None)
 		yield 'event_count', Uint64, (0, None), (False, None)
 		yield 'unknown_2', Uint64, (0, None), (False, None)
+
+
+WeatherEventsRoot.init_attributes()

--- a/generated/formats/wmeta/compounds/EventEntry.py
+++ b/generated/formats/wmeta/compounds/EventEntry.py
@@ -38,23 +38,24 @@ class EventEntry(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('hash', Uint, (0, None), (False, None), None),
-		('zero', Uint, (0, None), (False, None), None),
-		('block_name', Pointer, (0, ZString), (False, None), True),
-		('zero_2', Ushort, (0, None), (False, None), True),
-		('size', Ushort, (0, None), (False, None), True),
-		('flag_0', Uint, (0, None), (False, None), None),
-		('flag_1', Uint, (0, None), (False, None), None),
-		('flag_2', Uint, (0, None), (False, None), None),
-		('zero_3', Uint64, (0, None), (False, None), True),
-		('flag_3', Uint, (0, None), (False, None), True),
-		('hash_b', Uint, (0, None), (False, None), None),
-		('hash_c', Uint, (0, None), (False, None), None),
-		('zero_4', Uint, (0, None), (False, None), None),
-		('u_2', Uint, (0, None), (False, None), True),
-		('u_1', Uint, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('hash', Uint, (0, None), (False, None), None)
+		yield ('zero', Uint, (0, None), (False, None), None)
+		yield ('block_name', Pointer, (0, ZString), (False, None), True)
+		yield ('zero_2', Ushort, (0, None), (False, None), True)
+		yield ('size', Ushort, (0, None), (False, None), True)
+		yield ('flag_0', Uint, (0, None), (False, None), None)
+		yield ('flag_1', Uint, (0, None), (False, None), None)
+		yield ('flag_2', Uint, (0, None), (False, None), None)
+		yield ('zero_3', Uint64, (0, None), (False, None), True)
+		yield ('flag_3', Uint, (0, None), (False, None), True)
+		yield ('hash_b', Uint, (0, None), (False, None), None)
+		yield ('hash_c', Uint, (0, None), (False, None), None)
+		yield ('zero_4', Uint, (0, None), (False, None), None)
+		yield ('u_2', Uint, (0, None), (False, None), True)
+		yield ('u_1', Uint, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -77,3 +78,6 @@ class EventEntry(MemStruct):
 		if instance.context.version >= 19:
 			yield 'u_2', Uint, (0, None), (False, None)
 			yield 'u_1', Uint, (0, None), (False, None)
+
+
+EventEntry.init_attributes()

--- a/generated/formats/wmeta/compounds/MediaEntry.py
+++ b/generated/formats/wmeta/compounds/MediaEntry.py
@@ -24,13 +24,14 @@ class MediaEntry(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('hash', Uint, (0, None), (False, None), None),
-		('zero', Uint, (0, None), (False, None), None),
-		('block_name', Pointer, (0, ZString), (False, None), None),
-		('wav_name', Pointer, (0, ZString), (False, None), None),
-		('wem_name', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('hash', Uint, (0, None), (False, None), None)
+		yield ('zero', Uint, (0, None), (False, None), None)
+		yield ('block_name', Pointer, (0, ZString), (False, None), None)
+		yield ('wav_name', Pointer, (0, ZString), (False, None), None)
+		yield ('wem_name', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -40,3 +41,6 @@ class MediaEntry(MemStruct):
 		yield 'block_name', Pointer, (0, ZString), (False, None)
 		yield 'wav_name', Pointer, (0, ZString), (False, None)
 		yield 'wem_name', Pointer, (0, ZString), (False, None)
+
+
+MediaEntry.init_attributes()

--- a/generated/formats/wmeta/compounds/WmetasbMain.py
+++ b/generated/formats/wmeta/compounds/WmetasbMain.py
@@ -38,23 +38,24 @@ class WmetasbMain(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('hash', Uint, (0, None), (False, None), None),
-		('unk', Uint, (0, None), (False, None), None),
-		('block_name', Pointer, (0, ZString), (False, None), None),
-		('media_name', Pointer, (0, ZString), (False, None), True),
-		('bnk_name', Pointer, (0, ZString), (False, None), True),
-		('events', ArrayPointer, (None, None), (False, None), None),
-		('events_count', Uint64, (0, None), (False, None), None),
-		('hashes', ArrayPointer, (None, Uint), (False, None), True),
-		('hashes_count', Uint64, (0, None), (False, None), True),
-		('media', ArrayPointer, (None, None), (False, None), True),
-		('media_count', Uint64, (0, None), (False, None), True),
-		('unused_2', Pointer, (0, None), (False, None), True),
-		('unused_3', Pointer, (0, None), (False, None), True),
-		('unused_4', Pointer, (0, None), (False, None), True),
-		('unused_5', Pointer, (0, None), (False, None), True),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('hash', Uint, (0, None), (False, None), None)
+		yield ('unk', Uint, (0, None), (False, None), None)
+		yield ('block_name', Pointer, (0, ZString), (False, None), None)
+		yield ('media_name', Pointer, (0, ZString), (False, None), True)
+		yield ('bnk_name', Pointer, (0, ZString), (False, None), True)
+		yield ('events', ArrayPointer, (None, None), (False, None), None)
+		yield ('events_count', Uint64, (0, None), (False, None), None)
+		yield ('hashes', ArrayPointer, (None, Uint), (False, None), True)
+		yield ('hashes_count', Uint64, (0, None), (False, None), True)
+		yield ('media', ArrayPointer, (None, None), (False, None), True)
+		yield ('media_count', Uint64, (0, None), (False, None), True)
+		yield ('unused_2', Pointer, (0, None), (False, None), True)
+		yield ('unused_3', Pointer, (0, None), (False, None), True)
+		yield ('unused_4', Pointer, (0, None), (False, None), True)
+		yield ('unused_5', Pointer, (0, None), (False, None), True)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -76,3 +77,6 @@ class WmetasbMain(MemStruct):
 			yield 'unused_3', Pointer, (0, None), (False, None)
 			yield 'unused_4', Pointer, (0, None), (False, None)
 			yield 'unused_5', Pointer, (0, None), (False, None)
+
+
+WmetasbMain.init_attributes()

--- a/generated/formats/wmeta/compounds/WmetasbRoot.py
+++ b/generated/formats/wmeta/compounds/WmetasbRoot.py
@@ -16,13 +16,17 @@ class WmetasbRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('levels', ArrayPointer, (None, None), (False, None), None),
-		('count', Uint64, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('levels', ArrayPointer, (None, None), (False, None), None)
+		yield ('count', Uint64, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'levels', ArrayPointer, (instance.count, WmetasbRoot._import_map["wmeta.compounds.WmetasbMain"]), (False, None)
 		yield 'count', Uint64, (0, None), (False, None)
+
+
+WmetasbRoot.init_attributes()

--- a/generated/formats/world/compounds/PtrList.py
+++ b/generated/formats/world/compounds/PtrList.py
@@ -16,11 +16,15 @@ class PtrList(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('ptrs', Array, (0, ZString, (None,), Pointer), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'ptrs', Array, (0, ZString, (instance.arg,), Pointer), (False, None)
+
+
+PtrList.init_attributes()

--- a/generated/formats/world/compounds/WorldHeader.py
+++ b/generated/formats/world/compounds/WorldHeader.py
@@ -29,18 +29,19 @@ class WorldHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('world_type', Uint64, (0, None), (False, None), None),
-		('asset_pkgs', Pointer, (None, None), (False, None), None),
-		('asset_pkg_count', Uint64, (0, None), (False, None), None),
-		('lua_name', Pointer, (0, ZString), (False, None), None),
-		('ptr_0', Pointer, (0, None), (False, None), None),
-		('ptr_1', Pointer, (0, None), (False, None), None),
-		('prefabs', Pointer, (None, None), (False, None), None),
-		('ptr_2', Pointer, (0, None), (False, None), None),
-		('prefab_count', Uint64, (0, None), (False, None), None),
-		('ptr_3', Pointer, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('world_type', Uint64, (0, None), (False, None), None)
+		yield ('asset_pkgs', Pointer, (None, None), (False, None), None)
+		yield ('asset_pkg_count', Uint64, (0, None), (False, None), None)
+		yield ('lua_name', Pointer, (0, ZString), (False, None), None)
+		yield ('ptr_0', Pointer, (0, None), (False, None), None)
+		yield ('ptr_1', Pointer, (0, None), (False, None), None)
+		yield ('prefabs', Pointer, (None, None), (False, None), None)
+		yield ('ptr_2', Pointer, (0, None), (False, None), None)
+		yield ('prefab_count', Uint64, (0, None), (False, None), None)
+		yield ('ptr_3', Pointer, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -55,3 +56,6 @@ class WorldHeader(MemStruct):
 		yield 'ptr_2', Pointer, (0, None), (False, None)
 		yield 'prefab_count', Uint64, (0, None), (False, None)
 		yield 'ptr_3', Pointer, (0, None), (False, None)
+
+
+WorldHeader.init_attributes()

--- a/generated/formats/wsm/compounds/Vector3.py
+++ b/generated/formats/wsm/compounds/Vector3.py
@@ -26,11 +26,12 @@ class Vector3(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -38,3 +39,6 @@ class Vector3(MemStruct):
 		yield 'x', Float, (0, None), (False, None)
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
+
+
+Vector3.init_attributes()

--- a/generated/formats/wsm/compounds/Vector4.py
+++ b/generated/formats/wsm/compounds/Vector4.py
@@ -29,12 +29,13 @@ class Vector4(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('x', Float, (0, None), (False, None), None),
-		('y', Float, (0, None), (False, None), None),
-		('z', Float, (0, None), (False, None), None),
-		('w', Float, (0, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('x', Float, (0, None), (False, None), None)
+		yield ('y', Float, (0, None), (False, None), None)
+		yield ('z', Float, (0, None), (False, None), None)
+		yield ('w', Float, (0, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -43,3 +44,6 @@ class Vector4(MemStruct):
 		yield 'y', Float, (0, None), (False, None)
 		yield 'z', Float, (0, None), (False, None)
 		yield 'w', Float, (0, None), (False, None)
+
+
+Vector4.init_attributes()

--- a/generated/formats/wsm/compounds/Wsm.py
+++ b/generated/formats/wsm/compounds/Wsm.py
@@ -23,11 +23,12 @@ class Wsm(GenericHeader):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = GenericHeader._attribute_list + [
-		('header', WsmHeader, (0, None), (False, None), None),
-		('locs', Array, (0, None, (None, 3,), Float), (False, None), None),
-		('quats', Array, (0, None, (None, 4,), Float), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('header', WsmHeader, (0, None), (False, None), None)
+		yield ('locs', Array, (0, None, (None, 3,), Float), (False, None), None)
+		yield ('quats', Array, (0, None, (None, 4,), Float), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -35,3 +36,6 @@ class Wsm(GenericHeader):
 		yield 'header', WsmHeader, (0, None), (False, None)
 		yield 'locs', Array, (0, None, (instance.header.frame_count, 3,), Float), (False, None)
 		yield 'quats', Array, (0, None, (instance.header.frame_count, 4,), Float), (False, None)
+
+
+Wsm.init_attributes()

--- a/generated/formats/wsm/compounds/WsmHeader.py
+++ b/generated/formats/wsm/compounds/WsmHeader.py
@@ -30,13 +30,14 @@ class WsmHeader(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('duration', Float, (0, None), (False, None), None),
-		('frame_count', Uint, (0, None), (False, None), None),
-		('unknowns', Array, (0, None, (8,), Float), (False, None), None),
-		('locs', ArrayPointer, (None, None), (False, None), None),
-		('quats', ArrayPointer, (None, None), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('duration', Float, (0, None), (False, None), None)
+		yield ('frame_count', Uint, (0, None), (False, None), None)
+		yield ('unknowns', Array, (0, None, (8,), Float), (False, None), None)
+		yield ('locs', ArrayPointer, (None, None), (False, None), None)
+		yield ('quats', ArrayPointer, (None, None), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
@@ -46,3 +47,6 @@ class WsmHeader(MemStruct):
 		yield 'unknowns', Array, (0, None, (8,), Float), (False, None)
 		yield 'locs', ArrayPointer, (instance.frame_count, WsmHeader._import_map["wsm.compounds.Vector3"]), (False, None)
 		yield 'quats', ArrayPointer, (instance.frame_count, WsmHeader._import_map["wsm.compounds.Vector4"]), (False, None)
+
+
+WsmHeader.init_attributes()

--- a/generated/formats/xmlconfig/compounds/XmlconfigRoot.py
+++ b/generated/formats/xmlconfig/compounds/XmlconfigRoot.py
@@ -15,11 +15,15 @@ class XmlconfigRoot(MemStruct):
 		if set_default:
 			self.set_defaults()
 
-	_attribute_list = MemStruct._attribute_list + [
-		('xml_string', Pointer, (0, ZString), (False, None), None),
-		]
+	@classmethod
+	def _get_attribute_list(cls):
+		yield from super()._get_attribute_list()
+		yield ('xml_string', Pointer, (0, ZString), (False, None), None)
 
 	@classmethod
 	def _get_filtered_attribute_list(cls, instance, include_abstract=True):
 		yield from super()._get_filtered_attribute_list(instance, include_abstract)
 		yield 'xml_string', Pointer, (0, ZString), (False, None)
+
+
+XmlconfigRoot.init_attributes()

--- a/source/base_struct.py
+++ b/source/base_struct.py
@@ -166,7 +166,7 @@ class BaseStruct(metaclass=StructMetaClass):
 
     _import_map = ImportMap()
     _import_key = "base_struct"
-    _attribute_list = ()
+    _attribute_list = []
     allow_np = False
 
     def __init__(self, context, arg=0, template=None, set_default=True):

--- a/source/base_struct.py
+++ b/source/base_struct.py
@@ -25,86 +25,6 @@ class StructMetaClass(type):
             cls._import_map[dict['_import_key']] = cls
         super().__init__(name, bases, dict, **kwds)
 
-        def free_function(function_name):
-            """Checks if the function is defined"""
-            if function_name in dict:
-                return False
-            else:
-                # not defined in class body allows automatic filling, as long as any parents are also compatible
-                return callable(getattr(cls, function_name, lambda: True))
-
-        # if attribute list is not defined and we have the function to generate it, create it
-        if "_attribute_list" not in dict and not free_function("_get_attribute_list"):
-            cls._attribute_list = tuple(cls._get_attribute_list())
-
-        # check if the class has a non-empty _attribute_list
-        if getattr(cls, "_attribute_list", ()):
-            attribute_list = cls._attribute_list
-            # for convenience, sort the attribute list into continuous lists
-            attr_names, attr_types, _, _, attr_conds = zip(*attribute_list)
-            if all(cond is None for cond in attr_conds) and all(attr_type is not None for attr_type in attr_types):
-                # all fields are static
-                if len(set(attr_types)) == 1:
-                    # every field is the same type, iteration makes sense
-                    if free_function("__len__"):
-                        cls.__len__ = lambda self: len(attribute_list)
-                    if free_function("__iter__"):
-                        def __iter__(self):
-                            yield from (getattr(self, attr_name) for attr_name in attr_names)
-                        cls.__iter__ = __iter__
-                    if free_function("__getitem__"):
-                        def __getitem__(self, key):
-                            if 0 <= key < len(attribute_list):
-                                return getattr(self, attr_names[key])
-                            else:
-                                raise IndexError(f'Index {key} not in {type(self)}')
-                        cls.__getitem__ = __getitem__
-                    if free_function("__setitem__"):
-                        def __setitem__(self, key, value):
-                            if 0 <= key < len(attribute_list):
-                                return setattr(self, attr_names[key], value)
-                            else:
-                                raise IndexError(f'Index {key} not in {type(self)}')
-                        cls.__setitem__ = __setitem__
-                # check if all of the class's attributes have a from_value function
-                if all(callable(getattr(attr_type, "from_value", None)) for attr_type in attr_types):
-                    # since all fields are static and have a from_value function defined, this struct can also have
-                    # from_value defined
-                    if free_function("from_value"):
-                        def from_value(value):
-                            # from_value implies context-independence so pass None as context
-                            instance = cls(None)
-                            for f_name, f_type, value_element in zip(attr_names, attr_types, value):
-                                setattr(instance, f_name, f_type.from_value(value_element))
-                            return instance
-                        cls.from_value = from_value
-            # check if all of the class's attributes have a from_value function
-            if getattr(cls, "allow_np", False) and all(
-                    # check for a struct with get_np_dtype and flag set to True
-                    callable(getattr(attr_type, "get_np_dtype", None)) or
-                    # or a basic numeric type
-                    getattr(attr_type, "np_dtype", None)
-                    for attr_type in attr_types):
-                if free_function("create_array"):
-                    def create_array(shape, default=None, context=None, arg=0, template=None):
-                        np_dtype = cls.get_np_dtype(context, arg, template)
-                        return np.zeros(shape, dtype=np_dtype)
-                    cls.create_array = create_array
-                if free_function("read_array"):
-                    def read_array(stream, shape, context=None, arg=0, template=None):
-                        np_dtype = cls.get_np_dtype(context, arg, template)
-                        array = np.empty(shape, dtype=np_dtype)
-                        stream.readinto(array)
-                        return array
-                    cls.read_array = read_array
-                if free_function("write_array"):
-                    def write_array(instance, stream):
-                        # todo - do type conversion, cf. basic.py
-                        assert isinstance(instance, np.ndarray)
-                        # np_dtype = cls.get_np_dtype(context, arg, template)
-                        stream.write(instance.tobytes())
-                    cls.write_array = write_array
-
 
 def indent(e, level=0):
     i = "\n" + level * "	"
@@ -349,6 +269,89 @@ class BaseStruct(metaclass=StructMetaClass):
             except:
                 logging.error(f"validation failed on field {f_name} on type {cls}")
                 raise
+
+    @classmethod
+    def init_attributes(cls):
+
+        def free_function(function_name):
+            """Checks if the function is defined"""
+            if function_name in cls.__dict__:
+                return False
+            else:
+                # not defined in class body allows automatic filling, as long as any parents are also compatible
+                return callable(getattr(cls, function_name, lambda: True))
+
+        # if attribute list is not defined and we have the function to generate it, create it
+        if "_attribute_list" not in cls.__dict__ and not free_function("_get_attribute_list"):
+            cls._attribute_list = tuple(cls._get_attribute_list())
+
+        # check if the class has a non-empty _attribute_list
+        if getattr(cls, "_attribute_list", ()):
+            attribute_list = cls._attribute_list
+            # for convenience, sort the attribute list into continuous lists
+            attr_names, attr_types, _, _, attr_conds = zip(*attribute_list)
+            if all(cond is None for cond in attr_conds) and all(attr_type is not None for attr_type in attr_types):
+                # all fields are static
+                if len(set(attr_types)) == 1:
+                    # every field is the same type, iteration makes sense
+                    if free_function("__len__"):
+                        cls.__len__ = lambda self: len(attribute_list)
+                    if free_function("__iter__"):
+                        def __iter__(self):
+                            yield from (getattr(self, attr_name) for attr_name in attr_names)
+                        cls.__iter__ = __iter__
+                    if free_function("__getitem__"):
+                        def __getitem__(self, key):
+                            if 0 <= key < len(attribute_list):
+                                return getattr(self, attr_names[key])
+                            else:
+                                raise IndexError(f'Index {key} not in {type(self)}')
+                        cls.__getitem__ = __getitem__
+                    if free_function("__setitem__"):
+                        def __setitem__(self, key, value):
+                            if 0 <= key < len(attribute_list):
+                                return setattr(self, attr_names[key], value)
+                            else:
+                                raise IndexError(f'Index {key} not in {type(self)}')
+                        cls.__setitem__ = __setitem__
+                # check if all of the class's attributes have a from_value function
+                if all(callable(getattr(attr_type, "from_value", None)) for attr_type in attr_types):
+                    # since all fields are static and have a from_value function defined, this struct can also have
+                    # from_value defined
+                    if free_function("from_value"):
+                        def from_value(value):
+                            # from_value implies context-independence so pass None as context
+                            instance = cls(None)
+                            for f_name, f_type, value_element in zip(attr_names, attr_types, value):
+                                setattr(instance, f_name, f_type.from_value(value_element))
+                            return instance
+                        cls.from_value = from_value
+            # check if all of the class's attributes have a from_value function
+            if getattr(cls, "allow_np", False) and all(
+                    # check for a struct with get_np_dtype and flag set to True
+                    callable(getattr(attr_type, "get_np_dtype", None)) or
+                    # or a basic numeric type
+                    getattr(attr_type, "np_dtype", None)
+                    for attr_type in attr_types):
+                if free_function("create_array"):
+                    def create_array(shape, default=None, context=None, arg=0, template=None):
+                        np_dtype = cls.get_np_dtype(context, arg, template)
+                        return np.zeros(shape, dtype=np_dtype)
+                    cls.create_array = create_array
+                if free_function("read_array"):
+                    def read_array(stream, shape, context=None, arg=0, template=None):
+                        np_dtype = cls.get_np_dtype(context, arg, template)
+                        array = np.empty(shape, dtype=np_dtype)
+                        stream.readinto(array)
+                        return array
+                    cls.read_array = read_array
+                if free_function("write_array"):
+                    def write_array(instance, stream):
+                        # todo - do type conversion, cf. basic.py
+                        assert isinstance(instance, np.ndarray)
+                        # np_dtype = cls.get_np_dtype(context, arg, template)
+                        stream.write(instance.tobytes())
+                    cls.write_array = write_array
 
     @classmethod
     def _get_attribute_list(cls):

--- a/source/base_struct.py
+++ b/source/base_struct.py
@@ -33,6 +33,10 @@ class StructMetaClass(type):
                 # not defined in class body allows automatic filling, as long as any parents are also compatible
                 return callable(getattr(cls, function_name, lambda: True))
 
+        # if attribute list is not defined and we have the function to generate it, create it
+        if "_attribute_list" not in dict and not free_function("_get_attribute_list"):
+            cls._attribute_list = tuple(cls._get_attribute_list())
+
         # check if the class has a non-empty _attribute_list
         if getattr(cls, "_attribute_list", ()):
             attribute_list = cls._attribute_list
@@ -162,7 +166,7 @@ class BaseStruct(metaclass=StructMetaClass):
 
     _import_map = ImportMap()
     _import_key = "base_struct"
-    _attribute_list = []
+    _attribute_list = ()
     allow_np = False
 
     def __init__(self, context, arg=0, template=None, set_default=True):
@@ -345,6 +349,10 @@ class BaseStruct(metaclass=StructMetaClass):
             except:
                 logging.error(f"validation failed on field {f_name} on type {cls}")
                 raise
+
+    @classmethod
+    def _get_attribute_list(cls):
+        yield from ()
 
     @classmethod
     def _get_filtered_attribute_list(cls, instance, include_abstract=True):


### PR DESCRIPTION
Implemented possibility for recursive fields in the codegen. This is to allow something like https://github.com/niftools/nifskope/issues/185 .Some things had to be reworked for this.

### Done
1. When a field is recursive, its type is no longer simply imported  (`from module x import y`), instead, it is accessed through the import map stored on the type.
2. The attribute list is no longer directly stored, instead it can be returned as an iterator from the `_get_attribute_list` class function. For compatibility and to refrain from calling a function every time you need the attribute list, it is immediately stored there, though, resulting in seemingly unchanged functionality. It is also a tuple rather than a list, to reflect the immutability.
3. The dynamically generated functions are now added not through the StructMetaClass, but through a call to the `init_attributes` class function. This includes the aforementioned storing of the attribute list.

These were all necessary to prevent circular imports and trying to access classes before they existed in their module namespace when encountering recursive fields.

### Points of discussion
How to determine which fields are recursive. Currently, it uses the `recursive="true"` indicator on the field. However, in my view there are three possibilities:
1. Keep it as-is.
5. Use the order of the types in the xml  - any field type not defined _before_ it is used is assumed to be recursive. Nif.xml needs no changes for this, but many of the existing ones in cobra-tools do.
6. A combination of both: it is only allowed to use types in field before it is defined in the xml if that field has `recursive="true"`.

While I don't like introducing new attributes, this one if probably preferable over keeping a purely order-based, since it's more obvious about what's going on to the casual reader of the xml. On the other hand, I do like the idea of enforcing a certain order. Even though it's not explicitly mentioned in the description of the nif xml, I could imagine it might make parsing it easier for whatever generator uses it if that is an established, reliable standard.