### PR TITLE
Remove error if running codegen.py from a IDE.

### DIFF
--- a/codegen.py
+++ b/codegen.py
@@ -428,4 +428,8 @@ if __name__ == '__main__':
     parser.add_argument('-g', '--generated-dir', default="generated")
     parser.add_argument('--silent', action='store_true')
     args = parser.parse_args()
-    exit(generate_classes(gen_dir=args.generated_dir, silent=args.silent))
+    exit_code = generate_classes(gen_dir=args.generated_dir, silent=args.silent)
+    try:
+        exit(exit_code)
+    except NameError:
+        pass


### PR DESCRIPTION
When trying to run codegen.py from an IDE (Spyder, for me) it created an error. This fixed it. This is presumably because when running through a IDE, rather than the console, the [site module which contains exit](https://docs.python.org/3/library/constants.html#exit) is not imported.