### PR TITLE
Fix trackelement for update 11 for Planet Coaster 2

### DIFF
--- a/generated/formats/trackelement/structs/TrackElementData.py
+++ b/generated/formats/trackelement/structs/TrackElementData.py
@@ -22,6 +22,8 @@ class TrackElementData(MemStruct):
 
 		# Every bit encodes some track property
 		self.tracktype_bitfield = name_type_map['TracktypeBitfield'].from_value(0)
+		self.start_connection_bitfield = name_type_map['Uint64'].from_value(1)
+		self.end_connection_bitfield = name_type_map['Uint64'].from_value(1)
 		self.start_connection_bitfield = name_type_map['Uint'].from_value(1)
 		self.end_connection_bitfield = name_type_map['Uint'].from_value(1)
 
@@ -75,8 +77,10 @@ class TrackElementData(MemStruct):
 		yield 'direction', name_type_map['Uint'], (0, None), (False, None), (None, None)
 		yield 'unk_2', name_type_map['Uint'], (0, None), (False, None), (None, None)
 		yield 'tracktype_bitfield', name_type_map['TracktypeBitfield'], (0, None), (False, 0), (None, None)
-		yield 'start_connection_bitfield', name_type_map['Uint'], (0, None), (False, 1), (None, None)
-		yield 'end_connection_bitfield', name_type_map['Uint'], (0, None), (False, 1), (None, None)
+		yield 'start_connection_bitfield', name_type_map['Uint64'], (0, None), (False, 1), (lambda context: context.version >= 12, None)
+		yield 'end_connection_bitfield', name_type_map['Uint64'], (0, None), (False, 1), (lambda context: context.version >= 12, None)
+		yield 'start_connection_bitfield', name_type_map['Uint'], (0, None), (False, 1), (lambda context: context.version <= 11, None)
+		yield 'end_connection_bitfield', name_type_map['Uint'], (0, None), (False, 1), (lambda context: context.version <= 11, None)
 		yield 'offset', name_type_map['Float'], (0, None), (False, None), (None, None)
 		yield 'unk_5', name_type_map['Uint'], (0, None), (False, 0), (None, None)
 		yield 'x_offset', name_type_map['Float'], (0, None), (False, 0), (lambda context: context.version >= 12, None)
@@ -101,8 +105,12 @@ class TrackElementData(MemStruct):
 		yield 'direction', name_type_map['Uint'], (0, None), (False, None)
 		yield 'unk_2', name_type_map['Uint'], (0, None), (False, None)
 		yield 'tracktype_bitfield', name_type_map['TracktypeBitfield'], (0, None), (False, 0)
-		yield 'start_connection_bitfield', name_type_map['Uint'], (0, None), (False, 1)
-		yield 'end_connection_bitfield', name_type_map['Uint'], (0, None), (False, 1)
+		if instance.context.version >= 12:
+			yield 'start_connection_bitfield', name_type_map['Uint64'], (0, None), (False, 1)
+			yield 'end_connection_bitfield', name_type_map['Uint64'], (0, None), (False, 1)
+		if instance.context.version <= 11:
+			yield 'start_connection_bitfield', name_type_map['Uint'], (0, None), (False, 1)
+			yield 'end_connection_bitfield', name_type_map['Uint'], (0, None), (False, 1)
 		yield 'offset', name_type_map['Float'], (0, None), (False, None)
 		yield 'unk_5', name_type_map['Uint'], (0, None), (False, 0)
 		if instance.context.version >= 12:

--- a/generated/formats/trackelement/structs/TrackElementData.pyi
+++ b/generated/formats/trackelement/structs/TrackElementData.pyi
@@ -19,6 +19,8 @@ class TrackElementData(MemStruct):
     tracktype_bitfield: TracktypeBitfield
     start_connection_bitfield: int
     end_connection_bitfield: int
+    start_connection_bitfield: int
+    end_connection_bitfield: int
     offset: float
     unk_5: int
     x_offset: float

--- a/source/formats/trackelement/trackelement.xml
+++ b/source/formats/trackelement/trackelement.xml
@@ -99,8 +99,13 @@
 
 	    <field name="tracktype_bitfield" type="TracktypeBitfield" default="0">Every bit encodes some track property</field>
 
-        <field name="start_connection_bitfield" type="uint" default="1" />
-        <field name="end_connection_bitfield" type="uint" default="1" />
+        <!-- Planet Coaster 2 uses u64's for the connectors since upd11 -->
+        <field name="start_connection_bitfield" type="uint64" default="1" since="12" />
+        <field name="end_connection_bitfield" type="uint64" default="1" since="12" />
+
+        <!-- The rest keeps the old u32 fields -->
+        <field name="start_connection_bitfield" type="uint" default="1" until="11" />
+        <field name="end_connection_bitfield" type="uint" default="1" until="11" />
 
         <field name="offset" type="float">Used to offset the track on the Y when there is no spline (e.g. double line segments)</field>
         <field name="unk_5" type="uint" default="0" />


### PR DESCRIPTION
Updated connection bitfield types for compatibility with Planet Coaster 2 update 11.