### PR TITLE
Implementation of multiple args and templates for a field.

### DIFF
--- a/codegen/Compound.py
+++ b/codegen/Compound.py
@@ -35,15 +35,35 @@ class Compound(BaseClass):
             if self.struct.get("allow_np", None) == "true":
                 self.write_line(f, 1, f"allow_np = True")
 
+            # handle more-than-one length attributes as properties, to keep it synced with the main one
+            nr_args = int(self.struct.attrib.get("args", "1"))
+            if nr_args > 1:
+                self.write_line(f)
+                for i in range(nr_args):
+                    self.write_line(f, 1, "@property")
+                    self.write_line(f, 1, f"def arg_{i + 1}(self):")
+                    self.write_line(f, 2, f"return self.arg[{i}]")
+
+            nr_templates = int(self.struct.attrib.get("templates", "1"))
+            if nr_templates > 1:
+                self.write_line(f)
+                for i in range(nr_templates):
+                    self.write_line(f, 1, "@property")
+                    self.write_line(f, 1, f"def template_{i + 1}(self):")
+                    self.write_line(f, 2, f"return self.template[{i}]")
+
             # check all fields/members in this class and write them as fields
             # for union in self.field_unions.values():
             #   union.write_declaration(f)
             if "def __init__" not in self.src_code:
                 self.write_line(f)
                 self.write_line(f, 1, "def __init__(self, context, arg=0, template=None, set_default=True):")
+
+                # compound with generic="true" must have a template provided
                 if self.struct.attrib.get("generic", "False") == "True":
                     self.write_line(f, 2, "if template is None:")
                     self.write_line(f, 3, "raise TypeError(f'{type(self).__name__} requires template is not None')")
+
                 # the standard attributes are handled by the parent class
                 self.write_line(f, 2, "super().__init__(context, arg, template, set_default=False)")
 

--- a/codegen/Imports.py
+++ b/codegen/Imports.py
@@ -30,19 +30,25 @@ class Imports:
                     field_type = field.attrib["type"]
                     if not self.is_template(field_type):
                         self.add_indirect_import()
-                    arr1 = field.attrib.get("arr1")
-                    if arr1 is None:
-                        arr1 = field.attrib.get("length")
+                    arr1 = self.parent.get_attr_with_backups(field, ["arr1", "length"])
                     if arr1:
                         self.add("Array")
     
-                    template = field.attrib.get("template")
+                    template = self.parent.get_attr_with_array_alt(field, "template")
                     if template:
-                        # template can be either a type or a template
-                        # only import if a type
-                        template_class = convention.name_class(template)
-                        if not self.is_template(template_class):
-                            self.add_indirect_import()
+                        if isinstance(template, list):
+                            for entry in template:
+                                # template can be either a type or a template
+                                # only import if a type
+                                template_class = convention.name_class(entry)
+                                if not self.is_template(template_class):
+                                    self.add_indirect_import()
+                        else:
+                            # template can be either a type or a template
+                            # only import if a type
+                            template_class = convention.name_class(template)
+                            if not self.is_template(template_class):
+                                self.add_indirect_import()
     
                     onlyT = field.attrib.get("onlyT")
                     excludeT = field.attrib.get("excludeT")
@@ -61,7 +67,7 @@ class Imports:
             raise NotImplementedError(f'Unknown tag type {xml_struct.tag}')
 
     def is_template(self, string_to_check):
-        return string_to_check == "template"
+        return bool(convention.template_re.fullmatch(string_to_check))
 
     def add(self, cls_to_import):
         if cls_to_import and cls_to_import != self.xml_struct.attrib["name"]:

--- a/codegen/expression.py
+++ b/codegen/expression.py
@@ -142,6 +142,9 @@ class Expression(object):
             return f"int({left} {op} {right})"
         return f"{left} {op} {right}".strip()
 
+    def __repr__(self):
+        return str(self)
+
     @classmethod
     def _parse(cls, expr_str, target_variable=""):
         """Returns an Expression, string, or int, depending on the

--- a/codegen/naming_conventions.py
+++ b/codegen/naming_conventions.py
@@ -19,6 +19,7 @@ _RE_NAME_LC = re.compile('[a-z]')
 _RE_NAME_UC = re.compile('[A-Z]')
 """Matches an upper case character."""
 
+template_re = re.compile(r"template(_[0-9][0-9]*)?")
 
 def name_parts(name):
     """Intelligently split a name into parts:
