### PR TITLE
Force int for bitfield `_value` field.

### DIFF
--- a/generated/bitfield.py
+++ b/generated/bitfield.py
@@ -25,9 +25,9 @@ class BitfieldMember(object):
 
     def __set__(self, instance, value):
         # Clear the current value
-        instance._value = instance._value & ~self.mask
+        instance._value = int(instance._value & ~self.mask)
         # Update with the new value
-        instance._value |= (value << self.pos) & self.mask
+        instance._value |= int((value << self.pos) & self.mask)
 
 
 class BasicBitfield(object, metaclass=BitfieldMetaClass):
@@ -66,7 +66,7 @@ class BasicBitfield(object, metaclass=BitfieldMetaClass):
     @classmethod
     def from_value(cls, value):
         instance = cls(None, set_default=False)
-        instance._value = value
+        instance._value = int(value)
         return instance
 
     @classmethod

--- a/source/bitfield.py
+++ b/source/bitfield.py
@@ -25,9 +25,9 @@ class BitfieldMember(object):
 
     def __set__(self, instance, value):
         # Clear the current value
-        instance._value = instance._value & ~self.mask
+        instance._value = int(instance._value & ~self.mask)
         # Update with the new value
-        instance._value |= (value << self.pos) & self.mask
+        instance._value |= int((value << self.pos) & self.mask)
 
 
 class BasicBitfield(object, metaclass=BitfieldMetaClass):
@@ -66,7 +66,7 @@ class BasicBitfield(object, metaclass=BitfieldMetaClass):
     @classmethod
     def from_value(cls, value):
         instance = cls(None, set_default=False)
-        instance._value = value
+        instance._value = int(value)
         return instance
 
     @classmethod


### PR DESCRIPTION
In some operations, especially the bitfieldmember assignment, the bitfield `_value` field could accidentally be converted into something other than an int (like numpy.intc) if the input value was of the right class.

This would cause a conflict with the `__int__` function, which returns `_value` directly, and needs to be an int. I've therefore applied some int coercion on the functions that didn't already have it. This way, it is guaranteed that `_value` is always a proper python int (and the `__int__` function functioning properly is an indicator of that, hence why I didn't apply int coercion there).