### PR TITLE
Enum-like default of bitflag and bug fix get_src_code

### DIFF
--- a/codegen.py
+++ b/codegen.py
@@ -236,6 +236,9 @@ class XmlParser:
             elif struct.tag in self.bitstruct_types:
                 self.apply_convention(struct, convention.name_class, ("storage",))
                 # a bitfield/bitflags fields
+                if struct.tag == 'bitflags':
+                    for field in struct:
+                        field.attrib['enum_name'] = convention.name_enum_key_if_necessary(field.attrib['name'])
                 for field in struct:
                     self.apply_convention(field, convention.name_attribute, ("name",))
                     self.apply_convention(field, convention.name_class, ("type",))

--- a/codegen/BaseClass.py
+++ b/codegen/BaseClass.py
@@ -101,16 +101,13 @@ class BaseClass:
             self.write_line(stream, indent, line)
 
     def get_code_from_src(self,):
-        src_dir = os.path.join(root_dir, "source")
-        py_name = f"{self.class_name.lower()}.py"
+        src_file = os.path.join(root_dir, "source", self.parser.path_dict[self.class_name])
+        src_file = f"{src_file}.py"
 
-        for root, dirs, files in os.walk(src_dir, followlinks=True):
-            for name in files:
-                if self.parser.format_name in root and py_name == name.lower():
-                    src_path = os.path.join(root, name)
-                    # print(f"found source {src_path}")
-                    with open(src_path, "r", encoding=self.parser.encoding) as f:
-                        return f.read()
+        if os.path.exists(src_file):
+            with open(src_file, "r", encoding=self.parser.encoding) as f:
+                return f.read()
+
         return ""
 
     def grab_src_snippet(self, start, end=""):

--- a/codegen/Bitfield.py
+++ b/codegen/Bitfield.py
@@ -50,6 +50,9 @@ class Bitfield(BaseClass):
             f.write(f"\n\t_storage = {storage}")
             self.map_pos()
             self.get_mask()
+            if self.struct.tag == 'bitflags':
+                for field in self.struct:
+                    f.write(f"\n\t{field.attrib['enum_name']} = 2 ** {field.attrib['bit']}")
             for field in self.struct:
                 field_name = field.attrib["name"]
                 field_type = field.attrib.get("type", "int")

--- a/codegen/Union.py
+++ b/codegen/Union.py
@@ -163,28 +163,31 @@ class Union:
 
     def default_to_value(self, default_string, field_type, field_type_access):
         if default_string:
-            if field_type in self.compounds.parser.path_dict and self.compounds.parser.tag_dict[field_type.lower()] == "enum":
-                default_string = convention.name_enum_key_if_necessary(default_string)
-                return f'{field_type_access}.{default_string}'
+            if field_type in self.compounds.parser.path_dict and self.compounds.parser.tag_dict[field_type.lower()] in ("enum", "bitflags"):
+                try:
+                    default_string = str(int(default_string, 0))
+                    return default_string
+                except:
+                    default_string = convention.name_enum_key_if_necessary(default_string)
+                    return f'{field_type_access}.{default_string}'
+            elif ", " in default_string:
+                # already formatted by format_potential_tuple
+                pass
             else:
-                if ", " in default_string:
-                    # already formatted by format_potential_tuple
-                    pass
+                # check for boolean
+                if field_type in self.compounds.parser.path_dict and \
+                self.compounds.parser.tag_dict[field_type.lower()] == "basic" and \
+                    field_type in self.compounds.parser.basics.booleans:
+                    # boolean basics *can* be used as booleans, but don't have to be
+                    if default_string.capitalize() in ("True", "False"):
+                        default_string = default_string.capitalize()
+                        return default_string
+                value = interpret_literal(default_string)
+                if value is not None:
+                    default_string = str(value)
                 else:
-                    # check for boolean
-                    if field_type in self.compounds.parser.path_dict and \
-                    self.compounds.parser.tag_dict[field_type.lower()] == "basic" and \
-                        field_type in self.compounds.parser.basics.booleans:
-                        # boolean basics *can* be used as booleans, but don't have to be
-                        if default_string.capitalize() in ("True", "False"):
-                            default_string = default_string.capitalize()
-                            return default_string
-                    value = interpret_literal(default_string)
-                    if value is not None:
-                        default_string = str(value)
-                    else:
-                        # not interpretable, must be a string
-                        default_string = repr(default_string)
+                    # not interpretable, must be a string
+                    default_string = repr(default_string)
         return default_string
 
     def get_default_string(self, default_string, context, arg, template, arr1, field_type, field_type_access):


### PR DESCRIPTION
Changes:
1. Bitflags defaults can now be specified like enums. This is useful to support because in some languages, bitflags _are_ enums, and it makes it easier to read.
2. Enums can now be specified as integer literals. Somewhat of a side-effect of treating bitflags and enums the same in default specification, but I think it makes sense to support, because they are always integers.
3. Bug fix to get_src_code. TackY ran into this because they had the `nif` somewhere in their path, which meant that, for example, Matrix44 was already chosen when the ms2 Matrix44 was encountered by the walk. As a side-effect, the execution of codegen.py is also much faster, because it no longer has to walk the entire source directory for every class.