@@ -105,7 +106,7 @@ def name_class(name):
     >>> name_class('this IS a sillyNAME')
     'ThisIsASillyNAME'
     """
-    if name == "template":
+    if template_re.fullmatch(name):
         return name
     return ''.join(part.capitalize() for part in name_parts(name))
 

--- a/generated/array.py
+++ b/generated/array.py
@@ -1,7 +1,6 @@
 import logging
 import time
 from operator import index
-import math
 import xml.etree.ElementTree as ET
 
 import numpy as np
@@ -139,6 +138,14 @@ class Array(list):
             new_array.fill(lambda: dtype.from_value(value))
             return new_array
 
+    @staticmethod
+    def prod(iterator, *, start=1):
+        """Simple implementation of math.prod, because it does not exist in python 3.7."""
+        count = start
+        for i in iterator:
+            count *= i
+        return count
+
     @property
     def shape(self):
         return self._shape
@@ -164,7 +171,7 @@ class Array(list):
 
     @property
     def size(self):
-        return math.prod(self.shape)
+        return Array.prod(self.shape)
 
     @classmethod
     def perform_nested_func(cls, nested_iterable, efunc, ndim):
@@ -331,7 +338,7 @@ class RaggedArray(Array):
 
     @property
     def size(self):
-        return self.shape[0] * sum(self.shape[1]) * math.prod(self.shape[2:])
+        return self.shape[0] * sum(self.shape[1]) * Array.prod(self.shape[2:])
 
     @classmethod
     def from_stream(cls, stream, context, arg=0, template=None, shape=(), dtype=None):

--- a/generated/array.py
+++ b/generated/array.py
@@ -326,7 +326,7 @@ class RaggedArray(Array):
     @shape.setter
     def shape(self, shape_input):
         # conversion to int happens using the 'index' operator
-        shape = (index(shape_input[0]), shape_input[1], *(index(i) for i in shape_input[2:]))
+        shape = (index(shape_input[0]), tuple(index(i) for i in shape_input[1]), *(index(i) for i in shape_input[2:]))
         self._shape = shape
 
     @property
@@ -368,7 +368,7 @@ class RaggedArray(Array):
             arg = getattr(instance, "arg", 0)
             template = getattr(instance, "template", None)
             for i in range(instance.shape[0]):
-                yield (i, cls, (arg, template, instance.shape[1][i], dtype), (False, None))
+                yield (i, Array, (arg, template, (instance.shape[1][i],), dtype), (False, None))
 
     @classmethod
     def validate_instance(cls, instance, context, arg, template, shape, dtype):
@@ -391,6 +391,14 @@ class RaggedArray(Array):
             except AssertionError:
                 logging.error(f"validation failed on field {f_name} on type {cls}[{dtype}]")
                 raise
+
+    def append(self, x):
+        self.shape = (self.shape[0] + 1, (*self.shape[1], len(x)), *self.shape[2:])
+        super(list, self).append(x)
+
+    def extend(self, x):
+        self.shape = (self.shape[0] + len(x), (*self.shape[1], *(len(entry) for entry in x)) ,*self.shape[2:])
+        super(list, self).extend(x)
 
 
 def _class_to_name(cls):

--- a/source/array.py
+++ b/source/array.py
@@ -1,7 +1,6 @@
 import logging
 import time
 from operator import index
-import math
 import xml.etree.ElementTree as ET
 
 import numpy as np
@@ -139,6 +138,14 @@ class Array(list):
             new_array.fill(lambda: dtype.from_value(value))
             return new_array
 
+    @staticmethod
+    def prod(iterator, *, start=1):
+        """Simple implementation of math.prod, because it does not exist in python 3.7."""
+        count = start
+        for i in iterator:
+            count *= i
+        return count
+
     @property
     def shape(self):
         return self._shape
@@ -164,7 +171,7 @@ class Array(list):
 
     @property
     def size(self):
-        return math.prod(self.shape)
+        return Array.prod(self.shape)
 
     @classmethod
     def perform_nested_func(cls, nested_iterable, efunc, ndim):
@@ -331,7 +338,7 @@ class RaggedArray(Array):
 
     @property
     def size(self):
-        return self.shape[0] * sum(self.shape[1]) * math.prod(self.shape[2:])
+        return self.shape[0] * sum(self.shape[1]) * Array.prod(self.shape[2:])
 
     @classmethod
     def from_stream(cls, stream, context, arg=0, template=None, shape=(), dtype=None):

--- a/source/array.py
+++ b/source/array.py
@@ -326,7 +326,7 @@ class RaggedArray(Array):
     @shape.setter
     def shape(self, shape_input):
         # conversion to int happens using the 'index' operator
-        shape = (index(shape_input[0]), shape_input[1], *(index(i) for i in shape_input[2:]))
+        shape = (index(shape_input[0]), tuple(index(i) for i in shape_input[1]), *(index(i) for i in shape_input[2:]))
         self._shape = shape
 
     @property
@@ -368,7 +368,7 @@ class RaggedArray(Array):
             arg = getattr(instance, "arg", 0)
             template = getattr(instance, "template", None)
             for i in range(instance.shape[0]):
-                yield (i, cls, (arg, template, instance.shape[1][i], dtype), (False, None))
+                yield (i, Array, (arg, template, (instance.shape[1][i],), dtype), (False, None))
 
     @classmethod
     def validate_instance(cls, instance, context, arg, template, shape, dtype):
@@ -391,6 +391,14 @@ class RaggedArray(Array):
             except AssertionError:
                 logging.error(f"validation failed on field {f_name} on type {cls}[{dtype}]")
                 raise
+
+    def append(self, x):
+        self.shape = (self.shape[0] + 1, (*self.shape[1], len(x)), *self.shape[2:])
+        super(list, self).append(x)
+
+    def extend(self, x):
+        self.shape = (self.shape[0] + len(x), (*self.shape[1], *(len(entry) for entry in x)) ,*self.shape[2:])
+        super(list, self).extend(x)
 
 
 def _class_to_name(cls):


### PR DESCRIPTION
In python objects and classes are both objects. However, this is not the case in all languages. I would therefore like to restrict template to be limited to types (including templates itself). However, in certain cases template is used as a way to pass a second object. In order to allow for this, I have changed `arg` (and `template`, though it wasn't strictly necessary) to allow for the passing of multiple objects.

This is accomplished through attributes starting at `arg1` up to `arg<n>`, on the field. A type that uses multiple args must have `args="<n>"` denoted on the type, where `<n>` is the number of args that it uses. In the generated code, these are passed as a tuple in the same place as the `arg` parameter. It is also still stored as `arg`, but it is also accessible through the property `arg_<i>`. This is equivalent to `arg[i - 1]`. Template is treated the same way.

Example:
type:
```xml
<struct name="DataStreamData" args="2" module="NiMesh" since="V20_5_0_0">
    <field name="Data" type="byte" binary="true" length="#ARG1#">The data stream as binary (fallback if interpretation with template is not implemented).</field>
</struct>
```
used in field:
```xml
<field name="Data" type="DataStreamData" arg1="Num Bytes" arg2="Component Formats" />
```

The choice to (re)use the existing `arg` parameter on the types is to keep the function signatures and field definitions consistent across all types, rather than having to somehow check how many args and templates are passed. The choice to allow accessing the elements of arg through properties is to make the code generation easier - otherwise it would require either implementation of square brackets in the Expression class, or modification of the `name_attribute` function to make it less universally applicable. As a side-effect, it also makes it very clear upon reading the generated class whether they use multiple args or not.

As it is, I have not yet changed types other than the one in nif.xml to make use of these multiple args. I thought it useful to first check that there were no unforeseen changes beforehand.

### Other changes

1. Fixed RaggedArray.validate_instance and added `append` and `extend` methods for it (the latter two are not yet tested).
2. Removed `math.prod` use. The README promises compatibility with python 3.7. Since 3.7 does not contain math.prod, I created the same function on the Array class.